### PR TITLE
Adds integration facebook-pixel

### DIFF
--- a/integrations/facebook-pixel/HISTORY.md
+++ b/integrations/facebook-pixel/HISTORY.md
@@ -1,0 +1,90 @@
+2.5.0 / 2018-06-22
+==================
+
+  * Map productIds to content_ids param instead of product category.
+
+2.4.2 / 2018-04-02
+==================
+
+  * allow multiple PVs (#35)
+
+2.4.1 / 2017-08-23
+==================
+
+  * Fix typeerror for traits.gender.
+
+2.4.0 / 2017-06-08
+==================
+
+  * Fix an issue where properties for certain spec'd fb event fields (pertaining to travel events) that contain date strings were having their dates reconformed by Facade into an incompatible format for FB's API.
+
+2.3.0 / 2016-11-15
+==================
+
+  * Update value for Product Added and Product Viewed to take either properties.value or properties.price
+
+2.2.1 / 2016-09-13
+==================
+
+  * fallback to USD for currency
+
+2.2.0 / 2016-09-07
+==================
+
+  * support ecom-specv2
+  * Switch from moment to dateformat
+
+2.1.3 / 2016-08-25
+==================
+
+  * gate initialization with traits behind option
+
+2.1.2 / 2016-08-16
+==================
+
+ * Fix for release
+
+2.1.1 / 2016-08-16
+==================
+
+  * Merge pull request #21 from segment-integrations/update/ajs-integration
+  * updating dependencies
+
+2.1.0 / 2016-08-16
+==================
+
+  * Merge pull request #15 from segment-integrations/update/ecommerce-spec-v2
+  * update ecommerce spec syntax to v2
+  * Add support for advanced matching
+
+2.0.0 / 2016-06-21
+==================
+
+  * Remove Duo compatibility
+  * Add CI setup (coverage, linting, cross-browser compatibility, etc.)
+  * Update eslint configuration
+
+1.0.4 / 2016-05-07
+==================
+
+  * Bump Analytics.js core, tester, integration to use Facade 2.x
+
+1.0.3 / 2016-04-26
+==================
+
+  * add flag to disable automatic pageview tracking
+
+1.0.2 / 2015-12-16
+==================
+
+  * add segment agent identifier
+
+1.0.1 / 2015-12-10
+==================
+
+  * still send old conversion pixels for mapped ecommerce events
+
+1.0.0 / 2015-12-08
+==================
+
+  * Initial release :sparkles: — port custom audiences and conversion tracking to new pixel

--- a/integrations/facebook-pixel/README.md
+++ b/integrations/facebook-pixel/README.md
@@ -1,0 +1,12 @@
+# analytics.js-integration-facebook-pixel [![Build Status][ci-badge]][ci-link]
+
+Facebook Pixel integration for [Analytics.js][].
+
+## License
+
+Released under the [MIT license](LICENSE).
+
+
+[Analytics.js]: https://segment.com/docs/libraries/analytics.js/
+[ci-link]: https://circleci.com/gh/segment-integrations/analytics.js-integration-facebook-pixel
+[ci-badge]: https://circleci.com/gh/segment-integrations/analytics.js-integration-facebook-pixel.svg?style=svg

--- a/integrations/facebook-pixel/lib/index.js
+++ b/integrations/facebook-pixel/lib/index.js
@@ -1,0 +1,346 @@
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+
+var integration = require('@segment/analytics.js-integration');
+var foldl = require('@ndhoule/foldl');
+var each = require('@ndhoule/each');
+var reject = require('reject');
+var camel = require('to-camel-case');
+var is = require('is');
+var dateformat = require('dateformat');
+var Track = require('segmentio-facade').Track;
+
+/**
+ * Expose `Facebook Pixel`.
+ */
+
+var FacebookPixel = module.exports = integration('Facebook Pixel')
+  .global('fbq')
+  .option('pixelId', '')
+  .option('agent', 'seg')
+  .option('valueIdentifier', 'value')
+  .option('initWithExistingTraits', false)
+  .option('traverse', false)
+  .mapping('standardEvents')
+  .mapping('legacyEvents')
+  .tag('<script src="//connect.facebook.net/en_US/fbevents.js">');
+
+/**
+ * Initialize Facebook Pixel.
+ *
+ * @param {Facade} page
+ */
+
+FacebookPixel.prototype.initialize = function() {
+  window._fbq = function() {
+    if (window.fbq.callMethod) {
+      window.fbq.callMethod.apply(window.fbq, arguments);
+    } else {
+      window.fbq.queue.push(arguments);
+    }
+  };
+
+  window.fbq = window.fbq || window._fbq;
+  window.fbq.push = window.fbq;
+  window.fbq.loaded = true;
+  window.fbq.disablePushState = true; // disables automatic pageview tracking
+  window.fbq.allowDuplicatePageViews = true; // enables fb
+  window.fbq.agent = this.options.agent;
+  window.fbq.version = '2.0';
+  window.fbq.queue = [];
+  this.load(this.ready);
+  if (this.options.initWithExistingTraits) {
+    var traits = formatTraits(this.analytics);
+    window.fbq('init', this.options.pixelId, traits);
+  } else {
+    window.fbq('init', this.options.pixelId);
+  }
+};
+
+/**
+ * Has the Facebook Pixel library been loaded yet?
+ *
+ * @return {Boolean}
+ */
+
+FacebookPixel.prototype.loaded = function() {
+  return !!(window.fbq && window.fbq.callMethod);
+};
+
+/**
+ * Trigger a page view.
+ *
+ * @param {Facade} identify
+ */
+
+FacebookPixel.prototype.page = function() {
+  window.fbq('track', 'PageView');
+};
+
+/**
+ * Track an event.
+ *
+ * @param {Facade} track
+ */
+
+FacebookPixel.prototype.track = function(track) {
+  var event = track.event();
+  var revenue = formatRevenue(track.revenue());
+  var payload = foldl(function(acc, val, key) {
+    if (key === 'revenue') {
+      acc.value = revenue;
+      return acc;
+    }
+
+    /**
+    * FB requires these date fields be formatted in a specific way.
+    * The specifications are non iso8601 compliant.
+    * https://developers.facebook.com/docs/marketing-api/dynamic-ads-for-travel/audience
+    * Therefore, we check if the property is one of these reserved fields.
+    * If so, we check if we have converted it to an iso date object already.
+    * If we have, we convert it again into Facebook's spec.
+    * If we have not, the user has likely passed in a date string that already
+    * adheres to FB's docs so we can just pass it through as is.
+    * @ccnixon
+    */
+
+    var dateFields = [
+      'checkinDate',
+      'checkoutDate',
+      'departingArrivalDate',
+      'departingDepartureDate',
+      'returningArrivalDate',
+      'returningDepartureDate',
+      'travelEnd',
+      'travelStart'
+    ];
+
+    if (dateFields.indexOf(camel(key)) >= 0) {
+      if (is.date(val)) {
+        val = val.toISOString().split('T')[0];
+        acc[key] = val;
+        return acc;
+      }
+    }
+
+    acc[key] = val;
+    return acc;
+  }, {}, track.properties());
+
+  var standard = this.standardEvents(event);
+  var legacy = this.legacyEvents(event);
+
+  // non-mapped events get sent as "custom events" with full
+  // tranformed payload
+  if (![].concat(standard, legacy).length) {
+    window.fbq('trackCustom', event, payload);
+    return;
+  }
+
+  // standard conversion events, mapped to one of 9 standard events
+  // "Purchase" requires a currency parameter;
+  // send full transformed payload
+  each(function(event) {
+    if (event === 'Purchase') payload.currency = track.currency(); // defaults to 'USD'
+    window.fbq('track', event, payload);
+  }, standard);
+
+  // legacy conversion events — mapped to specific "pixelId"s
+  // send only currency and value
+  each(function(event) {
+    window.fbq('track', event, {
+      currency: track.currency(),
+      value: revenue
+    });
+  }, legacy);
+};
+
+/**
+ * Product List Viewed.
+ *
+ * @api private
+ * @param {Track} track category
+ */
+
+FacebookPixel.prototype.productListViewed = function(track) {
+  var contentType;
+  var contentIds = [];
+  var products = track.products();
+  
+  // First, check to see if a products array with productIds has been defined.
+  if (Array.isArray(products)) {
+    products.forEach(function(product) {
+      var productId = product.productId || product.product_id;
+      if (productId) {
+        contentIds.push(productId);
+      }
+    });
+  }
+
+  // If no products have been defined, fallback on legacy behavior.
+  // Facebook documents the content_type parameter decision here: https://developers.facebook.com/docs/facebook-pixel/api-reference
+  if (contentIds.length) {
+    contentType = 'product';
+  } else {
+    contentIds.push(track.category() || '');
+    contentType = 'product_group';
+  }
+
+  window.fbq('track', 'ViewContent', {
+    content_ids: contentIds,
+    content_type: contentType
+  });
+
+  // fall through for mapped legacy conversions
+  each(function(event) {
+    window.fbq('track', event, {
+      currency: track.currency(),
+      value: formatRevenue(track.revenue())
+    });
+  }, this.legacyEvents(track.event()));
+};
+
+/**
+ * Product viewed.
+ *
+ * @api private
+ * @param {Track} track
+ */
+
+FacebookPixel.prototype.productViewed = function(track) {
+  window.fbq('track', 'ViewContent', {
+    content_ids: [track.productId() || track.id() || track.sku() || ''],
+    content_type: 'product',
+    content_name: track.name() || '',
+    content_category: track.category() || '',
+    currency: track.currency(),
+    value: this.options.valueIdentifier === 'value' ? formatRevenue(track.value()) : formatRevenue(track.price())
+  });
+
+  // fall through for mapped legacy conversions
+  each(function(event) {
+    window.fbq('track', event, {
+      currency: track.currency(),
+      value: formatRevenue(track.revenue())
+    });
+  }, this.legacyEvents(track.event()));
+};
+
+/**
+ * Product added.
+ *
+ * @api private
+ * @param {Track} track
+ */
+
+FacebookPixel.prototype.productAdded = function(track) {
+  window.fbq('track', 'AddToCart', {
+    content_ids: [track.productId() || track.id() || track.sku() || ''],
+    content_type: 'product',
+    content_name: track.name() || '',
+    content_category: track.category() || '',
+    currency: track.currency(),
+    value: this.options.valueIdentifier === 'value' ? formatRevenue(track.value()) : formatRevenue(track.price())
+  });
+
+  // fall through for mapped legacy conversions
+  each(function(event) {
+    window.fbq('track', event, {
+      currency: track.currency(),
+      value: formatRevenue(track.revenue())
+    });
+  }, this.legacyEvents(track.event()));
+};
+
+/**
+ * Order Completed.
+ *
+ * @api private
+ * @param {Track} track
+ */
+
+FacebookPixel.prototype.orderCompleted = function(track) {
+  var content_ids = foldl(function(acc, product) {
+    var item = new Track({ properties: product });
+    var key = item.productId() || item.id() || item.sku();
+    if (key) acc.push(key);
+    return acc;
+  }, [], track.products() || []);
+
+  var revenue = formatRevenue(track.revenue());
+
+  window.fbq('track', 'Purchase', {
+    content_ids: content_ids,
+    content_type: 'product',
+    currency: track.currency(),
+    value: revenue
+  });
+
+  // fall through for mapped legacy conversions
+  each(function(event) {
+    window.fbq('track', event, {
+      currency: track.currency(),
+      value: formatRevenue(track.revenue())
+    });
+  }, this.legacyEvents(track.event()));
+};
+
+
+/**
+ * Get Revenue Formatted Correctly for FB.
+ *
+ * @api private
+ * @param {Track} track
+ */
+
+function formatRevenue(revenue) {
+  return Number(revenue || 0).toFixed(2);
+}
+
+/**
+ * Get Traits Formatted Correctly for FB.
+ *
+ * https://developers.facebook.com/docs/facebook-pixel/pixel-with-ads/conversion-tracking#advanced_match
+ *
+ * @api private
+ */
+
+function formatTraits(analytics) {
+  var traits = analytics && analytics.user().traits();
+  if (!traits) return {};
+  var firstName;
+  var lastName;
+  // Check for firstName property
+  // else check for name
+  if (traits.firstName) {
+    firstName = traits.firstName;
+    lastName = traits.lastName;
+  } else {
+    var nameArray = traits.name && traits.name.toLowerCase().split(' ') || [];
+    firstName = nameArray.shift();
+    lastName = nameArray.pop();
+  }
+  var gender;
+  if (traits.gender && is.string(traits.gender)) {
+    gender = traits.gender.slice(0,1).toLowerCase();
+  }
+  var birthday = traits.birthday && dateformat(traits.birthday, 'yyyymmdd');
+  var address = traits.address || {};
+  var city = address.city && address.city.split(' ').join('').toLowerCase();
+  var state = address.state && address.state.toLowerCase();
+  var postalCode = address.postalCode;
+  return reject({
+    em: traits.email,
+    fn: firstName,
+    ln: lastName,
+    ph: traits.phone,
+    ge: gender,
+    db: birthday,
+    ct: city,
+    st: state,
+    zp: postalCode
+  });
+}

--- a/integrations/facebook-pixel/package.json
+++ b/integrations/facebook-pixel/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@segment/analytics.js-integration-facebook-pixel",
+  "description": "The Facebook Pixel analytics.js integration.",
+  "version": "2.5.0",
+  "keywords": [
+    "analytics.js",
+    "analytics.js-integration",
+    "segment",
+    "facebook-pixel"
+  ],
+  "main": "lib/index.js",
+  "scripts": {
+    "test": "make test"
+  },
+  "author": "Segment \u003cfriends@segment.com\u003e",
+  "license": "SEE LICENSE IN LICENSE",
+  "homepage": "https://github.com/segmentio/analytics.js-integrations/blob/master/integrations/facebook-pixel#readme",
+  "bugs": {
+    "url": "https://github.com/segmentio/analytics.js-integrations/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/segmentio/analytics.js-integrations.git"
+  },
+  "dependencies": {
+    "@ndhoule/each": "^2.0.1",
+    "@ndhoule/foldl": "^2.0.1",
+    "@segment/analytics.js-integration": "^3.1.0",
+    "dateformat": "^1.0.12",
+    "is": "^3.2.1",
+    "reject": "0.0.1",
+    "segmentio-facade": "^3.1.0",
+    "to-camel-case": "^1.0.0"
+  },
+  "devDependencies": {
+    "@segment/analytics.js-core": "^3.0.0",
+    "@segment/analytics.js-integration-tester": "^3.1.0",
+    "@segment/clear-env": "^2.0.0",
+    "@segment/eslint-config": "^3.1.1",
+    "browserify": "^13.0.0",
+    "browserify-istanbul": "^2.0.0",
+    "eslint": "^2.9.0",
+    "eslint-plugin-mocha": "^2.2.0",
+    "eslint-plugin-require-path-exists": "^1.1.5",
+    "istanbul": "^0.4.3",
+    "karma": "1.3.0",
+    "karma-browserify": "^5.0.4",
+    "karma-chrome-launcher": "^1.0.1",
+    "karma-coverage": "^1.0.0",
+    "karma-junit-reporter": "^1.0.0",
+    "karma-mocha": "1.0.1",
+    "karma-phantomjs-launcher": "^1.0.0",
+    "karma-sauce-launcher": "^1.0.0",
+    "karma-spec-reporter": "0.0.26",
+    "mocha": "^2.2.5",
+    "npm-check": "^5.2.1",
+    "phantomjs-prebuilt": "^2.1.7",
+    "watchify": "^3.7.0"
+  }
+}

