### PR TITLE
[ENT-110] Add support for custom event type mappings

### DIFF
--- a/integrations/criteo/lib/index.js
+++ b/integrations/criteo/lib/index.js
@@ -84,6 +84,22 @@ Criteo.prototype.page = function(page) {
   }
 };
 
+Criteo.prototype.track = function(track) {
+  var eventMappings = this.options.eventMappings || {};
+  var event = track.event();
+  var eventTypeMappings = {
+    viewItem: 'productViewed',
+    viewList: 'productListViewed',
+    viewBasket: 'cartViewed',
+    trackTransaction: 'orderCompleted'
+  };
+  var eventType = eventMappings[event];
+  
+  if (eventTypeMappings[eventType]) {
+    return this[eventTypeMappings[eventType]](track);
+  }
+};
+
 /**
  * Product Viewed
  *

--- a/integrations/criteo/package.json
+++ b/integrations/criteo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-criteo",
   "description": "The Criteo analytics.js integration.",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/criteo/test/index.test.js
+++ b/integrations/criteo/test/index.test.js
@@ -13,7 +13,8 @@ describe('Criteo', function() {
   var options = {
     account: 42323,
     supportingPageData: {},
-    supportingUserData: {}
+    supportingUserData: {},
+    eventMappings: {}
   };
 
   beforeEach(function() {
@@ -100,6 +101,37 @@ describe('Criteo', function() {
         analytics.page('Home', { team: 'New York Giants' });
         analytics.called(window.criteo_q.push, { event: 'setData', team_page: 'New York Giants' });
         analytics.called(window.criteo_q.push, { event: 'viewHome' });
+      });
+    });
+
+    describe('#track', function() {
+      var eventTypeMappings = {
+        viewItem: 'productViewed',
+        viewList: 'productListViewed',
+        viewBasket: 'cartViewed',
+        trackTransaction: 'orderCompleted'
+      };
+
+      beforeEach(function() {
+        for (var event in eventTypeMappings) {
+          if (!eventTypeMappings.hasOwnProperty(event)) {
+            continue;
+          }
+          analytics.stub(criteo, eventTypeMappings[event]);
+        }
+      });
+
+      it('should handle custom event mappings', function() {
+        for (var eventType in eventTypeMappings) {
+          if (!eventTypeMappings.hasOwnProperty(eventType)) {
+            continue;
+          }
+          var customEventName = 'myCustomEvent';
+          var handler = eventTypeMappings[eventType];
+          criteo.options.eventMappings[customEventName] = eventType;
+          analytics.track(customEventName, {});
+          analytics.called(criteo[handler]);
+        }
       });
     });
 


### PR DESCRIPTION
Adds support for mapping custom events (ie. non-specd events) to Criteo event types. Addresses: https://segment.atlassian.net/browse/ENT-110. Going to add in the actual setting after merge is completed.