### PR TITLE
KISSmetrics: Reference alternative tracker URL

### DIFF
--- a/lib/kissmetrics/index.js
+++ b/lib/kissmetrics/index.js
@@ -7,7 +7,6 @@ var integration = require('analytics.js-integration');
 var push = require('global-queue')('_kmq');
 var Track = require('facade').Track;
 var alias = require('alias');
-var Batch = require('batch');
 var each = require('each');
 var is = require('is');
 
@@ -24,8 +23,7 @@ var KISSmetrics = module.exports = integration('KISSmetrics')
   .option('trackNamedPages', true)
   .option('trackCategorizedPages', true)
   .option('prefixProperties', true)
-  .tag('useless', '<script src="//i.kissmetrics.com/i.js">')
-  .tag('library', '<script src="//doug1izaerwt3.cloudfront.net/{{ apiKey }}.1.js">');
+  .tag('library', '<script src="//scripts.kissmetrics.com/{{ apiKey }}.2.js">');
 
 /**
  * Check if browser is mobile, for kissmetrics.
@@ -53,10 +51,7 @@ KISSmetrics.prototype.initialize = function(page){
   window._kmq = [];
   if (exports.isMobile) push('set', { 'Mobile Session': 'Yes' });
 
-  var batch = new Batch();
-  batch.push(function(done){ self.load('useless', done); }) // :)
-  batch.push(function(done){ self.load('library', done); })
-  batch.end(function(){
+  this.load('library', function(){
     self.trackPage(page);
     self.ready();
   });


### PR DESCRIPTION
This updates the tracker URL to reference a new version that initializes itself without the help of `i.js`.