### PR TITLE
Fix for GoSquared custom properties

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -53,7 +53,7 @@ Once your tests pass, you are ready to submit a pull request!
 
 ###Notes on Linting
 
-When you're adding an integration's javscript snippet to your integration, we don't want to have to worry about the formatting that they've used. To let JSCS ignore the snippet during linting, use these comments on either side (example code courtesy of the [JSCS readme](https://github.com/jscs-dev/node-jscs#error-suppression)).
+When you're adding an integration's javascript snippet to your integration, we don't want to have to worry about the formatting that they've used. To let JSCS ignore the snippet during linting, use these comments on either side (example code courtesy of the [JSCS readme](https://github.com/jscs-dev/node-jscs#error-suppression)).
 
 ```javascript
 // jscs:disable

--- a/component.json
+++ b/component.json
@@ -59,7 +59,9 @@
     "component/object": "0.0.3",
     "segmentio/obj-case": "0.0.7",
     "segmentio/json": "^1.0.0",
-    "component/reduce": "1.0.1"
+    "component/reduce": "1.0.1",
+    "ianstormtaylor/pick": "~0.1.0",
+    "harrietgrace/omit": "~0.1.0"
   },
   "development": {
     "component/jquery": "*",

--- a/integrations.js
+++ b/integrations.js
@@ -77,11 +77,11 @@ module.exports = [
   require('./lib/tapstream'),
   require('./lib/trakio'),
   require('./lib/twitter-ads'),
+  require('./lib/userlike'),
   require('./lib/uservoice'),
   require('./lib/vero'),
   require('./lib/visual-website-optimizer'),
   require('./lib/webengage'),
   require('./lib/woopra'),
-  require('./lib/yandex-metrica'),
-  require('./lib/userlike')
+  require('./lib/yandex-metrica')
 ];

--- a/lib/gosquared/index.js
+++ b/lib/gosquared/index.js
@@ -10,6 +10,9 @@ var callback = require('callback');
 var load = require('load-script');
 var onBody = require('on-body');
 var each = require('each');
+var is = require('is');
+var pick = require('pick');
+var omit = require('omit');
 
 /**
  * Expose `GoSquared` integration.
@@ -69,7 +72,7 @@ GoSquared.prototype.loaded = function(){
 /**
  * Page.
  *
- * https://beta.gosquared.com/docs/tracking/api/#pageviews
+ * https://www.gosquared.com/docs/tracking/api/#pageviews
  *
  * @param {Page} page
  */
@@ -83,27 +86,55 @@ GoSquared.prototype.page = function(page){
 /**
  * Identify.
  *
- * https://beta.gosquared.com/docs/tracking/identify
+ * https://www.gosquared.com/docs/tracking/identify
  *
  * @param {Identify} identify
  */
 
 GoSquared.prototype.identify = function(identify){
   var traits = identify.traits({
-    userId: 'user_id',
-    created: 'created_at'
+    createdAt: 'created_at',
+    firstName: 'first_name',
+    lastName: 'last_name',
+    title: 'company_position',
+    industry: 'company_industry'
   });
 
+  // https://www.gosquared.com/docs/tracking/api/#properties
+  var specialKeys = [
+    'id',
+    'email',
+    'name',
+    'first_name',
+    'last_name',
+    'username',
+    'description',
+    'avatar',
+    'phone',
+    'created_at',
+    'company_name',
+    'company_size',
+    'company_position',
+    'company_industry'
+  ];
+
+  // Segment allows traits to all be in a flat object
+  // GoSquared requires all custom properties to be in a `custom` object,
+
+  // select all special keys
+  var props = pick.apply(null, [traits].concat(specialKeys));
+  props.custom = omit(specialKeys, traits);
+
   var id = identify.userId();
-  var name = identify.name();
-  var email = identify.email();
-  var username = identify.username();
 
   if (id) {
-    push('identify', id, traits);
+    push('identify', id, props);
   } else {
-    push('properties', traits);
+    push('properties', props);
   }
+
+  var email = identify.email();
+  var username = identify.username();
 
   var name = email || username || id;
   if (name) push('set', 'visitorName', name);
@@ -112,7 +143,7 @@ GoSquared.prototype.identify = function(identify){
 /**
  * Track.
  *
- * https://beta.gosquared.com/docs/tracking/events
+ * https://www.gosquared.com/docs/tracking/events
  *
  * @param {Track} track
  */
@@ -124,7 +155,7 @@ GoSquared.prototype.track = function(track){
 /**
  * Checked out.
  *
- * https://beta.gosquared.com/docs/tracking/ecommerce
+ * https://www.gosquared.com/docs/tracking/ecommerce
  *
  * @param {Track} track
  * @api private

--- a/lib/gosquared/test.js
+++ b/lib/gosquared/test.js
@@ -120,22 +120,108 @@ describe('GoSquared', function(){
         analytics.stub(window, '_gs');
       });
 
+      var created = new Date();
+
       it('should set an id', function(){
         analytics.identify('id');
         analytics.called(window._gs, 'identify', 'id');
       });
 
-      it('should set traits', function(){
-        analytics.identify({ trait: true });
-        analytics.called(window._gs, 'properties', { trait: true });
+      it('should alias traits', function(){
+        analytics.identify({
+          firstName: 'first_name',
+          lastName: 'last_name',
+          createdAt: created,
+          title: 'company_position',
+          industry: 'company_industry'
+        });
+        analytics.called(window._gs, 'properties', {
+          first_name: 'first_name',
+          last_name: 'last_name',
+          created_at: created,
+          company_position: 'company_position',
+          company_industry: 'company_industry',
+          custom: {}
+        });
+      });
+
+      it('should keep special traits in root object', function(){
+        analytics.identify({
+          id: 'id',
+          email: 'email',
+          firstName: 'first_name',
+          lastName: 'last_name',
+          username: 'username',
+          description: 'description',
+          avatar: 'avatar',
+          phone: 'phone',
+          createdAt: created,
+          company_name: 'company_name',
+          company_size: 'company_size',
+          title: 'company_position',
+          industry: 'company_industry'
+        });
+        analytics.called(window._gs, 'properties', {
+          id: 'id',
+          email: 'email',
+          first_name: 'first_name',
+          last_name: 'last_name',
+          username: 'username',
+          description: 'description',
+          avatar: 'avatar',
+          phone: 'phone',
+          created_at: created,
+          company_name: 'company_name',
+          company_size: 'company_size',
+          company_position: 'company_position',
+          company_industry: 'company_industry',
+          custom: {}
+        });
+      });
+
+      it('should move non-special traits to custom object', function(){
+        analytics.identify({
+          trait: true,
+          weirdTraits: 'can go anywhere',
+          custom: 'works too'
+        });
+        analytics.called(window._gs, 'properties', {
+          custom: {
+            trait: true,
+            weirdTraits: 'can go anywhere',
+            custom: 'works too'
+          }
+        });
+      });
+
+      it('should keep both custom traits and non-special traits', function(){
+        analytics.identify({
+          trait: true,
+          weirdTraits: 'can go anywhere',
+          custom: {
+            iWantThese: 'traits',
+            too: 'yes'
+          }
+        });
+        analytics.called(window._gs, 'properties', {
+          custom: {
+            trait: true,
+            weirdTraits: 'can go anywhere',
+            custom: {
+              iWantThese: 'traits',
+              too: 'yes'
+            }
+          }
+        });
       });
 
       it('should set an id and traits', function(){
         analytics.identify('id', { trait: true });
         analytics.called(window._gs, 'identify', 'id', {
-          trait: true,
           id: 'id',
-          user_id: 'id'
+          custom: {
+            trait: true
+          }
         })
       });
 


### PR DESCRIPTION
We expect all non-special properties to be in a `custom` object, otherwise they'll be ignored.

Also updated aliased traits to work with our special properties better.