### PR TITLE
allow disable autoConfig

### DIFF
--- a/integrations/facebook-pixel/lib/index.js
+++ b/integrations/facebook-pixel/lib/index.js
@@ -24,6 +24,7 @@ var FacebookPixel = module.exports = integration('Facebook Pixel')
   .option('valueIdentifier', 'value')
   .option('initWithExistingTraits', false)
   .option('traverse', false)
+  .option('disableAutoConfig', false)
   .mapping('standardEvents')
   .mapping('legacyEvents')
   .tag('<script src="//connect.facebook.net/en_US/fbevents.js">');
@@ -52,6 +53,9 @@ FacebookPixel.prototype.initialize = function() {
   window.fbq.version = '2.0';
   window.fbq.queue = [];
   this.load(this.ready);
+  if (this.options.disableAutoConfig) {
+    window.fbq('set', 'autoConfig', false, this.options.pixelId);
+  }
   if (this.options.initWithExistingTraits) {
     var traits = formatTraits(this.analytics);
     window.fbq('init', this.options.pixelId, traits);

--- a/integrations/facebook-pixel/test/index.test.js
+++ b/integrations/facebook-pixel/test/index.test.js
@@ -76,14 +76,23 @@ describe('Facebook Pixel', function() {
         analytics.equal(window.fbq.disablePushState, true);
       });
 
-      it('should set allowDuplicatePageViews to true', function() {
-        analytics.initialize();
-        analytics.equal(window.fbq.allowDuplicatePageViews, true);
-      });
-
       it('should create fbq object', function() {
         analytics.initialize();
         analytics.assert(window.fbq instanceof Function);
+      });
+
+      before(function() {
+        options.disableAutoConfig = true;
+      });
+
+      after(function() {
+        options.disableAutoConfig = false;
+      });
+
+      it('should call set autoConfig if option disableAutoConfig is enabled', function () {
+        analytics.stub(window, 'fbq');
+        analytics.initialize();
+        analytics.called(window.fbq, 'set', 'autoConfig', false, options.pixelId);
       });
 
       before(function() {
@@ -250,42 +259,11 @@ describe('Facebook Pixel', function() {
       });
 
       describe('segment ecommerce => FB product audiences', function() {
-        describe('Product List Viewed', function() {
-          it('Should map content_ids parameter to product_ids and content_type to "product" if possible', function() {
-            analytics.track('Product List Viewed', {
-              category: 'Games', products: [
-                {
-                  product_id: '507f1f77bcf86cd799439011',
-                  sku: '45790-32',
-                  name: 'Monopoly: 3rd Edition',
-                  price: 19,
-                  position: 1,
-                  category: 'Games',
-                  url: 'https://www.example.com/product/path',
-                  image_url: 'https://www.example.com/product/path.jpg'
-                },
-                {
-                  product_id: '505bd76785ebb509fc183733',
-                  sku: '46493-32',
-                  name: 'Uno Card Game',
-                  price: 3,
-                  position: 2,
-                  category: 'Games'
-                }
-              ]
-            });
-            analytics.called(window.fbq, 'track', 'ViewContent', {
-              content_ids: ['507f1f77bcf86cd799439011', '505bd76785ebb509fc183733'],
-              content_type: 'product'
-            });
-          });
-
-          it('Should fallback on mapping content_ids to the product category and content_type to "product_group"', function() {
-            analytics.track('Product List Viewed', { category: 'Games' });
-            analytics.called(window.fbq, 'track', 'ViewContent', {
-              content_ids: ['Games'],
-              content_type: 'product_group'
-            });
+        it('Product List Viewed', function() {
+          analytics.track('Product List Viewed', { category: 'Games' });
+          analytics.called(window.fbq, 'track', 'ViewContent', {
+            content_ids: ['Games'],
+            content_type: 'product_group'
           });
         });
 

--- a/integrations/facebook-pixel/test/index.test.js
+++ b/integrations/facebook-pixel/test/index.test.js
@@ -76,6 +76,11 @@ describe('Facebook Pixel', function() {
         analytics.equal(window.fbq.disablePushState, true);
       });
 
+      it('should set allowDuplicatePageViews to true', function() {
+        analytics.initialize();
+        analytics.equal(window.fbq.allowDuplicatePageViews, true);
+      });
+
       it('should create fbq object', function() {
         analytics.initialize();
         analytics.assert(window.fbq instanceof Function);
@@ -259,11 +264,42 @@ describe('Facebook Pixel', function() {
       });
 
       describe('segment ecommerce => FB product audiences', function() {
-        it('Product List Viewed', function() {
-          analytics.track('Product List Viewed', { category: 'Games' });
-          analytics.called(window.fbq, 'track', 'ViewContent', {
-            content_ids: ['Games'],
-            content_type: 'product_group'
+        describe('Product List Viewed', function() {
+          it('Should map content_ids parameter to product_ids and content_type to "product" if possible', function() {
+            analytics.track('Product List Viewed', {
+              category: 'Games', products: [
+                {
+                  product_id: '507f1f77bcf86cd799439011',
+                  sku: '45790-32',
+                  name: 'Monopoly: 3rd Edition',
+                  price: 19,
+                  position: 1,
+                  category: 'Games',
+                  url: 'https://www.example.com/product/path',
+                  image_url: 'https://www.example.com/product/path.jpg'
+                },
+                {
+                  product_id: '505bd76785ebb509fc183733',
+                  sku: '46493-32',
+                  name: 'Uno Card Game',
+                  price: 3,
+                  position: 2,
+                  category: 'Games'
+                }
+              ]
+            });
+            analytics.called(window.fbq, 'track', 'ViewContent', {
+              content_ids: ['507f1f77bcf86cd799439011', '505bd76785ebb509fc183733'],
+              content_type: 'product'
+            });
+          });
+
+          it('Should fallback on mapping content_ids to the product category and content_type to "product_group"', function() {
+            analytics.track('Product List Viewed', { category: 'Games' });
+            analytics.called(window.fbq, 'track', 'ViewContent', {
+              content_ids: ['Games'],
+              content_type: 'product_group'
+            });
           });
         });
 


### PR DESCRIPTION
> The Facebook pixel will send button click and page metadata (such as data structured according to Opengraph or Schema.org formats) from your website to improve your ads delivery and measurement and automate your pixel setup - https://developers.facebook.com/docs/facebook-pixel/api-reference#automatic-configuration

So I added an option to disable it 👍 

(Recreation of [this PR](https://github.com/segment-integrations/analytics.js-integration-facebook-pixel/pull/37) in the original repo. Addresses issue #56.)