### PR TITLE
Add integration wootric

### DIFF
--- a/integrations/wootric/HISTORY.md
+++ b/integrations/wootric/HISTORY.md
@@ -1,0 +1,63 @@
+
+2.2.0 / 2018-08-31
+==================
+
+  * Pass userId as segment_user_id to Wootric (#16)
+
+2.1.1 / 2018-07-23
+==================
+
+  * Using the latest Wootric CDN URL instead of CloudFront domain (#15)
+
+2.1.0 / 2018-05-02
+==================
+
+  * Add support for Track events
+  * Refactor Identify
+
+2.0.3 / 2017-11-02
+==================
+
+  * Update Wootric js sdk source to support their new version
+
+2.0.2 / 2017-02-02
+==================
+
+  * Update date properties to be in Unix timestamp format and suffixed with '_date'
+
+2.0.1 / 2016-10-06
+==================
+
+  * Fix minor bug 
+
+2.0.0 / 2016-06-21
+==================
+
+  * Remove Duo compatibility
+  * Add CI setup (coverage, linting, cross-browser compatibility, etc.)
+  * Update eslint configuration
+
+1.0.4 / 2016-05-07
+==================
+
+  * Bump Analytics.js core, tester, integration to use Facade 2.x
+
+1.0.3 / 2015-09-04
+==================
+
+  * Convert unix time to seconds from milliseconds
+
+1.0.2 / 2015-06-30
+==================
+
+  * Replace analytics.js dependency with analytics.js-core
+
+1.0.1 / 2015-06-24
+==================
+
+  * Bump analytics.js-integration version
+
+1.0.0 / 2015-06-09
+==================
+
+  * Initial commit :sparkles:

--- a/integrations/wootric/README.md
+++ b/integrations/wootric/README.md
@@ -1,0 +1,12 @@
+# analytics.js-integration-wootric [![Build Status][ci-badge]][ci-link]
+
+Wootric integration for [Analytics.js][].
+
+## License
+
+Released under the [MIT license](LICENSE).
+
+
+[Analytics.js]: https://segment.com/docs/libraries/analytics.js/
+[ci-link]: https://circleci.com/gh/segment-integrations/analytics.js-integration-wootric
+[ci-badge]: https://circleci.com/gh/segment-integrations/analytics.js-integration-wootric.svg?style=svg

--- a/integrations/wootric/lib/index.js
+++ b/integrations/wootric/lib/index.js
@@ -1,0 +1,177 @@
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+
+var foldl = require('@ndhoule/foldl');
+var is = require('is');
+var integration = require('@segment/analytics.js-integration');
+var omit = require('omit');
+
+/**
+ * Expose `Wootric` integration.
+ */
+
+var Wootric = module.exports = integration('Wootric')
+  .assumesPageview()
+  .option('accountToken', '')
+  .global('wootricSettings')
+  .global('wootric_survey_immediately')
+  .global('wootric')
+  .tag('library', '<script src="//cdn.wootric.com/wootric-sdk.js"></script>')
+  .tag('pixel', '<img src="//d8myem934l1zi.cloudfront.net/pixel.gif?account_token={{ accountToken }}&email={{ email }}&created_at={{ createdAt }}&url={{ url }}&random={{ cacheBuster }}">');
+
+/**
+ * Initialize Wootric.
+ *
+ * @api public
+ */
+
+Wootric.prototype.initialize = function() {
+  // We use this to keep track of the last page that Wootric has tracked to
+  // ensure we don't accidentally send a duplicate page call
+  this.lastPageTracked = null;
+  window.wootricSettings = window.wootricSettings || {};
+  window.wootricSettings.account_token = this.options.accountToken;
+
+  var self = this;
+  this.load('library', function() {
+    self.ready();
+  });
+};
+
+/**
+ * Has the Wootric library been loaded yet?
+ *
+ * @api private
+ * @return {boolean}
+ */
+
+Wootric.prototype.loaded = function() {
+  // We are always ready since we are just setting a global variable in initialize
+  return !!window.wootric;
+};
+
+/**
+ * Identify a user.
+ *
+ * @api public
+ * @param {Facade} identify
+ */
+
+Wootric.prototype.identify = function(identify) {
+  var userId = identify.userId();
+  var anonymousId = identify.anonymousId();
+  var traits = identify.traits();
+  var email = identify.email();
+  var createdAt = identify.created();
+  var language = traits.language;
+
+  window.wootricSettings.segment_user_id = userId || anonymousId;
+  if (language) window.wootricSettings.language = language;
+
+  survey(email, createdAt, traits, null);
+};
+
+/**
+ * Track.
+ *
+ * @api public
+ * @param {Track} track
+ */
+
+Wootric.prototype.track = function(track) {
+  var properties = track.properties();
+  var email = track.email();
+  var eventName = track.event();
+
+  survey(email, null, properties, eventName);
+};
+
+/**
+ * Page.
+ *
+ * @api public
+ * @param {Page} page
+ */
+
+Wootric.prototype.page = function(page) {
+  // Only track page if we haven't already tracked it
+  if (this.lastPageTracked === window.location) {
+    return;
+  }
+
+  // Set this page as the last page tracked
+  this.lastPageTracked = window.location;
+
+  var wootricSettings = window.wootricSettings;
+  this.load('pixel', {
+    accountToken: this.options.accountToken,
+    email: encodeURIComponent(wootricSettings.email),
+    createdAt: wootricSettings.created_at,
+    url: encodeURIComponent(page.url()),
+    cacheBuster: Math.random()
+  });
+};
+
+/**
+ * Convert trait key to Wootric format.
+ *
+ * @param {string} trait
+ * @param {*} value
+ */
+
+function convertKey(key, value) {
+  if (is.date(value) && !key.endsWith('_date')) return key + '_date';
+  return key;
+}
+
+/**
+ * Convert a date to unix timestamp.
+ *
+ * @api private
+ * @param {Date} date
+ * @return {number}
+ */
+
+function convertDate(date) {
+  return Math.round(date.getTime() / 1000);
+}
+
+if (!String.prototype.endsWith) {
+  String.prototype.endsWith = function(searchString, position) {
+    var subjectString = this.toString();
+    if (typeof position !== 'number' || !isFinite(position) || Math.floor(position) !== position || position > subjectString.length) {
+      position = subjectString.length;
+    }
+    position -= searchString.length;
+    var lastIndex = subjectString.lastIndexOf(searchString, position);
+    return lastIndex !== -1 && lastIndex === position;
+  };
+}
+
+/**
+  * Survey end user
+  *
+  * @param {String} email
+  * @param {Date} createdAt
+  * @param {Object} properties
+  * @param {String} eventName
+  */
+
+function survey(email, createdAt, properties, eventName) {
+  if (createdAt && createdAt.getTime) window.wootricSettings.created_at = Math.round(createdAt.getTime() / 1000);
+  window.wootricSettings.email = email;
+  window.wootricSettings.event_name = eventName;
+
+  // Convert keys to Wootric format
+  var newProperties = foldl(function(results, value, key) {
+    results[convertKey(key, value)] = is.date(value) ? convertDate(value) : value;
+    return results;
+  }, {}, properties);
+
+  window.wootricSettings.properties = omit(['created', 'createdAt', 'email'], newProperties);
+
+  window.wootric('run');
+}

--- a/integrations/wootric/package.json
+++ b/integrations/wootric/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@segment/analytics.js-integration-wootric",
+  "description": "The Wootric analytics.js integration.",
+  "version": "2.2.0",
+  "keywords": [
+    "analytics.js",
+    "analytics.js-integration",
+    "segment",
+    "wootric"
+  ],
+  "main": "lib/index.js",
+  "scripts": {
+    "test": "make test"
+  },
+  "author": "Segment \u003cfriends@segment.com\u003e",
+  "license": "SEE LICENSE IN LICENSE",
+  "homepage": "https://github.com/segmentio/analytics.js-integrations/blob/master/integrations/wootric#readme",
+  "bugs": {
+    "url": "https://github.com/segmentio/analytics.js-integrations/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/segmentio/analytics.js-integrations.git"
+  },
+  "dependencies": {
+    "@ndhoule/foldl": "^2.0.1",
+    "@segment/analytics.js-integration": "^2.1.0",
+    "is": "^3.1.0",
+    "omit": "harrietgrace/omit"
+  },
+  "devDependencies": {
+    "@segment/analytics.js-core": "^3.0.0",
+    "@segment/analytics.js-integration-tester": "^3.1.0",
+    "@segment/clear-env": "^2.0.0",
+    "@segment/eslint-config": "^3.1.1",
+    "browserify": "^13.0.0",
+    "browserify-istanbul": "^2.0.0",
+    "eslint": "^2.9.0",
+    "eslint-plugin-mocha": "^2.2.0",
+    "eslint-plugin-require-path-exists": "^1.1.5",
+    "istanbul": "^0.4.3",
+    "karma": "1.3.0",
+    "karma-browserify": "^5.0.4",
+    "karma-chrome-launcher": "^1.0.1",
+    "karma-coverage": "^1.0.0",
+    "karma-junit-reporter": "^1.0.0",
+    "karma-mocha": "1.0.1",
+    "karma-phantomjs-launcher": "^1.0.0",
+    "karma-sauce-launcher": "^1.0.0",
+    "karma-spec-reporter": "0.0.26",
+    "mocha": "^2.2.5",
+    "npm-check": "^5.2.1",
+    "phantomjs-prebuilt": "^2.1.7",
+    "watchify": "^3.7.0"
+  }
+}

--- a/integrations/wootric/test/.eslintrc
+++ b/integrations/wootric/test/.eslintrc
@@ -1,0 +1,3 @@
+{
+  "extends": "@segment/eslint-config/mocha"
+}

--- a/integrations/wootric/test/index.test.js
+++ b/integrations/wootric/test/index.test.js
@@ -1,0 +1,332 @@
+'use strict';
+
+var Analytics = require('@segment/analytics.js-core').constructor;
+var integration = require('@segment/analytics.js-integration');
+var Wootric = require('../lib/');
+var tester = require('@segment/analytics.js-integration-tester');
+var sandbox = require('@segment/clear-env');
+var is = require('is');
+
+describe('Wootric', function() {
+  var wootric;
+  var analytics;
+  var options = {
+    accountToken: 'NPS-01fe3cbc'
+  };
+
+  beforeEach(function() {
+    analytics = new Analytics();
+    wootric = new Wootric(options);
+    analytics.use(Wootric);
+    analytics.use(tester);
+    analytics.add(wootric);
+    // Configure Wootric to survey immediately
+    window.wootric_survey_immediately = true;
+  });
+
+  afterEach(function() {
+    analytics.restore();
+    analytics.reset();
+    wootric.reset();
+    sandbox();
+  });
+
+  it('should have the right settings', function() {
+    analytics.compare(Wootric, integration('Wootric')
+      .assumesPageview()
+      .option('accountToken', '')
+      .global('wootricSettings')
+      .global('wootric_survey_immediately')
+      .global('wootric'));
+  });
+
+  describe('before loading', function() {
+    beforeEach(function() {
+      analytics.stub(wootric, 'load');
+    });
+
+    it('should not have a wootric object', function() {
+      analytics.assert(!window.wootric);
+    });
+
+    describe('#initialize', function() {
+      beforeEach(function() {
+        analytics.initialize();
+        analytics.page();
+      });
+
+      it('should have settings with account token', function() {
+        analytics.assert(window.wootricSettings.account_token === 'NPS-01fe3cbc');
+      });
+
+      it('should setup the wootricSettings object', function() {
+        is.object(window.wootricSettings);
+      });
+
+      it('should have lastPageTracked set to null', function() {
+        analytics.assert(wootric.lastPageTracked === null);
+      });
+
+      it('should call #load', function() {
+        analytics.called(wootric.load);
+      });
+    });
+  });
+
+  describe('loading', function() {
+    it('should load', function(done) {
+      analytics.load(wootric, done);
+    });
+  });
+
+  describe('after loading', function() {
+    beforeEach(function(done) {
+      analytics.once('ready', done);
+      analytics.initialize();
+      analytics.page();
+    });
+
+    it('should have created the global wootric object', function() {
+      analytics.assert(typeof window.wootric === 'function');
+    });
+
+    describe('#track', function() {
+      it('should set email on track', function() {
+        analytics.track('track_event', {
+          email: 'shawn@shawnmorgan.com'
+        });
+        analytics.equal(window.wootricSettings.email, 'shawn@shawnmorgan.com');
+      });
+
+      it('should set event_name on track', function() {
+        analytics.track('track_event', {
+          email: 'shawn@shawnmorgan.com'
+        });
+        analytics.equal(window.wootricSettings.event_name, 'track_event');
+      });
+
+      it('should set created_at to null on track', function() {
+        analytics.track('track_event', {
+          email: 'shawn@shawnmorgan.com',
+          createdAt: '01/01/2015'
+        });
+        analytics.equal(window.wootricSettings.created_at, null);
+      });
+
+      it('should set properties based on other traits', function() {
+        analytics.track('track_event', {
+          email: 'shawn@shawnmorgan.com',
+          createdAt: '01/01/2015',
+          property1: 'foo',
+          property2: 'bar'
+        });
+        analytics.assert(window.wootricSettings.properties.property1 === 'foo');
+        analytics.assert(window.wootricSettings.properties.property2 === 'bar');
+      });
+
+      it('should omit email and createdAt when setting window.wootricSettings.properties', function() {
+        analytics.track('track_event', {
+          email: 'shawn@shawnmorgan.com',
+          createdAt: '01/01/2015',
+          property1: 'foo',
+          property2: 'bar'
+        });
+        analytics.assert(!window.wootricSettings.properties.email);
+        analytics.assert(!window.wootricSettings.properties.createdAt);
+      });
+    });
+
+    describe('#identify', function() {
+      it('should set segment_user_id on identify when userId defined', function() {
+        analytics.identify('abcd1234', {
+          email: 'shawn@shawnmorgan.com'
+        });
+        analytics.equal(window.wootricSettings.segment_user_id, 'abcd1234');
+      });
+
+      it('should set segment_user_id to wite the anonymousId on identify when userId not defined', function() {
+        analytics.identify({
+          email: 'shawn@shawnmorgan.com'
+        });
+        analytics.equal(window.wootricSettings.segment_user_id, analytics.user().anonymousId());
+      });
+
+      it('should set email on identify', function() {
+        analytics.identify({
+          email: 'shawn@shawnmorgan.com'
+        });
+        analytics.equal(window.wootricSettings.email, 'shawn@shawnmorgan.com');
+      });
+
+      it('should set event_name to null on identify', function() {
+        analytics.identify({
+          email: 'shawn@shawnmorgan.com'
+        });
+        analytics.equal(window.wootricSettings.event_name, null);
+      });
+
+      it('should set created_at on identify using ISO YYYY-MM-DD format', function() {
+        analytics.identify({
+          createdAt: '2015-01-01'
+        });
+        analytics.equal(window.wootricSettings.created_at, 1420070400);
+      });
+
+      it('should set created_at on identify using ISO YYYYMMDD format', function() {
+        analytics.identify({
+          createdAt: '20150101'
+        });
+        analytics.equal(window.wootricSettings.created_at, 1420070400);
+      });
+
+      it('should set created_at on traits using Unix Timestamp format', function() {
+        analytics.identify({
+          createdAt: '1420099200000'
+        });
+        analytics.equal(window.wootricSettings.created_at, 1420099200);
+      });
+
+      it('should round Unix Timstamps with a decimal to the nearest whole digit', function() {
+        analytics.identify({
+          createdAt: '1420099200.435'
+        });
+        analytics.equal(window.wootricSettings.created_at, 1420099200);
+      });
+
+      it('should set language', function() {
+        analytics.identify({
+          language: 'es'
+        });
+        analytics.equal(window.wootricSettings.language, 'es');
+      });
+
+      it('should set properties based on other traits', function() {
+        analytics.identify({
+          email: 'shawn@shawnmorgan.com',
+          createdAt: '01/01/2015',
+          property1: 'foo',
+          property2: 'bar'
+        });
+        analytics.assert(window.wootricSettings.properties.property1 === 'foo');
+        analytics.assert(window.wootricSettings.properties.property2 === 'bar');
+      });
+
+      it('should set suffix _date to property key and convert date if trait is a date', function() {
+        analytics.identify({
+          email: 'shawn@shawnmorgan.com',
+          createdAt: '01/01/2015',
+          property1: 'foo',
+          property2: '2015-01-01'
+        });
+        analytics.assert(window.wootricSettings.properties.property1 === 'foo');
+        analytics.assert(window.wootricSettings.properties.hasOwnProperty('property2_date'));
+        analytics.assert(!window.wootricSettings.properties.hasOwnProperty('property2'));
+        analytics.equal(window.wootricSettings.properties.property2_date, 1420070400);
+      });
+
+      it('should not convert to date if property key has suffix _date', function() {
+        analytics.identify({
+          email: 'shawn@shawnmorgan.com',
+          createdAt: '01/01/2015',
+          property1: 'foo',
+          property2_date: 1420070400
+        });
+        analytics.assert(window.wootricSettings.properties.property1 === 'foo');
+        analytics.equal(window.wootricSettings.properties.property2_date, 1420070400);
+        analytics.assert(!window.wootricSettings.properties.hasOwnProperty('property2_date_date'));
+      });
+
+      it('should omit email and createdAt when setting window.wootricSettings.properties', function() {
+        analytics.identify({
+          email: 'shawn@shawnmorgan.com',
+          createdAt: '01/01/2015',
+          property1: 'foo',
+          property2: 'bar'
+        });
+        analytics.assert(!window.wootricSettings.properties.email);
+        analytics.assert(!window.wootricSettings.properties.createdAt);
+      });
+    });
+
+    describe('#page', function() {
+      beforeEach(function() {
+        analytics.page({});
+      });
+
+      it('should track the current page', function() {
+        analytics.assert(window.wootricSettings);
+        analytics.assert(wootric.lastPageTracked);
+      });
+
+      it('should set lastPageTracked to window location', function() {
+        analytics.assert(wootric.lastPageTracked === window.location);
+      });
+    });
+
+    describe('survey', function() {
+      it('should set email on identify', function() {
+        analytics.identify({
+          email: 'shawn@shawnmorgan.com'
+        });
+        analytics.equal(window.wootricSettings.email, 'shawn@shawnmorgan.com');
+      });
+
+      it('should set created_at on identify using ISO YYYY-MM-DD format', function() {
+        analytics.identify({
+          createdAt: '2015-01-01'
+        });
+        analytics.equal(window.wootricSettings.created_at, 1420070400);
+      });
+
+      it('should set created_at on identify using ISO YYYYMMDD format', function() {
+        analytics.identify({
+          createdAt: '20150101'
+        });
+        analytics.equal(window.wootricSettings.created_at, 1420070400);
+      });
+
+      it('should set created_at on traits using Unix Timestamp format', function() {
+        analytics.identify({
+          createdAt: '1420099200000'
+        });
+        analytics.equal(window.wootricSettings.created_at, 1420099200);
+      });
+
+      it('should round Unix Timstamps with a decimal to the nearest whole digit', function() {
+        analytics.identify({
+          createdAt: '1420099200.435'
+        });
+        analytics.equal(window.wootricSettings.created_at, 1420099200);
+      });
+
+      it('should set language', function() {
+        analytics.identify({
+          language: 'es'
+        });
+        analytics.equal(window.wootricSettings.language, 'es');
+      });
+
+      it('should set properties based on other traits', function() {
+        analytics.identify({
+          email: 'shawn@shawnmorgan.com',
+          createdAt: '01/01/2015',
+          property1: 'foo',
+          property2: 'bar'
+        });
+        analytics.assert(window.wootricSettings.properties.property1 === 'foo');
+        analytics.assert(window.wootricSettings.properties.property2 === 'bar');
+      });
+
+      it('should omit email and createdAt when setting window.wootricSettings.properties', function() {
+        analytics.identify({
+          email: 'shawn@shawnmorgan.com',
+          createdAt: '01/01/2015',
+          property1: 'foo',
+          property2: 'bar'
+        });
+        analytics.assert(!window.wootricSettings.properties.email);
+        analytics.assert(!window.wootricSettings.properties.createdAt);
+      });
+    });
+  });
+});

--- a/integrations/wootric/test/index.test.js
+++ b/integrations/wootric/test/index.test.js
@@ -73,12 +73,6 @@ describe('Wootric', function() {
     });
   });
 
