### PR TITLE
Add/identify

### DIFF
--- a/lib/google-analytics/index.js
+++ b/lib/google-analytics/index.js
@@ -196,6 +196,25 @@ GA.prototype.page = function(page){
 };
 
 /**
+ * Identify.
+ *
+ * @param {Identify} event
+ */
+
+GA.prototype.identify = function(identify){
+  var opts = this.options;
+
+  //set userId
+  if (opts.sendUserId && identify.userId()) {
+    window.ga('set', 'userId', identify.userId());
+  }
+
+  //set dimensions
+  var custom = metrics(user.traits(), opts);
+  if (length(custom)) window.ga('set', custom);
+ };
+
+/**
  * Track.
  *
  * https://developers.google.com/analytics/devguides/collection/analyticsjs/events

--- a/lib/google-analytics/test.js
+++ b/lib/google-analytics/test.js
@@ -322,6 +322,30 @@ describe('Google Analytics', function(){
         });
       });
 
+      describe('#identify', function(){
+        beforeEach(function(){
+          analytics.stub(window, 'ga');
+        });
+
+        it('should send user id if sendUserId option is true and identify.user() is truthy', function(){
+          ga.options.sendUserId = true;
+          analytics.identify('Steven');
+          analytics.called(window.ga, 'set', 'userId', 'Steven');
+        });
+
+        it('should send not user id if sendUserId option is false and identify.user() is truthy', function(){
+          ga.options.sendUserId = false;
+          analytics.identify('Steven');
+          analytics.assert(0 == window.ga.args.length);
+        });
+
+        it('should set custom dimensions', function(){
+          ga.options.dimensions = { age: 'dimension1' };
+          analytics.identify('Steven', { age: 25 });
+          analytics.called(window.ga, 'set', { dimension1: 25 });
+        });
+      });
+
       describe('#track', function(){
         beforeEach(function(){
           analytics.stub(window, 'ga');


### PR DESCRIPTION
https://segment.zendesk.com/agent/tickets/23205

^This guy has a SPA and since the userId is set on initialize in our GA integration, the subsequent events to GA don't get the userId attached, until the next page load