### PR TITLE
Add integration amplitude

### DIFF
--- a/integrations/amplitude/HISTORY.md
+++ b/integrations/amplitude/HISTORY.md
@@ -1,0 +1,146 @@
+2.8.0 / 2018-04-04
+==================
+
+  * Update SDK version to 4.1.1
+
+2.7.0 / 2018-02-12
+==================
+
+  * anonymousID-as-deviceID + group{Type, Value}Trait support (#38)
+
+2.6.0 / 2017-09-18
+==================
+
+  * Update Amplitude to 3.7.0
+
+2.5.0 / 2017-08-30
+==================
+
+  * Improve revenue tracking from Order Completed events.
+
+2.4.0 / 2017-05-17
+==================
+
+  * Patch potential duplicate track event issue when using Groups functionality.
+
+2.4.0 / 2017-05-17
+==================
+
+  * Add support for Amplitude's `group` functionality to both identify and track events
+
+2.3.0 / 2017-04-11
+==================
+
+  * Allow mapping query params from context.page.search to a custom user/event property
+
+2.2.0 / 2016-11-15
+==================
+
+  * Update Amplitude v3.4.0 with support for forceHttps, trackGclid, saveParamsReferrerOncePerSession, deviceIdFromUrlParam options.
+
+2.1.1 / 2016-08-08
+==================
+
+  * Only send revenue event if revenue is being tracked
+
+2.1.0 / 2016-07-21
+==================
+
+  * update amplitude v3.0.2 with support for logrevenueV2 option
+  * Update Karma to 1.1.0
+
+2.0.0 / 2016-06-21
+==================
+
+  * Remove Duo compatibility
+  * Add CI setup (coverage, linting, cross-browser compatibility, etc.)
+  * Update eslint configuration
+
+1.0.16 / 2016-05-07
+==================
+
+  * Bump Analytics.js core, tester, integration to use Facade 2.x
+
+1.0.15 / 2016-05-02
+===================
+
+  * correctly set options
+
+1.0.14 / 2016-03-16
+===================
+
+  * Update Amplitude v2.9.1
+  * Fix bug where saveReferrer throws exception if sessionStorage is disabled.
+  * Log messages with a try/catch to support IE 8.
+  * Validate event properties during logEvent and initialization before sending request.
+  * Add instructions for proper integration with RequireJS.
+
+1.0.13 / 2016-02-11
+===================
+
+  * Updating Amplitude SDK v2.9.0
+
+1.0.12 / 2016-01-11
+===================
+
+  * Merge pull request #11 from amplitude/fix-runqueuedfunctions
+  * Only runQueuedFunctions after SDK loads
+1.0.11 / 2015-12-04
+===================
+
+  * updating Amplitude SDK v2.7.0
+
+1.0.10 / 2015-11-07
+===================
+
+  * updating Amplitude SDK v2.6.1
+
+1.0.9 / 2015-11-03
+==================
+
+  * updating amplitude SDK v2.6.0
+
+1.0.8 / 2015-10-21
+==================
+
+  * updating Amplitude SDK to v2.5.0
+
+1.0.7 / 2015-09-23
+==================
+
+  * Update Amplitude javascript sdk to v2.4.1
+
+1.0.6 / 2015-09-23
+==================
+
+  * Update Amplitude javascript sdk to v2.3.0
+
+1.0.5 / 2015-08-26
+==================
+
+  * Update Amplitude version to 2.2.1
+
+1.0.4 / 2015-06-30
+==================
+
+  * Replace analytics.js dependency with analytics.js-core
+
+1.0.3 / 2015-06-30
+==================
+
+  * Replace analytics.js dependency with analytics.js-core
+
+1.0.2 / 2015-06-24
+==================
+
+  * Bump analytics.js-integration version
+
+1.0.1 / 2015-06-24
+==================
+
+  * Bump analytics.js-integration version
+
+1.0.0 / 2015-06-09
+==================
+
+  * Initial commit :sparkles:

--- a/integrations/amplitude/README.md
+++ b/integrations/amplitude/README.md
@@ -1,0 +1,12 @@
+# analytics.js-integration-amplitude [![Build Status][ci-badge]][ci-link]
+
+Amplitude integration for [Analytics.js][].
+
+## License
+
+Released under the [MIT license](LICENSE).
+
+
+[Analytics.js]: https://segment.com/docs/libraries/analytics.js/
+[ci-link]: https://circleci.com/gh/segment-integrations/analytics.js-integration-amplitude
+[ci-badge]: https://circleci.com/gh/segment-integrations/analytics.js-integration-amplitude.svg?style=svg

--- a/integrations/amplitude/lib/index.js
+++ b/integrations/amplitude/lib/index.js
@@ -1,0 +1,368 @@
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+
+var bind = require('component-bind');
+var integration = require('@segment/analytics.js-integration');
+var topDomain = require('@segment/top-domain');
+var when = require('do-when');
+var is = require('is');
+var each = require('@ndhoule/each');
+var Track = require('segmentio-facade').Track;
+
+/**
+ * UMD?
+ */
+
+var umd = typeof window.define === 'function' && window.define.amd;
+
+/**
+ * Source.
+ */
+
+var src = '//d24n15hnbwhuhn.cloudfront.net/libs/amplitude-4.1.1-min.gz.js';
+
+/**
+ * Expose `Amplitude` integration.
+ */
+
+var Amplitude = module.exports = integration('Amplitude')
+  .global('amplitude')
+  .option('apiKey', '')
+  .option('trackAllPages', false)
+  .option('trackNamedPages', true)
+  .option('trackCategorizedPages', true)
+  .option('trackUtmProperties', true)
+  .option('trackReferrer', false)
+  .option('batchEvents', false)
+  .option('eventUploadThreshold', 30)
+  .option('eventUploadPeriodMillis', 30000)
+  .option('useLogRevenueV2', false)
+  .option('forceHttps', false)
+  .option('trackGclid', false)
+  .option('saveParamsReferrerOncePerSession', true)
+  .option('deviceIdFromUrlParam', false)
+  .option('mapQueryParams', {})
+  .option('trackRevenuePerProduct', false)
+  .option('preferAnonymousIdForDeviceId', false)
+  .tag('<script src="' + src + '">');
+
+/**
+ * Initialize.
+ *
+ * https://github.com/amplitude/Amplitude-Javascript
+ *
+ * @api public
+ */
+
+Amplitude.prototype.initialize = function() {
+  /* eslint-disable */
+  (function(e,t){var n=e.amplitude||{_q:[],_iq:{}};function r(e,t){e.prototype[t]=function(){this._q.push([t].concat(Array.prototype.slice.call(arguments,0)));return this}}var i=function(){this._q=[];return this};var s=["add","append","clearAll","prepend","set","setOnce","unset"];for(var o=0;o<s.length;o++){r(i,s[o])}n.Identify=i;var a=function(){this._q=[];return this};var u=["setProductId","setQuantity","setPrice","setRevenueType","setEventProperties"];for(var c=0;c<u.length;c++){r(a,u[c])}n.Revenue=a;var l=["init","logEvent","logRevenue","setUserId","setUserProperties","setOptOut","setVersionName","setDomain","setDeviceId","setGlobalUserProperties","identify","clearUserProperties","setGroup","logRevenueV2","regenerateDeviceId","logEventWithTimestamp","logEventWithGroups","setSessionId"];function p(e){function t(t){e[t]=function(){e._q.push([t].concat(Array.prototype.slice.call(arguments,0)))}}for(var n=0;n<l.length;n++){t(l[n])}}p(n);n.getInstance=function(e){e=(!e||e.length===0?"$default_instance":e).toLowerCase();if(!n._iq.hasOwnProperty(e)){n._iq[e]={_q:[]};p(n._iq[e])}return n._iq[e]};e.amplitude=n})(window,document);
+  /* eslint-enable */
+
+  this.setDomain(window.location.href);
+  window.amplitude.init(this.options.apiKey, null, {
+    includeUtm: this.options.trackUtmProperties,
+    includeReferrer: this.options.trackReferrer,
+    batchEvents: this.options.batchEvents,
+    eventUploadThreshold: this.options.eventUploadThreshold,
+    eventUploadPeriodMillis: this.options.eventUploadPeriodMillis,
+    forceHttps: this.options.forceHttps,
+    includeGclid: this.options.trackGclid,
+    saveParamsReferrerOncePerSession: this.options.saveParamsReferrerOncePerSession,
+    deviceIdFromUrlParam: this.options.deviceIdFromUrlParam
+  });
+
+  var loaded = bind(this, this.loaded);
+  var ready = this.ready;
+  // FIXME (wcjohnson11): Refactor the load method to include this logic
+  // to better support if UMD present
+  if (umd) {
+    window.require([src], function(amplitude) {
+      window.amplitude = amplitude;
+      when(loaded, function() {
+        window.amplitude.runQueuedFunctions();
+        ready();
+      });
+    });
+    return;
+  }
+
+  this.load(function() {
+    when(loaded, function() {
+      window.amplitude.runQueuedFunctions();
+      ready();
+    });
+  });
+};
+
+/**
+ * Loaded?
+ *
+ * @api private
+ * @return {boolean}
+ */
+
+Amplitude.prototype.loaded = function() {
+  return !!(window.amplitude && window.amplitude.options);
+};
+
+/**
+ * Page.
+ *
+ * @api public
+ * @param {Page} page
+ */
+
+Amplitude.prototype.page = function(page) {
+  this.setDeviceIdFromAnonymousId(page);
+
+  var category = page.category();
+  var name = page.fullName();
+  var opts = this.options;
+
+  // all pages
+  if (opts.trackAllPages) {
+    this.track(page.track());
+  }
+
+  // categorized pages
+  if (category && opts.trackCategorizedPages) {
+    this.track(page.track(category));
+  }
+
+  // named pages
+  if (name && opts.trackNamedPages) {
+    this.track(page.track(name));
+  }
+};
+
+/**
+ * Identify.
+ *
+ * @api public
+ * @param {Facade} identify
+ */
+
+Amplitude.prototype.identify = function(identify) {
+  this.setDeviceIdFromAnonymousId(identify);
+
+  var id = identify.userId();
+  var traits = identify.traits();
+  if (id) window.amplitude.setUserId(id);
+  if (traits) {
+    // map query params from context url if opted in
+    var mapQueryParams = this.options.mapQueryParams;
+    var query = identify.proxy('context.page.search');
+    if (!is.empty(mapQueryParams)) {
+      // since we accept any arbitrary property name and we dont have conditional UI components
+      // in the app where we can limit users to only add a single mapping, so excuse the temporary jank
+      each(function(value, key) {
+        traits[key] = query;
+      }, mapQueryParams);
+    }
+
+    window.amplitude.setUserProperties(traits);
+  }
+
+  // Set user groups: https://amplitude.zendesk.com/hc/en-us/articles/115001361248#setting-user-groups
+  var groups = identify.options(this.name).groups;
+  if (groups && is.object(groups)) {
+    for (var group in groups) {
+      if (groups.hasOwnProperty(group)) window.amplitude.setGroup(group, groups[group]);
+    }
+  }
+};
+
+/**
+ * Track.
+ *
+ * @api public
+ * @param {Track} event
+ */
+
+Amplitude.prototype.track = logEvent;
+
+function logEvent(track, dontSetRevenue) {
+  this.setDeviceIdFromAnonymousId(track);
+
+  var props = track.properties();
+  var options = track.options(this.name);
+  var event = track.event();
+  // map query params from context url if opted in
+  var mapQueryParams = this.options.mapQueryParams;
+  var query = track.proxy('context.page.search');
+  if (!is.empty(mapQueryParams)) {
+    var params = {};
+    var type;
+      // since we accept any arbitrary property name and we dont have conditional UI components
+      // in the app where we can limit users to only add a single mapping, so excuse the temporary jank
+    each(function(value, key) {
+      // add query params to either `user_properties` or `event_properties`
+      type = value;
+      type === 'user_properties' ? params[key] = query : props[key] = query;
+    }, mapQueryParams);
+
+    if (type === 'user_properties') window.amplitude.setUserProperties(params);
+  }
+
+  // track the event
+  if (options.groups) {
+    window.amplitude.logEventWithGroups(event, props, options.groups);
+  } else {
+    window.amplitude.logEvent(event, props);
+  }
+
+  // Ideally, user's will track revenue using an Order Completed event.
+  // However, we have previously setRevenue for any event given it had a revenue property.
+  // We need to keep this behavior around for backwards compatibility.
+  if (track.revenue() && !dontSetRevenue) this.setRevenue(mapRevenueAttributes(track));
+}
+
+Amplitude.prototype.orderCompleted = function(track) {
+  this.setDeviceIdFromAnonymousId(track);
+
+  var products = track.products();
+  var clonedTrack = track.json();
+  var trackRevenuePerProduct = this.options.trackRevenuePerProduct;
+  // If there is no products Array, we can just treat this like we always have.
+  if (!products || !Array.isArray(products)) return logEvent.call(this, track);
+
+  // Amplitude does not allow arrays of objects to as properties of events.
+  // Our Order Completed event however uses a products array for product level tracking.
+  // We need to remove this before logging the event and then use it to track revenue.
+  delete clonedTrack.properties.products;
+
+  // There are two ways to track revenue with Amplitude:
+  // 1) Log a single Revenue event for all products in the order.
+  // 2) Log a Revenue event for each product in the order.
+  // If the user has chosen the second option, we pass a dontSetRevenue flag to logEvent.
+  logEvent.call(this, new Track(clonedTrack), trackRevenuePerProduct);
+
+  // Loop through products array.
+  each(function(product) {
+    var price = product.price;
+    var quantity = product.quantity;
+    clonedTrack.properties = product;
+    clonedTrack.event = 'Product Purchased';
+    // Price and quantity are both required by Amplitude:
+    // https://amplitude.zendesk.com/hc/en-us/articles/115001361248#tracking-revenue
+    // Price could potentially be 0 so handle that edge case.
+    if (trackRevenuePerProduct && price != null && quantity) this.setRevenue(mapRevenueAttributes(new Track(clonedTrack)));
+    logEvent.call(this, new Track(clonedTrack), trackRevenuePerProduct);
+  }.bind(this), products);
+};
+
+
+/**
+ * Group.
+ *
+ * @api public
+ * @param {Group} group
+ */
+
+Amplitude.prototype.group = function(group) {
+  this.setDeviceIdFromAnonymousId(group);
+
+  var groupType = group.traits()[this.options.groupTypeTrait];
+  var groupValue = group.traits()[this.options.groupValueTrait];
+  if (groupType && groupValue) {
+    window.amplitude.setGroup(groupType, groupValue);
+  } else {
+    var groupId = group.groupId();
+    if (groupId) {
+      window.amplitude.setGroup('[Segment] Group', groupId);
+    }
+  }
+};
+
+/**
+ * Set domain name to root domain in Amplitude.
+ *
+ * @api private
+ * @param {string} href
+ */
+
+Amplitude.prototype.setDomain = function(href) {
+  var domain = topDomain(href);
+  window.amplitude.setDomain(domain);
+};
+
+/**
+ * If enabled by settings, set the device ID from the Segment anonymous ID.
+ *
+ * This logic cannot be performed at initialization time, because customers may
+ * want to modify anonymous IDs between initializing Segment and sending their
+ * first event.
+ *
+ * @api private
+ * @param {Fadade} facade to get anonymousId from.
+ */
+Amplitude.prototype.setDeviceIdFromAnonymousId = function(facade) {
+  if (this.options.preferAnonymousIdForDeviceId) {
+    this.setDeviceId(facade.anonymousId());
+  }
+};
+
+/**
+ * Override device ID in Amplitude.
+ *
+ * @api private
+ * @param {string} deviceId
+ */
+
+Amplitude.prototype.setDeviceId = function(deviceId) {
+  if (deviceId) window.amplitude.setDeviceId(deviceId);
+};
+
+Amplitude.prototype.setRevenue = function(properties) {
+  var price = properties.price;
+  var productId = properties.productId;
+  var revenueType = properties.revenueType;
+  var quantity = properties.quantity;
+  var eventProps = properties.eventProps;
+  var revenue = properties.revenue;
+
+  if (this.options.useLogRevenueV2) {
+    // This is to support backwards compatibility with a legacy revenue tracking strategy.
+    // Using a properly formatted Order Completed event is the recommended strategy now.
+    // If it is properly formatted, this voodoo will not happen.
+    if (!price) {
+      price = revenue;
+      quantity = 1;
+    }
+
+    var ampRevenue = new window.amplitude.Revenue()
+    .setPrice(price)
+    .setQuantity(quantity)
+    .setEventProperties(eventProps);
+
+    if (revenueType) ampRevenue.setRevenueType(revenueType);
+
+    if (productId) ampRevenue.setProductId(productId);
+
+    window.amplitude.logRevenueV2(ampRevenue);
+  } else {
+    window.amplitude.logRevenue(revenue || price * quantity, quantity, productId);
+  }
+};
+
+function mapRevenueAttributes(track) {
+  // Revenue type can be anything such as Refund, Tax, etc.
+  // Using mapper here to support future ecomm event => revenue mappings (Order Refund, etc.)
+  var mapRevenueType = {
+    'order completed': 'Purchase',
+    'product purchased': 'Purchase'
+  };
+
+  return {
+    price: track.price(),
+    productId: track.productId(),
+    revenueType: track.proxy('properties.revenueType') || mapRevenueType[track.event().toLowerCase()],
+    quantity: track.quantity(),
+    eventProps: track.properties(),
+    revenue: track.revenue()
+  };
+}

--- a/integrations/amplitude/package.json
+++ b/integrations/amplitude/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@segment/analytics.js-integration-amplitude",
+  "description": "The Amplitude analytics.js integration.",
+  "version": "2.8.0",
+  "keywords": [
+    "analytics.js",
+    "analytics.js-integration",
+    "segment",
+    "amplitude"
+  ],
+  "main": "lib/index.js",
+  "scripts": {
+    "test": "make test"
+  },
+  "author": "Segment \u003cfriends@segment.com\u003e",
+  "license": "SEE LICENSE IN LICENSE",
+  "homepage": "https://github.com/segmentio/analytics.js-integrations/blob/master/integrations/amplitude#readme",
+  "bugs": {
+    "url": "https://github.com/segmentio/analytics.js-integrations/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/segmentio/analytics.js-integrations.git"
+  },
+  "dependencies": {
+    "@ndhoule/each": "^2.0.1",
+    "@segment/analytics.js-integration": "^2.1.0",
+    "@segment/top-domain": "^3.0.0",
+    "component-bind": "^1.0.0",
+    "do-when": "^1.0.0",
+    "is": "^3.2.1",
+    "segmentio-facade": "^3.2.1"
+  },
+  "devDependencies": {
+    "@segment/analytics.js-core": "^3.0.0",
+    "@segment/analytics.js-integration-tester": "^3.1.0",
+    "@segment/clear-env": "^2.0.0",
+    "@segment/eslint-config": "^3.1.1",
+    "browserify": "^13.0.0",
+    "browserify-istanbul": "^2.0.0",
+    "eslint": "^2.9.0",
+    "eslint-plugin-mocha": "^2.2.0",
+    "eslint-plugin-require-path-exists": "^1.1.5",
+    "istanbul": "^0.4.3",
+    "karma": "1.3.0",
+    "karma-browserify": "^5.0.4",
+    "karma-chrome-launcher": "^1.0.1",
+    "karma-coverage": "^1.0.0",
+    "karma-junit-reporter": "^1.0.0",
+    "karma-mocha": "1.0.1",
+    "karma-phantomjs-launcher": "^1.0.0",
+    "karma-sauce-launcher": "^1.0.0",
+    "karma-spec-reporter": "0.0.26",
+    "mocha": "^2.2.5",
+    "npm-check": "^5.2.1",
+    "phantomjs-prebuilt": "^2.1.7",
+    "sinon": "^3.2.1",
+    "watchify": "^3.7.0"
+  }
+}