-  describe('loading', function() {
-    it('should load', function(done) {
-      analytics.load(wootric, done);
-    });
-  });
-
   describe('after loading', function() {
     beforeEach(function(done) {
       analytics.once('ready', done);

--- a/integrations/wootric/test/index.test.js
+++ b/integrations/wootric/test/index.test.js
@@ -86,10 +86,6 @@ describe('Wootric', function() {
       analytics.page();
     });
 
-    it('should have created the global wootric object', function() {
-      analytics.assert(typeof window.wootric === 'function');
-    });
-
     describe('#track', function() {
       it('should set email on track', function() {
         analytics.track('track_event', {


### PR DESCRIPTION
This commit copies the content of the integration repo into
the "integrations" folder.

Original repo: https://github.com/segment-integrations/analytics.js-integration-wootric
Readme: https://github.com/segment-integrations/analytics.js-integration-wootric/blob/master/README.md


**What does this PR do?**
Move the wootric ajs repo into the monorepo

**Are there breaking changes in this PR?**
No

**Has this been tested end-to-end? Please provide screenshots on how the fix now populates in the end tool. If not, what was done to test?**
Testing to come after this code is merged. Tests were run locally and passed

**Any background context you want to provide?**
Moving this repo at this time to accommodate an update in functionality directly from the Wootric team.

**Is there parity with the server-side/android/iOS integration (if applicable)?**
n/a

**Does this require a metadata change? If so, please link the PR from https://github.com/segmentio/destination-scripts.**
no

**What are the relevant tickets?**
https://segment.atlassian.net/browse/PLATFORM-3022

**Link to CC ticket**
https://segment.atlassian.net/browse/CC-1536

**List all the tests accounts you have used to make sure this change works**
testing+wootric@segment.com


**Helpful Docs**

