### PR TITLE
Blueshift: Fix user IDs, send category and name with page, remove group()

### DIFF
--- a/lib/blueshift/index.js
+++ b/lib/blueshift/index.js
@@ -1,7 +1,10 @@
+
 /**
  * Module dependencies.
  */
+
 var integration = require('analytics.js-integration');
+var foldl = require('foldl');
 
 /**
  * Expose `Blueshift` integration.
@@ -52,9 +55,22 @@ Blueshift.prototype.loaded = function(){
 
 Blueshift.prototype.page = function(page){
   if (this.options.retarget) window.blueshift.retarget();
+
   var properties = page.properties();
   properties._bsft_source = 'segment.com';
-  window.blueshift.pageload(properties);
+  properties.customer_id = page.userId();
+  properties.anonymousId = page.anonymousId();
+  properties.category = page.category();
+  properties.name = page.name();
+
+  window.blueshift.pageload(removeBlankAttributes(properties));
+};
+
+/**
+ * Trait Aliases.
+ */
+var traitAliases = {
+  created: 'created_at'
 };
 
 /**
@@ -65,23 +81,15 @@ Blueshift.prototype.page = function(page){
  */
 
 Blueshift.prototype.identify = function(identify){
-  if (!identify.userId()) return this.debug('user id required');
-  var traits = identify.traits({ created: 'created_at' });
+  if (!identify.userId() && !identify.anonymousId()) {
+    return this.debug('user id required');
+  }
+  var traits = identify.traits(traitAliases);
   traits._bsft_source = 'segment.com';
-  window.blueshift.identify(traits);
-};
+  traits.customer_id = identify.userId();
+  traits.anonymousId = identify.anonymousId();
 
-/**
- * Group.
- *
- * @api public
- * @param {Group} group
- */
-
-Blueshift.prototype.group = function(group){
-  var traits = group.traits({ created: 'created_at' });
-  traits._bsft_source = 'segment.com';
-  window.blueshift.track('group', traits);
+  window.blueshift.identify(removeBlankAttributes(traits));
 };
 
 /**
@@ -94,5 +102,38 @@ Blueshift.prototype.group = function(group){
 Blueshift.prototype.track = function(track){
   var properties = track.properties();
   properties._bsft_source = 'segment.com';
-  window.blueshift.track(track.event(), properties);
+  properties.customer_id = track.userId();
+  properties.anonymousId = track.anonymousId();
+
+  window.blueshift.track(track.event(), removeBlankAttributes(properties));
 };
+
+/**
+ * Alias.
+ *
+ * @param {Alias} alias
+ */
+
+Blueshift.prototype.alias = function(alias){
+  window.blueshift.track('alias', removeBlankAttributes({
+    _bsft_source: 'segment.com',
+    customer_id: alias.userId(),
+    previous_customer_id: alias.previousId(),
+    anonymousId: alias.anonymousId()
+  }));
+};
+
+/**
+ * Filters null/undefined values from an object, returning a new object.
+ *
+ * @api private
+ * @param {Object} obj
+ * @return {Object}
+ */
+
+function removeBlankAttributes(obj){
+  return foldl(function(results, val, key){
+    if (val !== null && val !== undefined) results[key] = val;
+    return results;
+  }, {}, obj);
+}

--- a/lib/blueshift/test.js
+++ b/lib/blueshift/test.js
@@ -93,39 +93,30 @@ describe('Blueshift', function(){
         analytics.stub(window.blueshift, 'identify');
       });
 
-      it('should send an id', function(){
-        analytics.identify('id');
-        analytics.called(window.blueshift.identify, { id: 'id', _bsft_source: 'segment.com' });
-      });
-
-      it('should not call identify if an id is not sent', function(){
+      it('should send anonymousId', function(){
         analytics.identify();
-        analytics.didNotCall(window.blueshift.identify);
+        analytics.called(window.blueshift.identify, {
+          _bsft_source: 'segment.com',
+          anonymousId: analytics.user().anonymousId()
+        });
       });
 
-      it('should not send only traits', function(){
+      it('should send id', function(){
+        analytics.identify('id');
+        analytics.called(window.blueshift.identify, {
+          id: 'id',
+          customer_id: 'id',
+          _bsft_source: 'segment.com',
+          anonymousId: analytics.user().anonymousId()
+        });
+      });
+
+      it('should send traits', function(){
         analytics.identify({ trait: true });
-        analytics.didNotCall(window.blueshift.identify);
-      });
-
-      it('should send an id and traits', function(){
-        analytics.identify('id', { trait: true });
-        analytics.called(window.blueshift.identify, { id: 'id', trait: true, _bsft_source: 'segment.com' });
-      });
-    });
-
-    describe('#group', function(){
-      beforeEach(function(){
-        analytics.stub(window.blueshift, 'track');
-      });
-
-      it('should call track with event equal group', function(){
-        analytics.group('123', { name: 'test', industry: 'Technology' });
-        analytics.called(window.blueshift.track, 'group', {
-          name: 'test',
-          industry: 'Technology',
-          id: '123',
-          _bsft_source: 'segment.com'
+        analytics.called(window.blueshift.identify, {
+          trait: true,
+          _bsft_source: 'segment.com',
+          anonymousId: analytics.user().anonymousId()
         });
       });
     });
@@ -137,12 +128,47 @@ describe('Blueshift', function(){
 
       it('should send an event', function(){
         analytics.track('event');
-        analytics.called(window.blueshift.track, 'event', { _bsft_source: 'segment.com' });
+        var properties = {
+          _bsft_source: 'segment.com',
+          anonymousId: analytics.user().anonymousId()
+        };
+        analytics.called(window.blueshift.track, 'event', properties);
       });
 
-      it('should send an event and properties', function(){
+      it('should send an event with properties', function(){
         analytics.track('event', { property: true });
-        analytics.called(window.blueshift.track, 'event', { property: true, _bsft_source: 'segment.com' });
+        var properties = {
+          _bsft_source: 'segment.com',
+          anonymousId: analytics.user().anonymousId(),
+          property: true
+        };
+        analytics.called(window.blueshift.track, 'event', properties);
+      });
+    });
+
+    describe('#alias', function(){
+      beforeEach(function(){
+        analytics.stub(window.blueshift, 'track');
+        analytics.stub(window.blueshift, 'alias');
+      });
+
+      it('should send new id', function(){
+        analytics.alias('new');
+        analytics.called(window.blueshift.track, 'alias', {
+          _bsft_source: 'segment.com',
+          customer_id: 'new',
+          anonymousId: analytics.user().anonymousId()
+        });
+      });
+
+      it('should send new & old id', function(){
+        analytics.alias('new', 'old');
+        analytics.called(window.blueshift.track, 'alias', {
+          _bsft_source: 'segment.com',
+          customer_id: 'new',
+          previous_customer_id: 'old',
+          anonymousId: analytics.user().anonymousId()
+        });
       });
     });
   });


### PR DESCRIPTION
* Send `customer_id` & `anonymous_id` with identify, track, page, and alias calls
* Send category/name with page
* Remove `.group()` call