--- a/integrations/amplitude/test/.eslintrc
+++ b/integrations/amplitude/test/.eslintrc
@@ -1,0 +1,3 @@
+{
+  "extends": "@segment/eslint-config/mocha"
+}

--- a/integrations/amplitude/test/index.test.js
+++ b/integrations/amplitude/test/index.test.js
@@ -1,0 +1,480 @@
+'use strict';
+
+var Analytics = require('@segment/analytics.js-core').constructor;
+var integration = require('@segment/analytics.js-integration');
+var sandbox = require('@segment/clear-env');
+var tester = require('@segment/analytics.js-integration-tester');
+var Amplitude = require('../lib/');
+var sinon = require('sinon');
+
+describe('Amplitude', function() {
+  var amplitude;
+  var analytics;
+  var options = {
+    apiKey: '07808866adb2510adf19ee69e8fc2201',
+    trackUtmProperties: true,
+    trackReferrer: false,
+    batchEvents: false,
+    eventUploadThreshold: 30,
+    eventUploadPeriodMillis: 30000,
+    forceHttps: false,
+    trackGclid: false,
+    saveParamsReferrerOncePerSession: true,
+    deviceIdFromUrlParam: false,
+    trackRevenuePerProduct: false,
+    mapQueryParams: {}
+  };
+
+  beforeEach(function() {
+    analytics = new Analytics();
+    amplitude = new Amplitude(options);
+    analytics.use(Amplitude);
+    analytics.use(tester);
+    analytics.add(amplitude);
+  });
+
+  afterEach(function() {
+    analytics.restore();
+    analytics.reset();
+    amplitude.reset();
+    sandbox();
+  });
+
+  it('should have the right settings', function() {
+    analytics.compare(Amplitude, integration('Amplitude')
+      .global('amplitude')
+      .option('apiKey', '')
+      .option('trackAllPages', false)
+      .option('trackUtmProperties', true)
+      .option('trackNamedPages', true)
+      .option('trackReferrer', false)
+      .option('batchEvents', false)
+      .option('eventUploadThreshold', 30)
+      .option('eventUploadPeriodMillis', 30000)
+      .option('forceHttps', false)
+      .option('trackGclid', false)
+      .option('saveParamsReferrerOncePerSession', true)
+      .option('trackRevenuePerProduct', false)
+      .option('deviceIdFromUrlParam', false));
+  });
+
+  describe('before loading', function() {
+    beforeEach(function() {
+      analytics.stub(amplitude, 'load');
+    });
+
+    afterEach(function() {
+      amplitude.reset();
+    });
+
+    describe('#initialize', function() {
+      it('should create window.amplitude', function() {
+        analytics.assert(!window.amplitude);
+        analytics.initialize();
+        analytics.page();
+        analytics.assert(window.amplitude);
+      });
+
+      it('should call load', function() {
+        amplitude.initialize();
+        analytics.called(amplitude.load);
+      });
+    });
+  });
+
+  describe('loading', function() {
+    it('should load', function(done) {
+      analytics.load(amplitude, done);
+    });
+  });
+
+  describe('after loading', function() {
+    beforeEach(function(done) {
+      analytics.once('ready', done);
+      analytics.initialize();
+      analytics.page();
+    });
+
+    it('should init with right options', function() {
+      analytics.assert(window.amplitude.options.includeUtm === options.trackUtmProperties);
+      analytics.assert(window.amplitude.options.includeReferrer === options.trackReferrer);
+      analytics.assert(window.amplitude.options.batchEvents === options.batchEvents);
+      analytics.assert(window.amplitude.options.eventUploadThreshold === options.eventUploadThreshold);
+      analytics.assert(window.amplitude.options.eventUploadPeriodMillis === options.eventUploadPeriodMillis);
+      analytics.assert(window.amplitude.options.forceHttps === options.forceHttps);
+      analytics.assert(window.amplitude.options.includeGclid === options.trackGclid);
+      analytics.assert(window.amplitude.options.saveParamsReferrerOncePerSession === options.saveParamsReferrerOncePerSession);
+      analytics.assert(window.amplitude.options.deviceIdFromUrlParam === options.deviceIdFromUrlParam);
+    });
+
+    it('should set api key', function() {
+      analytics.assert(window.amplitude.options.apiKey === options.apiKey);
+    });
+
+    describe('#setDomain', function() {
+      it('should set domain', function() {
+        analytics.spy(amplitude, 'setDomain');
+        analytics.initialize();
+        analytics.page();
+        analytics.called(amplitude.setDomain, window.location.href);
+      });
+    });
+
+    describe('#setDeviceId', function() {
+      it('should call window.amplitude.setDeviceId', function() {
+        analytics.spy(window.amplitude, 'setDeviceId');
+        amplitude.setDeviceId('deviceId');
+        analytics.called(window.amplitude.setDeviceId, 'deviceId');
+      });
+    });
+
+    describe('#_initUtmData', function() {
+      it('should initialize utm properties', function() {
+        amplitude.options.trackUtmProperties = true;
+        analytics.once('ready', function() {
+          analytics.spy(window.amplitude, '_initUtmData');
+          analytics.called(window.amplitude._initUtmData);
+        });
+      });
+
+      it('should not track utm properties if disabled', function() {
+        analytics.spy(window.amplitude, '_initUtmData');
+        analytics.didNotCall(window.amplitude._initUtmData);
+      });
+    });
+
+    describe('#page', function() {
+      beforeEach(function() {
+        analytics.stub(window.amplitude, 'logEvent');
+        analytics.stub(window.amplitude, 'setUserProperties');
+        analytics.stub(window.amplitude, 'setDeviceId');
+      });
+
+      it('should not track unnamed pages by default', function() {
+        analytics.page();
+        analytics.didNotCall(window.amplitude.logEvent);
+      });
+
+      it('should track unnamed pages if enabled', function() {
+        amplitude.options.trackAllPages = true;
+        analytics.page();
+        analytics.called(window.amplitude.logEvent, 'Loaded a Page');
+      });
+
+      it('should track named pages by default', function() {
+        analytics.page('Name');
+        analytics.called(window.amplitude.logEvent, 'Viewed Name Page');
+      });
+
+      it('should track named pages with a category added', function() {
+        analytics.page('Category', 'Name');
+        analytics.called(window.amplitude.logEvent, 'Viewed Category Name Page');
+      });
+
+      it('should track categorized pages by default', function() {
+        analytics.page('Category', 'Name');
+        analytics.called(window.amplitude.logEvent, 'Viewed Category Page');
+      });
+
+      it('should not track name or categorized pages if disabled', function() {
+        amplitude.options.trackNamedPages = false;
+        amplitude.options.trackCategorizedPages = false;
+        analytics.page('Category', 'Name');
+        analytics.didNotCall(window.amplitude.logEvent);
+      });
+
+      it('should map query params to custom property as user properties', function() {
+        amplitude.options.trackAllPages = true;
+        amplitude.options.mapQueryParams = { customProp: 'user_properties' };
+        analytics.page({}, { page: { search: '?suh=dude' } });
+        analytics.called(window.amplitude.setUserProperties, { customProp: '?suh=dude' });
+      });
+
+      it('should map query params to custom property as event properties', function() {
+        amplitude.options.trackAllPages = true;
+        amplitude.options.mapQueryParams = { params: 'event_properties' };
+        analytics.page({ referrer: document.referrer }, { page: { search: '?suh=dude' } });
+        analytics.called(window.amplitude.logEvent, 'Loaded a Page', {
+          params: '?suh=dude',
+          path: '/context.html',
+          referrer: document.referrer,
+          search: '', // in practice this would also be set to the query param but limitation of test prevents this from being set
+          title: '',
+          url: 'http://localhost:9876/context.html'
+        });
+      });
+
+      it('should set deviceId if `preferAnonymousIdForDeviceId` is set', function() {
+        analytics.user().anonymousId('example');
+        amplitude.options.preferAnonymousIdForDeviceId = false;
+        analytics.identify('id');
+        analytics.didNotCall(window.amplitude.setDeviceId);
+
+        amplitude.options.preferAnonymousIdForDeviceId = true;
+        analytics.identify('id');
+        analytics.called(window.amplitude.setDeviceId, 'example');
+      });
+    });
+
+    describe('#identify', function() {
+      beforeEach(function() {
+        analytics.stub(window.amplitude, 'setUserId');
+        analytics.stub(window.amplitude, 'setUserProperties');
+        analytics.stub(window.amplitude, 'setGroup');
+        analytics.stub(window.amplitude, 'setDeviceId');
+      });
+
+      it('should send an id', function() {
+        analytics.identify('id');
+        analytics.called(window.amplitude.setUserId, 'id');
+      });
+
+      it('should send traits', function() {
+        analytics.identify({ trait: true });
+        analytics.called(window.amplitude.setUserProperties, { trait: true });
+      });
+
+      it('should send an id and traits', function() {
+        analytics.identify('id', { trait: true });
+        analytics.called(window.amplitude.setUserId, 'id');
+        analytics.called(window.amplitude.setUserProperties, { id: 'id', trait: true });
+      });
+
+      it('should send query params under custom trait if set', function() {
+        amplitude.options.mapQueryParams = { ham: 'user_properties' };
+        analytics.identify('id', { trait: true }, { page: { search: '?foo=bar' } });
+        analytics.called(window.amplitude.setUserId, 'id');
+        analytics.called(window.amplitude.setUserProperties, { id: 'id', trait: true, ham: '?foo=bar' });
+      });
+
+      it('should set user groups if integration option `groups` is present', function() {
+        analytics.identify('id', {}, { integrations: { Amplitude: { groups: { foo: 'bar' } } } });
+        analytics.called(window.amplitude.setGroup, 'foo', 'bar');
+      });
+
+      it('should set deviceId if `preferAnonymousIdForDeviceId` is set', function() {
+        analytics.user().anonymousId('example');
+        amplitude.options.preferAnonymousIdForDeviceId = false;
+        analytics.identify('id');
+        analytics.didNotCall(window.amplitude.setDeviceId);
+
+        amplitude.options.preferAnonymousIdForDeviceId = true;
+        analytics.identify('id');
+        analytics.called(window.amplitude.setDeviceId, 'example');
+      });
+    });
+
+    describe('#track', function() {
+      beforeEach(function() {
+        analytics.stub(window.amplitude, 'logEvent');
+        analytics.stub(window.amplitude, 'setUserProperties');
+        analytics.stub(window.amplitude, 'logRevenue');
+        analytics.stub(window.amplitude, 'logRevenueV2');
+        analytics.stub(window.amplitude, 'logEventWithGroups');
+        analytics.stub(window.amplitude, 'setDeviceId');
+      });
+
+      it('should send an event', function() {
+        analytics.track('event');
+        analytics.called(window.amplitude.logEvent, 'event');
+        analytics.didNotCall(window.amplitude.logRevenue);
+        analytics.didNotCall(window.amplitude.logRevenueV2);
+      });
+
+      it('should send an event and properties', function() {
+        analytics.track('event', { property: true });
+        analytics.called(window.amplitude.logEvent, 'event', { property: true });
+        analytics.didNotCall(window.amplitude.logRevenue);
+        analytics.didNotCall(window.amplitude.logRevenueV2);
+      });
+
+      it('should send a revenue event', function() {
+        analytics.track('event', { revenue: 19.99 });
+        analytics.called(window.amplitude.logRevenue, 19.99, 1, undefined);
+        analytics.didNotCall(window.amplitude.logRevenueV2);
+      });
+
+      it('should send a revenue event with quantity and productId', function() {
+        analytics.track('event', { revenue: 19.99, quantity: 2, productId: 'AMP1' });
+        analytics.called(window.amplitude.logRevenue, 19.99, 2, 'AMP1');
+        analytics.didNotCall(window.amplitude.logRevenueV2);
+      });
+
+      it('should send a revenueV2 event', function() {
+        amplitude.options.useLogRevenueV2 = true;
+        analytics.track('event', { revenue: 19.99 });
+        var ampRevenue = new window.amplitude.Revenue().setPrice(19.99).setEventProperties({ revenue: 19.99 });
+        analytics.didNotCall(window.amplitude.logRevenue);
+        analytics.called(window.amplitude.logRevenueV2, ampRevenue);
+      });
+
+      it('should send a revenueV2 event with quantity and productId and revenueType', function() {
+        amplitude.options.useLogRevenueV2 = true;
+        var props = { revenue: 20.00, quantity: 2, price: 10.00, productId: 'AMP1', revenueType: 'purchase' };
+        analytics.track('event', props);
+        var ampRevenue = new window.amplitude.Revenue().setPrice(10.00).setQuantity(2).setProductId('AMP1');
+        ampRevenue.setRevenueType('purchase').setEventProperties(props);
+        analytics.didNotCall(window.amplitude.logRevenue);
+        analytics.called(window.amplitude.logRevenueV2, ampRevenue);
+      });
+
+      it('should send a revenueV2 event with revenue if missing price', function() {
+        amplitude.options.useLogRevenueV2 = true;
+        analytics.track('event', { revenue: 20.00, quantity: 2, productId: 'AMP1' });
+        var ampRevenue = new window.amplitude.Revenue().setPrice(20.00).setProductId('AMP1');
+        ampRevenue.setEventProperties({ revenue: 20.00, quantity: 2, productId: 'AMP1' });
+        analytics.didNotCall(window.amplitude.logRevenue);
+        analytics.called(window.amplitude.logRevenueV2, ampRevenue);
+      });
+
+      it('should only send a revenue event if revenue is being logged', function() {
+        analytics.track('event', { price: 10.00, quantity: 2, productId: 'AMP1' });
+        analytics.called(window.amplitude.logEvent);
+        analytics.didNotCall(window.amplitude.logRevenue);
+        analytics.didNotCall(window.amplitude.logRevenueV2);
+      });
+
+      it('should only send a revenueV2 event if revenue is being logged', function() {
+        amplitude.options.useLogRevenueV2 = true;
+        analytics.track('event', { price: 10.00, quantity: 2, productId: 'AMP1' });
+        analytics.called(window.amplitude.logEvent);
+        analytics.didNotCall(window.amplitude.logRevenue);
+        analytics.didNotCall(window.amplitude.logRevenueV2);
+      });
+
+      it('should send a query params under custom prop as user properties', function() {
+        amplitude.options.mapQueryParams = { ham: 'user_properties' };
+        analytics.track('event', { foo: 'bar' }, { page: { search: '?foo=bar' } });
+        analytics.called(window.amplitude.setUserProperties, { ham: '?foo=bar' });
+      });
+
+      it('should send a query params under custom prop as user or event properties', function() {
+        amplitude.options.mapQueryParams = { ham: 'event_properties' };
+        analytics.track('event', { foo: 'bar' }, { page: { search: '?foo=bar' } });
+        analytics.called(window.amplitude.logEvent, 'event', { foo: 'bar', ham: '?foo=bar' });
+      });
+
+      it('should send an event with groups if `groups` is an integration specific option', function() {
+        analytics.track('event', { foo: 'bar' }, { integrations: { Amplitude: { groups: { sports: 'basketball' } } } });
+        analytics.called(window.amplitude.logEventWithGroups, 'event', { foo: 'bar' }, { sports: 'basketball' });
+      });
+
+      it('should set deviceId if `preferAnonymousIdForDeviceId` is set', function() {
+        analytics.user().anonymousId('example');
+        amplitude.options.preferAnonymousIdForDeviceId = false;
+        analytics.page();
+        analytics.didNotCall(window.amplitude.setDeviceId);
+
+        amplitude.options.preferAnonymousIdForDeviceId = true;
+        analytics.page();
+        analytics.called(window.amplitude.setDeviceId, 'example');
+      });
+    });
+
+    describe('#orderCompleted', function() {
+      beforeEach(function() {
+        analytics.stub(window.amplitude, 'setDeviceId');
+      });
+
+      var payload;
+      beforeEach(function() {
+        payload = {
+          checkoutId: 'fksdjfsdjfisjf9sdfjsd9f',
+          orderId: '50314b8e9bcf000000000000',
+          affiliation: 'Google Store',
+          total: 30,
+          revenue: 25,
+          shipping: 3,
+          tax: 2,
+          discount: 2.5,
+          coupon: 'hasbros',
+          currency: 'USD',
+          products: [
+            {
+              productId: '507f1f77bcf86cd799439011',
+              sku: '45790-32',
+              name: 'Monopoly: 3rd Edition',
+              price: 19,
+              quantity: 1,
+              category: 'Games'
+            },
+            {
+              productId: '505bd76785ebb509fc183733',
+              sku: '46493-32',
+              name: 'Uno Card Game',
+              price: 3,
+              quantity: 2,
+              category: 'Games'
+            }
+          ]
+        };
+      });
+
+      it('should send a logRevenueV2 event for all items in products array if trackRevenuePerProduct is true', function() {
+        var spy = sinon.spy(window.amplitude, 'logRevenueV2');
+        amplitude.options.trackRevenuePerProduct = true;
+        amplitude.options.useLogRevenueV2 = true;
+
+        analytics.track('Order Completed', payload);
+        analytics.assert(spy.calledTwice);
+      });
+
+      it('should only send a single logRevenueV2 event with the total revenue of all products if trackRevenuePerProduct is false ', function() {
+        var spy = sinon.spy(window.amplitude, 'logEvent');
+        amplitude.options.trackRevenuePerProduct = false;
+        amplitude.options.useLogRevenueV2 = true;
+
+        analytics.track('Order Completed', payload);
+        analytics.assert(spy.withArgs('Product Purchased').calledTwice);
+      });
+
+      it('should set deviceId if `preferAnonymousIdForDeviceId` is set', function() {
+        analytics.user().anonymousId('example');
+        amplitude.options.preferAnonymousIdForDeviceId = false;
+        analytics.track('Order Completed');
+        analytics.didNotCall(window.amplitude.setDeviceId);
+
+        amplitude.options.preferAnonymousIdForDeviceId = true;
+        analytics.track('Order Completed');
+        analytics.called(window.amplitude.setDeviceId, 'example');
+      });
+    });
+
+    describe('#group', function() {
+      beforeEach(function() {
+        analytics.stub(window.amplitude, 'setGroup');
+        analytics.stub(window.amplitude, 'setDeviceId');
+      });
+
+      it('should call setGroup', function() {
+        analytics.group('testGroupId');
+        analytics.called(window.amplitude.setGroup, '[Segment] Group', 'testGroupId');
+      });
+
+      it('should use `groupTypeTrait` and `groupValueTrait` when both are present', function() {
+        amplitude.options.groupTypeTrait = 'foo';
+        amplitude.options.groupValueTrait = 'bar';
+        analytics.group('testGroupId', { foo: 'asdf', bar: 'fafa' });
+        analytics.called(window.amplitude.setGroup, 'asdf', 'fafa');
+      });
+
+      it('should fall back to default behavior if either `group{Type, Value}Trait` is missing', function() {
+        amplitude.options.groupTypeTrait = 'foo';
+        amplitude.options.groupValueTrait = 'bar';
+        analytics.group('testGroupId', { notFoo: 'asdf', bar: 'fafa' });
+        analytics.called(window.amplitude.setGroup, '[Segment] Group', 'testGroupId');
+      });
+
+      it('should set deviceId if `preferAnonymousIdForDeviceId` is set', function() {
+        analytics.user().anonymousId('example');
+        amplitude.options.preferAnonymousIdForDeviceId = false;
+        analytics.group('group');
+        analytics.didNotCall(window.amplitude.setDeviceId);
+
+        amplitude.options.preferAnonymousIdForDeviceId = true;
+        analytics.group('group');
+        analytics.called(window.amplitude.setDeviceId, 'example');
+      });
+    });
+  });
+});


### PR DESCRIPTION
This commit copies the content of the integration repo into
the "integrations" folder.

Original repo: https://github.com/segment-integrations/analytics.js-integration-amplitude
Readme: https://github.com/segment-integrations/analytics.js-integration-amplitude/blob/master/README.md


**What does this PR do?**


**Are there breaking changes in this PR?**


**Has this been tested end-to-end? Please provide screenshots on how the fix now populates in the end tool. If not, what was done to test?**


**Any background context you want to provide?**


**Is there parity with the server-side/android/iOS integration (if applicable)?**


**Does this require a metadata change? If so, please link the PR from https://github.com/segmentio/destination-scripts.**


**What are the relevant tickets?**


**Link to CC ticket**


**List all the tests accounts you have used to make sure this change works**


**Helpful Docs**

