### PR TITLE
Add forms SDK to Hubspot integration

### DIFF
--- a/integrations/hubspot/package.json
+++ b/integrations/hubspot/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-hubspot",
   "description": "The Hubspot analytics.js integration.",
-  "version": "2.1.3",
+  "version": "2.2.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/karma/safari.js
+++ b/karma/safari.js
@@ -4,7 +4,7 @@ function setSafari (config) {
     sl_safari_9: {
       base: 'SauceLabs',
       browserName: 'safari',
-      version: '9.0'
+      version: '9'
     }
   }
   config.browsers = Object.keys(config.customLaunchers)


### PR DESCRIPTION
**What does this PR do?**
Adds support to optionally load the Hubspot Forms SDK alongside their analytics pixel: https://developers.hubspot.com/docs/methods/forms/advanced_form_options.


**Are there breaking changes in this PR?**
No

**Has this been tested end-to-end? Please provide screenshots on how the fix now populates in the end tool. If not, what was done to test?**


**Any background context you want to provide?**
This is a customer request.

**Is there parity with the server-side/android/iOS integration (if applicable)?**


**Does this require a metadata change? If so, please link the PR from https://github.com/segmentio/destination-scripts.**


**What are the relevant tickets?**
https://segment.atlassian.net/browse/PLATFORM-1464


**Link to CC ticket**
https://segment.atlassian.net/browse/CC-1407

**List all the tests accounts you have used to make sure this change works**


**Helpful Docs**

