### PR TITLE
Adding anonymous id and aliasing for Outbound.io

### DIFF
--- a/lib/outbound/index.js
+++ b/lib/outbound/index.js
@@ -39,7 +39,7 @@ Outbound.prototype.identify = function(identify){
     'firstName',
     'lastName'
   ];
-  var userId = identify.userId();
+  var userId = identify.userId() || identify.anonymousId();
   var attributes = {
     attributes: omit(traitsToOmit, identify.traits()),
     email: identify.email(),
@@ -51,5 +51,9 @@ Outbound.prototype.identify = function(identify){
 };
 
 Outbound.prototype.track = function(track){
-  window.outbound.track(track.event(), track.properties());
+  window.outbound.track(track.event(), track.properties(), track.timestamp());
+};
+
+Outbound.prototype.alias = function(alias){
+  window.outbound.identify(alias.userId(), { previousId: alias.previousId() });
 };

--- a/lib/outbound/test.js
+++ b/lib/outbound/test.js
@@ -10,7 +10,7 @@ describe('Outbound', function(){
   var outbound;
   var analytics;
   var options = {
-    publicApiKey: 'pub-3e2b0899b2c81c6f0c59342d1ff057c3'
+    publicApiKey: 'pub-9cb1d6e54b003d5274e54a483ef741be'
   };
 
   beforeEach(function(){
@@ -101,6 +101,13 @@ describe('Outbound', function(){
         analytics.identify('user123', testTraits);
         analytics.called(window.outbound.identify, 'user123', attributes);
       });
+
+      it('should accept anonymousId', function(){
+        var anonymousId = 'anonymousId';
+
+        analytics.identify(anonymousId);
+        analytics.called(window.outbound.identify, anonymousId);
+      });
     });
 
     describe('#track', function(){
@@ -115,6 +122,18 @@ describe('Outbound', function(){
 
       it('should send an event and properties', function(){
         analytics.track('event', { property: true });
+        analytics.called(window.outbound.track, 'event', { property: true });
+      });
+    });
+
+    describe('#alias', function(){
+      beforeEach(function(){
+        analytics.stub(window.outbound, 'identify');
+      });
+
+      it('should alias a user', function(){
+        analytics.alias('user123', 'actualUserId');
+        analytics.called(window.outbound.identify, 'user123', { previousId: 'actualUserId' });
       });
     });
   });


### PR DESCRIPTION
This pull request adds the ability to alias using Outbound's client-side implementation and the ability to pass in anonymous users into the identify call.