--- a/integrations/facebook-pixel/test/.eslintrc
+++ b/integrations/facebook-pixel/test/.eslintrc
@@ -1,0 +1,3 @@
+{
+  "extends": "@segment/eslint-config/mocha"
+}

--- a/integrations/facebook-pixel/test/index.test.js
+++ b/integrations/facebook-pixel/test/index.test.js
@@ -1,0 +1,419 @@
+'use strict';
+
+var Analytics = require('@segment/analytics.js-core').constructor;
+var sandbox = require('@segment/clear-env');
+var tester = require('@segment/analytics.js-integration-tester');
+var FacebookPixel = require('../lib');
+
+describe('Facebook Pixel', function() {
+  var analytics;
+  var facebookPixel;
+  var options = {
+    legacyEvents: {
+      legacyEvent: 'asdFrkj'
+    },
+    standardEvents: {
+      standardEvent: 'standard',
+      'booking completed': 'Purchase',
+      search: 'Search'
+    },
+    pixelId: '123123123',
+    agent: 'test',
+    initWithExistingTraits: false
+  };
+
+  beforeEach(function() {
+    analytics = new Analytics();
+    facebookPixel = new FacebookPixel(options);
+    analytics.use(FacebookPixel);
+    analytics.use(tester);
+    analytics.add(facebookPixel);
+    analytics.identify('123', {
+      name: 'Ash Ketchum',
+      gender: 'Male',
+      birthday: '01/13/1991',
+      address: {
+        city: 'Emerald',
+        state: 'Kanto',
+        postalCode: 123456
+      }
+    });
+  });
+
+  afterEach(function(done) {
+    analytics.waitForScripts(function() {
+      analytics.restore();
+      analytics.reset();
+      facebookPixel.reset();
+      sandbox();
+      done();
+    });
+  });
+
+  describe('before loading', function() {
+    beforeEach(function() {
+      analytics.stub(facebookPixel, 'load');
+    });
+
+    afterEach(function() {
+      facebookPixel.reset();
+    });
+
+    describe('#initialize', function() {
+      it('should call load on initialize', function() {
+        analytics.initialize();
+        analytics.called(facebookPixel.load);
+      });
+
+      it('should set the correct agent and version', function() {
+        analytics.initialize();
+        analytics.equal(window.fbq.agent, 'test');
+        analytics.equal(window.fbq.version, '2.0');
+      });
+
+      it('should set disablePushState to true', function() {
+        analytics.initialize();
+        analytics.equal(window.fbq.disablePushState, true);
+      });
+
+      it('should set allowDuplicatePageViews to true', function() {
+        analytics.initialize();
+        analytics.equal(window.fbq.allowDuplicatePageViews, true);
+      });
+
+      it('should create fbq object', function() {
+        analytics.initialize();
+        analytics.assert(window.fbq instanceof Function);
+      });
+
+      before(function() {
+        options.initWithExistingTraits = true;
+      });
+
+      after(function() {
+        options.initWithExistingTraits = false;
+      });
+
+      it('should call init with the user\'s traits if option enabled', function() {
+        var payload = {
+          ct: 'emerald',
+          db: '19910113',
+          fn: 'ash',
+          ge: 'm',
+          ln: 'ketchum',
+          st: 'kanto',
+          zp: 123456
+        };
+        analytics.stub(window, 'fbq');
+        analytics.initialize();
+        analytics.called(window.fbq, 'init', options.pixelId, payload);
+      });
+    });
+  });
+
+  describe('loading', function() {
+    beforeEach(function() {
+      analytics.stub(window, 'fbq');
+      analytics.initialize();
+    });
+
+    it('should load', function(done) {
+      analytics.load(facebookPixel, done);
+    });
+  });
+
+  describe('after loading', function() {
+    beforeEach(function(done) {
+      analytics.once('ready', done);
+      analytics.initialize();
+    });
+
+    describe('#page', function() {
+      beforeEach(function() {
+        analytics.stub(window, 'fbq');
+      });
+
+      it('should track a pageview', function() {
+        analytics.page();
+        analytics.called(window.fbq, 'track', 'PageView');
+      });
+    });
+
+    describe('#track', function() {
+      beforeEach(function() {
+        analytics.stub(window, 'fbq');
+      });
+
+      describe('event not mapped to legacy or standard', function() {
+        it('should send a "custom" event', function() {
+          analytics.track('event');
+          analytics.called(window.fbq, 'trackCustom', 'event');
+        });
+
+        it('should send a "custom" event and properties', function() {
+          analytics.track('event', { property: true });
+          analytics.called(window.fbq, 'trackCustom', 'event', { property: true });
+        });
+
+        it('should send properties correctly', function() {
+          analytics.track('event', {
+            currency: 'XXX',
+            revenue: 13,
+            property: true
+          });
+          analytics.called(window.fbq, 'trackCustom', 'event', {
+            currency: 'XXX',
+            value: '13.00',
+            property: true
+          });
+        });
+      });
+
+      describe('event mapped to legacy', function() {
+        it('should send a correctly mapped event', function() {
+          analytics.track('legacyEvent');
+          analytics.called(window.fbq, 'track', 'asdFrkj', {
+            currency: 'USD',
+            value: '0.00'
+          });
+        });
+
+        it('should send an event and properties', function() {
+          analytics.track('legacyEvent', { revenue: 10 });
+          analytics.called(window.fbq, 'track', 'asdFrkj', {
+            currency: 'USD',
+            value: '10.00'
+          });
+        });
+
+        it('should send only currency and revenue', function() {
+          analytics.track('legacyEvent', { revenue: 13, property: true });
+          analytics.called(window.fbq, 'track', 'asdFrkj', {
+            currency: 'USD',
+            value: '13.00'
+          });
+        });
+      });
+
+      describe('event mapped to standard', function() {
+        it('should send a correctly mapped event — no required properties', function() {
+          analytics.track('standardEvent');
+          analytics.called(window.fbq, 'track', 'standard', {});
+        });
+
+        it('should send properties correctly', function() {
+          analytics.track('standardEvent', {
+            currency: 'XXX',
+            revenue: 13,
+            property: true
+          });
+          analytics.called(window.fbq, 'track', 'standard', {
+            currency: 'XXX',
+            value: '13.00',
+            property: true
+          });
+        });
+
+        it('should default currency to USD if mapped to "Purchase"', function() {
+          analytics.track('booking completed', {
+            revenue: 13,
+            property: true
+          });
+          analytics.called(window.fbq, 'track', 'Purchase', {
+            currency: 'USD',
+            value: '13.00',
+            property: true
+          });
+        });
+
+        describe('Dyanmic Ads for Travel date parsing', function() {
+          it('should correctly pass in iso8601 formatted date objects', function() {
+            analytics.track('search', {
+              checkin_date: '2017-07-01T20:03:46Z'
+            });
+
+            analytics.called(window.fbq, 'track', 'Search', {
+              checkin_date: '2017-07-01'
+            });
+          });
+
+          it('should pass through strings that we did not recognize as dates as-is', function() {
+            analytics.track('search', {
+              checkin_date: '2017-06-23T15:30:00GMT'
+            });
+
+            analytics.called(window.fbq, 'track', 'Search', {
+              checkin_date: '2017-06-23T15:30:00GMT'
+            });
+          });
+        });
+      });
+
+      describe('segment ecommerce => FB product audiences', function() {
+        describe('Product List Viewed', function() {
+          it('Should map content_ids parameter to product_ids and content_type to "product" if possible', function() {
+            analytics.track('Product List Viewed', {
+              category: 'Games', products: [
+                {
+                  product_id: '507f1f77bcf86cd799439011',
+                  sku: '45790-32',
+                  name: 'Monopoly: 3rd Edition',
+                  price: 19,
+                  position: 1,
+                  category: 'Games',
+                  url: 'https://www.example.com/product/path',
+                  image_url: 'https://www.example.com/product/path.jpg'
+                },
+                {
+                  product_id: '505bd76785ebb509fc183733',
+                  sku: '46493-32',
+                  name: 'Uno Card Game',
+                  price: 3,
+                  position: 2,
+                  category: 'Games'
+                }
+              ]
+            });
+            analytics.called(window.fbq, 'track', 'ViewContent', {
+              content_ids: ['507f1f77bcf86cd799439011', '505bd76785ebb509fc183733'],
+              content_type: 'product'
+            });
+          });
+
+          it('Should fallback on mapping content_ids to the product category and content_type to "product_group"', function() {
+            analytics.track('Product List Viewed', { category: 'Games' });
+            analytics.called(window.fbq, 'track', 'ViewContent', {
+              content_ids: ['Games'],
+              content_type: 'product_group'
+            });
+          });
+        });
+
+        it('Product Viewed', function() {
+          analytics.track('Product Viewed', {
+            product_id: '507f1f77bcf86cd799439011',
+            currency: 'USD',
+            quantity: 1,
+            price: 44.33,
+            name: 'my product',
+            category: 'cat 1',
+            sku: 'p-298',
+            value: 24.75
+          });
+          analytics.called(window.fbq, 'track', 'ViewContent', {
+            content_ids: ['507f1f77bcf86cd799439011'],
+            content_type: 'product',
+            content_name: 'my product',
+            content_category: 'cat 1',
+            currency: 'USD',
+            value: '24.75'
+          });
+        });
+
+        it('Should map properties.price to facebooks value if price is selected', function() {
+          facebookPixel.options.valueIdentifier = 'price';
+          analytics.track('Product Viewed', {
+            product_id: '507f1f77bcf86cd799439011',
+            currency: 'USD',
+            quantity: 1,
+            price: 44.33,
+            name: 'my product',
+            category: 'cat 1',
+            sku: 'p-298',
+            value: 24.75
+          });
+          analytics.called(window.fbq, 'track', 'ViewContent', {
+            content_ids: ['507f1f77bcf86cd799439011'],
+            content_type: 'product',
+            content_name: 'my product',
+            content_category: 'cat 1',
+            currency: 'USD',
+            value: '44.33'
+          });
+        });
+
+        it('Adding to Cart', function() {
+          analytics.track('Product Added', {
+            product_id: '507f1f77bcf86cd799439011',
+            currency: 'USD',
+            quantity: 1,
+            price: 44.33,
+            name: 'my product',
+            category: 'cat 1',
+            sku: 'p-298',
+            value: 24.75
+          });
+          analytics.called(window.fbq, 'track', 'AddToCart', {
+            content_ids: ['507f1f77bcf86cd799439011'],
+            content_type: 'product',
+            content_name: 'my product',
+            content_category: 'cat 1',
+            currency: 'USD',
+            value: '24.75'
+          });
+        });
+
+        it('Should map properties.price to facebooks value if price is selected', function() {
+          facebookPixel.options.valueIdentifier = 'price';
+          analytics.track('Product Added', {
+            product_id: '507f1f77bcf86cd799439011',
+            currency: 'USD',
+            quantity: 1,
+            price: 44.33,
+            name: 'my product',
+            category: 'cat 1',
+            sku: 'p-298',
+            value: 24.75
+          });
+          analytics.called(window.fbq, 'track', 'AddToCart', {
+            content_ids: ['507f1f77bcf86cd799439011'],
+            content_type: 'product',
+            content_name: 'my product',
+            content_category: 'cat 1',
+            currency: 'USD',
+            value: '44.33'
+          });
+        });
+
+        it('Completing an Order', function() {
+          analytics.track('Order Completed', {
+            products: [
+              { product_id: '507f1f77bcf86cd799439011' },
+              { product_id: '505bd76785ebb509fc183733' }
+            ],
+            currency: 'USD',
+            total: 0.50
+          });
+          analytics.called(window.fbq, 'track', 'Purchase', {
+            content_ids: ['507f1f77bcf86cd799439011', '505bd76785ebb509fc183733'],
+            content_type: 'product',
+            currency: 'USD',
+            value: '0.50'
+          });
+        });
+
+        it('Should send both pixel and standard event if mapped', function() {
+          facebookPixel.options.legacyEvents = { 'Completed Order': '123456' };
+          analytics.track('Completed Order', {
+            products: [
+              { product_id: '507f1f77bcf86cd799439011' },
+              { product_id: '505bd76785ebb509fc183733' }
+            ],
+            currency: 'USD',
+            total: 0.50
+          });
+          analytics.called(window.fbq, 'track', 'Purchase', {
+            content_ids: ['507f1f77bcf86cd799439011', '505bd76785ebb509fc183733'],
+            content_type: 'product',
+            currency: 'USD',
+            value: '0.50'
+          });
+          analytics.called(window.fbq, 'track', '123456', {
+            currency: 'USD',
+            value: '0.50'
+          });
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
**What does this PR do?**
Moves FB Pixel into the monorepo.

Original repo: https://github.com/segment-integrations/analytics.js-integration-facebook-pixel
Readme: https://github.com/segment-integrations/analytics.js-integration-facebook-pixel/blob/master/README.md

**Are there breaking changes in this PR?**
Negative

**Has this been tested end-to-end? Please provide screenshots on how the fix now populates in the end tool. If not, what was done to test?**
Tests with PhantomJS pass locally. SauceLabs tests to run after this PR.

**What are the relevant tickets?**
https://segment.atlassian.net/secure/RapidBoard.jspa?rapidView=76&projectKey=PLATFORM&modal=detail&selectedIssue=PLATFORM-3101

**Link to CC ticket**
n/a

