### PR TITLE
FB Pixel: Custom Content Types and Automatic Configuration

### DIFF
--- a/integrations/facebook-pixel/HISTORY.md
+++ b/integrations/facebook-pixel/HISTORY.md
@@ -1,3 +1,10 @@
+2.5.1 / 2018-09-10
+==================
+
+  * Makes content type customizable for Product List Viewed, Product Viewed, Product Added, and
+  Order Completed events.
+  * Adds a setting to disable Automatic Configuration.
+
 2.5.0 / 2018-06-22
 ==================
 

--- a/integrations/facebook-pixel/lib/index.js
+++ b/integrations/facebook-pixel/lib/index.js
@@ -24,6 +24,7 @@ var FacebookPixel = module.exports = integration('Facebook Pixel')
   .option('valueIdentifier', 'value')
   .option('initWithExistingTraits', false)
   .option('traverse', false)
+  .option('disableAutoConfig', false)
   .mapping('standardEvents')
   .mapping('legacyEvents')
   .tag('<script src="//connect.facebook.net/en_US/fbevents.js">');
@@ -52,6 +53,9 @@ FacebookPixel.prototype.initialize = function() {
   window.fbq.version = '2.0';
   window.fbq.queue = [];
   this.load(this.ready);
+  if (this.options.disableAutoConfig) {
+    window.fbq('set', 'autoConfig', false, this.options.pixelId);
+  }
   if (this.options.initWithExistingTraits) {
     var traits = formatTraits(this.analytics);
     window.fbq('init', this.options.pixelId, traits);

--- a/integrations/facebook-pixel/lib/index.js
+++ b/integrations/facebook-pixel/lib/index.js
@@ -191,7 +191,7 @@ FacebookPixel.prototype.productListViewed = function(track) {
 
   window.fbq('track', 'ViewContent', {
     content_ids: contentIds,
-    content_type: contentType
+    content_type: track.proxy('properties.contentType') || contentType, 
   });
 
   // fall through for mapped legacy conversions
@@ -213,7 +213,7 @@ FacebookPixel.prototype.productListViewed = function(track) {
 FacebookPixel.prototype.productViewed = function(track) {
   window.fbq('track', 'ViewContent', {
     content_ids: [track.productId() || track.id() || track.sku() || ''],
-    content_type: 'product',
+    content_type: track.proxy('properties.contentType') || 'product',
     content_name: track.name() || '',
     content_category: track.category() || '',
     currency: track.currency(),
@@ -239,7 +239,7 @@ FacebookPixel.prototype.productViewed = function(track) {
 FacebookPixel.prototype.productAdded = function(track) {
   window.fbq('track', 'AddToCart', {
     content_ids: [track.productId() || track.id() || track.sku() || ''],
-    content_type: 'product',
+    content_type: track.proxy('properties.contentType') || 'product',
     content_name: track.name() || '',
     content_category: track.category() || '',
     currency: track.currency(),
@@ -274,7 +274,7 @@ FacebookPixel.prototype.orderCompleted = function(track) {
 
   window.fbq('track', 'Purchase', {
     content_ids: content_ids,
-    content_type: 'product',
+    content_type: track.proxy('properties.contentType') || 'product',
     currency: track.currency(),
     value: revenue
   });

--- a/integrations/facebook-pixel/lib/index.js
+++ b/integrations/facebook-pixel/lib/index.js
@@ -24,7 +24,7 @@ var FacebookPixel = module.exports = integration('Facebook Pixel')
   .option('valueIdentifier', 'value')
   .option('initWithExistingTraits', false)
   .option('traverse', false)
-  .option('disableAutoConfig', false)
+  .option('automaticConfiguration', true)
   .mapping('standardEvents')
   .mapping('legacyEvents')
   .tag('<script src="//connect.facebook.net/en_US/fbevents.js">');
@@ -53,7 +53,7 @@ FacebookPixel.prototype.initialize = function() {
   window.fbq.version = '2.0';
   window.fbq.queue = [];
   this.load(this.ready);
-  if (this.options.disableAutoConfig) {
+  if (!this.options.automaticConfiguration) {
     window.fbq('set', 'autoConfig', false, this.options.pixelId);
   }
   if (this.options.initWithExistingTraits) {

--- a/integrations/facebook-pixel/lib/index.js
+++ b/integrations/facebook-pixel/lib/index.js
@@ -242,12 +242,6 @@ FacebookPixel.prototype.productViewed = function(track) {
  */
 
 FacebookPixel.prototype.productAdded = function(track) {
-  var contentType = ['product']
-  var mappedContentTypes = this.contentTypes(track.category());
-  if (mappedContentTypes.length) {
-    contentType = mappedContentTypes
-  }  
-
   window.fbq('track', 'AddToCart', {
     content_ids: [track.productId() || track.id() || track.sku() || ''],
     content_type: this.mappedContentTypesOrDefault(track.category(), ['product']),

--- a/integrations/facebook-pixel/package.json
+++ b/integrations/facebook-pixel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-facebook-pixel",
   "description": "The Facebook Pixel analytics.js integration.",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/facebook-pixel/test/index.test.js
+++ b/integrations/facebook-pixel/test/index.test.js
@@ -225,7 +225,6 @@ describe('Facebook Pixel', function() {
             property: true
           });
         });
-
         describe('Dyanmic Ads for Travel date parsing', function() {
           it('should correctly pass in iso8601 formatted date objects', function() {
             analytics.track('search', {
@@ -287,6 +286,36 @@ describe('Facebook Pixel', function() {
               content_type: 'product_group'
             });
           });
+
+          it('should send the custom content type if set', function() {
+            analytics.track('Product List Viewed', {
+              content_type: 'games',
+              category: 'Games', products: [
+                {
+                  product_id: '507f1f77bcf86cd799439011',
+                  sku: '45790-32',
+                  name: 'Monopoly: 3rd Edition',
+                  price: 19,
+                  position: 1,
+                  category: 'Games',
+                  url: 'https://www.example.com/product/path',
+                  image_url: 'https://www.example.com/product/path.jpg'
+                },
+                {
+                  product_id: '505bd76785ebb509fc183733',
+                  sku: '46493-32',
+                  name: 'Uno Card Game',
+                  price: 3,
+                  position: 2,
+                  category: 'Games'
+                }
+              ]
+            });
+            analytics.called(window.fbq, 'track', 'ViewContent', {
+              content_ids: ['507f1f77bcf86cd799439011', '505bd76785ebb509fc183733'],
+              content_type: 'games'
+            });
+          })
         });
 
         it('Product Viewed', function() {
@@ -332,6 +361,28 @@ describe('Facebook Pixel', function() {
           });
         });
 
+        it('should send the custom content type if set', function() {
+          analytics.track('Product Viewed', {
+            product_id: '507f1f77bcf86cd799439011',
+            currency: 'USD',
+            quantity: 1,
+            price: 44.33,
+            name: 'my product',
+            category: 'cat 1',
+            sku: 'p-298',
+            value: 24.75,
+            content_type: 'music'
+          });
+          analytics.called(window.fbq, 'track', 'ViewContent', {
+            content_ids: ['507f1f77bcf86cd799439011'],
+            content_type: 'music',
+            content_name: 'my product',
+            content_category: 'cat 1',
+            currency: 'USD',
+            value: '24.75'
+          });
+        })
+
         it('Adding to Cart', function() {
           analytics.track('Product Added', {
             product_id: '507f1f77bcf86cd799439011',
@@ -375,6 +426,28 @@ describe('Facebook Pixel', function() {
           });
         });
 
+        it('should send the custom content type if set', function() {
+          analytics.track('Product Added', {
+            product_id: '507f1f77bcf86cd799439011',
+            currency: 'USD',
+            quantity: 1,
+            price: 44.33,
+            name: 'my product',
+            category: 'cat 1',
+            sku: 'p-298',
+            value: 24.75,
+            content_type: "stuff"
+          });
+          analytics.called(window.fbq, 'track', 'AddToCart', {
+            content_ids: ['507f1f77bcf86cd799439011'],
+            content_type: 'stuff',
+            content_name: 'my product',
+            content_category: 'cat 1',
+            currency: 'USD',
+            value: '24.75'
+          });
+        })
+
         it('Completing an Order', function() {
           analytics.track('Order Completed', {
             products: [
@@ -413,6 +486,24 @@ describe('Facebook Pixel', function() {
             value: '0.50'
           });
         });
+
+        it('should send the custom content type if set', function() {
+          analytics.track('Order Completed', {
+            products: [
+              { product_id: '507f1f77bcf86cd799439011' },
+              { product_id: '505bd76785ebb509fc183733' }
+            ],
+            currency: 'USD',
+            total: 0.50,
+            content_type: 'home_listing'
+          });
+          analytics.called(window.fbq, 'track', 'Purchase', {
+            content_ids: ['507f1f77bcf86cd799439011', '505bd76785ebb509fc183733'],
+            content_type: 'home_listing',
+            currency: 'USD',
+            value: '0.50'
+          });
+        })
       });
     });
   });

--- a/integrations/facebook-pixel/test/index.test.js
+++ b/integrations/facebook-pixel/test/index.test.js
@@ -76,6 +76,11 @@ describe('Facebook Pixel', function() {
         analytics.equal(window.fbq.disablePushState, true);
       });
 
+      it('should set allowDuplicatePageViews to true', function() {
+        analytics.initialize();
+        analytics.equal(window.fbq.allowDuplicatePageViews, true);
+      });
+
       it('should create fbq object', function() {
         analytics.initialize();
         analytics.assert(window.fbq instanceof Function);
@@ -258,11 +263,42 @@ describe('Facebook Pixel', function() {
       });
 
       describe('segment ecommerce => FB product audiences', function() {
-        it('Product List Viewed', function() {
-          analytics.track('Product List Viewed', { category: 'Games' });
-          analytics.called(window.fbq, 'track', 'ViewContent', {
-            content_ids: ['Games'],
-            content_type: 'product_group'
+        describe('Product List Viewed', function() {
+          it('Should map content_ids parameter to product_ids and content_type to "product" if possible', function() {
+            analytics.track('Product List Viewed', {
+              category: 'Games', products: [
+                {
+                  product_id: '507f1f77bcf86cd799439011',
+                  sku: '45790-32',
+                  name: 'Monopoly: 3rd Edition',
+                  price: 19,
+                  position: 1,
+                  category: 'Games',
+                  url: 'https://www.example.com/product/path',
+                  image_url: 'https://www.example.com/product/path.jpg'
+                },
+                {
+                  product_id: '505bd76785ebb509fc183733',
+                  sku: '46493-32',
+                  name: 'Uno Card Game',
+                  price: 3,
+                  position: 2,
+                  category: 'Games'
+                }
+              ]
+            });
+            analytics.called(window.fbq, 'track', 'ViewContent', {
+              content_ids: ['507f1f77bcf86cd799439011', '505bd76785ebb509fc183733'],
+              content_type: 'product'
+            });
+          });
+
+          it('Should fallback on mapping content_ids to the product category and content_type to "product_group"', function() {
+            analytics.track('Product List Viewed', { category: 'Games' });
+            analytics.called(window.fbq, 'track', 'ViewContent', {
+              content_ids: ['Games'],
+              content_type: 'product_group'
+            });
           });
 
           it('should send the custom content type if set', function() {

--- a/integrations/facebook-pixel/test/index.test.js
+++ b/integrations/facebook-pixel/test/index.test.js
@@ -9,6 +9,7 @@ describe('Facebook Pixel', function() {
   var analytics;
   var facebookPixel;
   var options = {
+    automaticConfiguration: true,
     legacyEvents: {
       legacyEvent: 'asdFrkj'
     },
@@ -87,11 +88,11 @@ describe('Facebook Pixel', function() {
       });
 
       before(function() {
-        options.disableAutoConfig = true;
+        options.automaticConfiguration = false;
       });
 
       after(function() {
-        options.disableAutoConfig = false;
+        options.automaticConfiguration = true;
       });
 
       it('should call set autoConfig if option disableAutoConfig is enabled', function () {

--- a/integrations/facebook-pixel/test/index.test.js
+++ b/integrations/facebook-pixel/test/index.test.js
@@ -18,6 +18,9 @@ describe('Facebook Pixel', function() {
       'booking completed': 'Purchase',
       search: 'Search'
     },
+    contentTypes: {
+      Cars: "vehicle"
+    },
     pixelId: '123123123',
     agent: 'test',
     initWithExistingTraits: false
@@ -274,7 +277,7 @@ describe('Facebook Pixel', function() {
                   name: 'Monopoly: 3rd Edition',
                   price: 19,
                   position: 1,
-                  category: 'Games',
+                  category: 'Cars',
                   url: 'https://www.example.com/product/path',
                   image_url: 'https://www.example.com/product/path.jpg'
                 },
@@ -284,13 +287,13 @@ describe('Facebook Pixel', function() {
                   name: 'Uno Card Game',
                   price: 3,
                   position: 2,
-                  category: 'Games'
+                  category: 'Cars'
                 }
               ]
             });
             analytics.called(window.fbq, 'track', 'ViewContent', {
               content_ids: ['507f1f77bcf86cd799439011', '505bd76785ebb509fc183733'],
-              content_type: 'product'
+              content_type: ['product']
             });
           });
 
@@ -298,14 +301,13 @@ describe('Facebook Pixel', function() {
             analytics.track('Product List Viewed', { category: 'Games' });
             analytics.called(window.fbq, 'track', 'ViewContent', {
               content_ids: ['Games'],
-              content_type: 'product_group'
+              content_type: ['product_group']
             });
           });
 
-          it('should send the custom content type if set', function() {
+          it('should send the custom content type if mapped', function() {
             analytics.track('Product List Viewed', {
-              content_type: 'games',
-              category: 'Games', products: [
+              category: 'Cars', products: [
                 {
                   product_id: '507f1f77bcf86cd799439011',
                   sku: '45790-32',
@@ -328,7 +330,7 @@ describe('Facebook Pixel', function() {
             });
             analytics.called(window.fbq, 'track', 'ViewContent', {
               content_ids: ['507f1f77bcf86cd799439011', '505bd76785ebb509fc183733'],
-              content_type: 'games'
+              content_type: ['vehicle']
             });
           })
         });
@@ -346,7 +348,7 @@ describe('Facebook Pixel', function() {
           });
           analytics.called(window.fbq, 'track', 'ViewContent', {
             content_ids: ['507f1f77bcf86cd799439011'],
-            content_type: 'product',
+            content_type: ['product'],
             content_name: 'my product',
             content_category: 'cat 1',
             currency: 'USD',
@@ -368,7 +370,7 @@ describe('Facebook Pixel', function() {
           });
           analytics.called(window.fbq, 'track', 'ViewContent', {
             content_ids: ['507f1f77bcf86cd799439011'],
-            content_type: 'product',
+            content_type: ['product'],
             content_name: 'my product',
             content_category: 'cat 1',
             currency: 'USD',
@@ -376,23 +378,22 @@ describe('Facebook Pixel', function() {
           });
         });
 
-        it('should send the custom content type if set', function() {
+        it('should send the custom content type if mapped', function() {
           analytics.track('Product Viewed', {
             product_id: '507f1f77bcf86cd799439011',
             currency: 'USD',
             quantity: 1,
             price: 44.33,
             name: 'my product',
-            category: 'cat 1',
+            category: 'Cars',
             sku: 'p-298',
             value: 24.75,
-            content_type: 'music'
           });
           analytics.called(window.fbq, 'track', 'ViewContent', {
             content_ids: ['507f1f77bcf86cd799439011'],
-            content_type: 'music',
+            content_type: ['vehicle'],
             content_name: 'my product',
-            content_category: 'cat 1',
+            content_category: 'Cars',
             currency: 'USD',
             value: '24.75'
           });
@@ -411,7 +412,7 @@ describe('Facebook Pixel', function() {
           });
           analytics.called(window.fbq, 'track', 'AddToCart', {
             content_ids: ['507f1f77bcf86cd799439011'],
-            content_type: 'product',
+            content_type: ['product'],
             content_name: 'my product',
             content_category: 'cat 1',
             currency: 'USD',
@@ -433,7 +434,7 @@ describe('Facebook Pixel', function() {
           });
           analytics.called(window.fbq, 'track', 'AddToCart', {
             content_ids: ['507f1f77bcf86cd799439011'],
-            content_type: 'product',
+            content_type: ['product'],
             content_name: 'my product',
             content_category: 'cat 1',
             currency: 'USD',
@@ -441,23 +442,23 @@ describe('Facebook Pixel', function() {
           });
         });
 
-        it('should send the custom content type if set', function() {
+        it('should send the custom content type if mapped', function() {
           analytics.track('Product Added', {
             product_id: '507f1f77bcf86cd799439011',
             currency: 'USD',
             quantity: 1,
             price: 44.33,
             name: 'my product',
-            category: 'cat 1',
+            category: 'Cars',
             sku: 'p-298',
             value: 24.75,
             content_type: "stuff"
           });
           analytics.called(window.fbq, 'track', 'AddToCart', {
             content_ids: ['507f1f77bcf86cd799439011'],
-            content_type: 'stuff',
+            content_type: ['vehicle'],
             content_name: 'my product',
-            content_category: 'cat 1',
+            content_category: 'Cars',
             currency: 'USD',
             value: '24.75'
           });
@@ -474,7 +475,7 @@ describe('Facebook Pixel', function() {
           });
           analytics.called(window.fbq, 'track', 'Purchase', {
             content_ids: ['507f1f77bcf86cd799439011', '505bd76785ebb509fc183733'],
-            content_type: 'product',
+            content_type: ['product_group'],
             currency: 'USD',
             value: '0.50'
           });
@@ -492,7 +493,7 @@ describe('Facebook Pixel', function() {
           });
           analytics.called(window.fbq, 'track', 'Purchase', {
             content_ids: ['507f1f77bcf86cd799439011', '505bd76785ebb509fc183733'],
-            content_type: 'product',
+            content_type: ['product_group'],
             currency: 'USD',
             value: '0.50'
           });
@@ -502,19 +503,18 @@ describe('Facebook Pixel', function() {
           });
         });
 
-        it('should send the custom content type if set', function() {
+        it('should send the custom content type if mapped', function() {
           analytics.track('Order Completed', {
             products: [
-              { product_id: '507f1f77bcf86cd799439011' },
-              { product_id: '505bd76785ebb509fc183733' }
+              { product_id: '507f1f77bcf86cd799439011', category: 'Cars' },
+              { product_id: '505bd76785ebb509fc183733', category: 'Cars' }
             ],
             currency: 'USD',
             total: 0.50,
-            content_type: 'home_listing'
           });
           analytics.called(window.fbq, 'track', 'Purchase', {
             content_ids: ['507f1f77bcf86cd799439011', '505bd76785ebb509fc183733'],
-            content_type: 'home_listing',
+            content_type: ['vehicle'],
             currency: 'USD',
             value: '0.50'
           });

--- a/integrations/facebook-pixel/test/index.test.js
+++ b/integrations/facebook-pixel/test/index.test.js
@@ -76,14 +76,23 @@ describe('Facebook Pixel', function() {
         analytics.equal(window.fbq.disablePushState, true);
       });
 
-      it('should set allowDuplicatePageViews to true', function() {
-        analytics.initialize();
-        analytics.equal(window.fbq.allowDuplicatePageViews, true);
-      });
-
       it('should create fbq object', function() {
         analytics.initialize();
         analytics.assert(window.fbq instanceof Function);
+      });
+
+      before(function() {
+        options.disableAutoConfig = true;
+      });
+
+      after(function() {
+        options.disableAutoConfig = false;
+      });
+
+      it('should call set autoConfig if option disableAutoConfig is enabled', function () {
+        analytics.stub(window, 'fbq');
+        analytics.initialize();
+        analytics.called(window.fbq, 'set', 'autoConfig', false, options.pixelId);
       });
 
       before(function() {
@@ -249,42 +258,11 @@ describe('Facebook Pixel', function() {
       });
 
       describe('segment ecommerce => FB product audiences', function() {
-        describe('Product List Viewed', function() {
-          it('Should map content_ids parameter to product_ids and content_type to "product" if possible', function() {
-            analytics.track('Product List Viewed', {
-              category: 'Games', products: [
-                {
-                  product_id: '507f1f77bcf86cd799439011',
-                  sku: '45790-32',
-                  name: 'Monopoly: 3rd Edition',
-                  price: 19,
-                  position: 1,
-                  category: 'Games',
-                  url: 'https://www.example.com/product/path',
-                  image_url: 'https://www.example.com/product/path.jpg'
-                },
-                {
-                  product_id: '505bd76785ebb509fc183733',
-                  sku: '46493-32',
-                  name: 'Uno Card Game',
-                  price: 3,
-                  position: 2,
-                  category: 'Games'
-                }
-              ]
-            });
-            analytics.called(window.fbq, 'track', 'ViewContent', {
-              content_ids: ['507f1f77bcf86cd799439011', '505bd76785ebb509fc183733'],
-              content_type: 'product'
-            });
-          });
-
-          it('Should fallback on mapping content_ids to the product category and content_type to "product_group"', function() {
-            analytics.track('Product List Viewed', { category: 'Games' });
-            analytics.called(window.fbq, 'track', 'ViewContent', {
-              content_ids: ['Games'],
-              content_type: 'product_group'
-            });
+        it('Product List Viewed', function() {
+          analytics.track('Product List Viewed', { category: 'Games' });
+          analytics.called(window.fbq, 'track', 'ViewContent', {
+            content_ids: ['Games'],
+            content_type: 'product_group'
           });
 
           it('should send the custom content type if set', function() {


### PR DESCRIPTION
**What does this PR do?**
- Adds a setting to disable [Automatic Configuration](https://developers.facebook.com/docs/facebook-pixel/api-reference#automatic-configuration).
- Adds a mapping for Content Types ([FB Pixel Settings](https://app.segment.com/partner-portal/integration/facebook-pixel/settings)). For backwards compatibility we are falling back to `product` and `product_group`.

**Are there breaking changes in this PR?**
Negative.

**Has this been tested end-to-end? Please provide screenshots on how the fix now populates in the end tool. If not, what was done to test?**
TODO in staging.

Local `automaticConfiguration` testing was verified in dev tools.

Local testing where a custom content type is passed to FB:
<img width="296" alt="screen shot 2018-09-12 at 7 10 37 pm" src="https://user-images.githubusercontent.com/11635476/45463075-90d9c600-b6bf-11e8-8d35-41e913b0afac.png">
The category "Games" was mapped to "vehicles" in this example.

**Does this require a metadata change? If so, please link the PR from https://github.com/segmentio/destination-scripts.**
Two new [settings](https://app.segment.com/partner-portal/integration/facebook-pixel/settings) were added, but migrations weren't needed.

**What are the relevant tickets?**
[PLATFORM-2538](https://segment.atlassian.net/browse/PLATFORM-2538)
[PLATFORM-2310](https://segment.atlassian.net/browse/PLATFORM-2310)

**Link to CC ticket**
https://segment.atlassian.net/browse/CC-1573

**List all the tests accounts you have used to make sure this change works**
Personal FB Pixel account

**Helpful Docs**
https://paper.dropbox.com/folder/show/Facebook-Pixel-e.1gg8YzoPEhbTkrhvQwJ2zz409feT37UwVJoNokfnCOndQwCZywN3
