### PR TITLE
Remove legacy linting rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,3 @@
 {
-  "extends": "@segment/eslint-config/browser/legacy"
+  "ecmaVerion": 5
 }


### PR DESCRIPTION
**What does this PR do?**
Removes the legacy linting rules and replaces them with a general rule to just flag any non-es5 syntax. This will allow us to use Standard as our code formatter while also protecting against accidentally shipping code that potentially breaks our supported browsers.

**Are there breaking changes in this PR?**


**Has this been tested end-to-end? Please provide screenshots on how the fix now populates in the end tool. If not, what was done to test?**


**Any background context you want to provide?**


**Is there parity with the server-side/android/iOS integration (if applicable)?**


**Does this require a metadata change? If so, please link the PR from https://github.com/segmentio/destination-scripts.**


**What are the relevant tickets?**


**Link to CC ticket**


**List all the tests accounts you have used to make sure this change works**


**Helpful Docs**

