### PR TITLE
fix heap id mess :)

### DIFF
--- a/lib/heap/index.js
+++ b/lib/heap/index.js
@@ -50,11 +50,9 @@ Heap.prototype.loaded = function(){
 
 Heap.prototype.identify = function(identify){
   var traits = identify.traits();
-  var username = identify.username();
   var id = identify.userId();
-  var handle = username || id;
-  if (handle) traits.handle = handle;
-  delete traits.username;
+  if (traits.email) delete traits.email
+  if (id) traits.handle = id;
   window.heap.identify(traits);
 };
 

--- a/lib/heap/test.js
+++ b/lib/heap/test.js
@@ -93,9 +93,9 @@ describe('Heap', function(){
         analytics.called(window.heap.identify, { trait: true });
       });
 
-      it('should send username as handle', function(){
-        analytics.identify({ username: 'username' });
-        analytics.called(window.heap.identify, { handle: 'username' });
+      it('should not send email', function(){
+        analytics.identify({ trait: true, email: 'email@email.org' });
+        analytics.called(window.heap.identify, { trait: true });
       });
 
       it('should send id as handle', function(){
@@ -103,9 +103,9 @@ describe('Heap', function(){
         analytics.called(window.heap.identify, { handle: 'id', id: 'id' });
       })
 
-      it('should prefer username', function(){
-        analytics.identify('id', { username: 'baz' });
-        analytics.called(window.heap.identify, { handle: 'baz', id: 'id' });
+      it('should send id as handle and traits', function(){
+        analytics.identify('id', { trait: 'trait' });
+        analytics.called(window.heap.identify, { handle: 'id', id: 'id', trait: 'trait' });
       })
     });
 


### PR DESCRIPTION
@amillet89 

reasons for this change:

we had a call with Ravi @ Heap yesterday confirming how their identify API should works. wanted to standardize across client and server and ensure we were following best practices.

It can have adverse affects to send both "handle" and "email" to Heap. So this fix ensures that we only send handle, never email, and we default to the Segment `userId` for the handle.

Ravi, your GH handle is ballin' outrageous. @swag 