### PR TITLE
Adds Search/InitiateCheckout events

### DIFF
--- a/integrations/facebook-pixel/HISTORY.md
+++ b/integrations/facebook-pixel/HISTORY.md
@@ -1,3 +1,8 @@
+2.5.4/ 2018-09-13
+==================
+
+  * Adds Search and InitiateCheckout event support
+
 2.5.2/ 2018-09-13
 ==================
 

--- a/integrations/facebook-pixel/lib/index.js
+++ b/integrations/facebook-pixel/lib/index.js
@@ -302,6 +302,60 @@ FacebookPixel.prototype.orderCompleted = function(track) {
   }, this.legacyEvents(track.event()));
 };
 
+FacebookPixel.prototype.productsSearched = function(track) {
+  window.fbq('track', 'Search', {
+    search_string: track.proxy('properties.query')
+  });
+
+
+  // fall through for mapped legacy conversions
+  each(function(event) {
+    window.fbq('track', event, {
+      currency: track.currency(),
+      value: formatRevenue(track.revenue())
+    });
+  }, this.legacyEvents(track.event()));
+}
+
+FacebookPixel.prototype.checkoutStarted = function(track) {
+  var products = track.products() || [];
+  var contentIds = [];
+  var contents = [];
+  var contentCategory = track.category();
+
+  each(function(product) {
+    var track = new Track({ properties: product });
+    contentIds.push(track.productId() || track.id() || track.sku())
+    contents.push({
+      id: track.productId() || track.id() || track.sku(),
+      quantity: track.quantity(),
+      item_price: track.price(),
+    })
+  }, products);
+
+  // If no top-level category was defined use that of the first product. @gabriel
+  if (!contentCategory && products[0] && products[0].category) {
+    contentCategory = products[0].category
+  }
+
+  window.fbq('track', 'InitiateCheckout', {
+    content_category: contentCategory,
+    content_ids: contentIds, 
+    contents: contents,
+    currency: track.currency(),
+    num_items: contentIds.length,
+    value: formatRevenue(track.revenue())
+  });
+
+    // fall through for mapped legacy conversions
+    each(function(event) {
+      window.fbq('track', event, {
+        currency: track.currency(),
+        value: formatRevenue(track.revenue())
+      });
+    }, this.legacyEvents(track.event()));
+}
+
 /**
  * mappedContentTypesOrDefault returns an array of mapped content types for
  * the category - or returns the defaul value.

--- a/integrations/facebook-pixel/package.json
+++ b/integrations/facebook-pixel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-facebook-pixel",
   "description": "The Facebook Pixel analytics.js integration.",
-  "version": "2.5.2",
+  "version": "2.5.4",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/facebook-pixel/test/index.test.js
+++ b/integrations/facebook-pixel/test/index.test.js
@@ -519,6 +519,102 @@ describe('Facebook Pixel', function() {
             value: '0.50'
           });
         })
+
+        describe('.productsSearched()', function() {
+          it('should send pixel the search string', function() {
+            analytics.track('Products Searched', { query: 'yo' })
+            analytics.called(window.fbq, 'track', 'Search', {
+              search_string: 'yo'
+            })
+          })
+        })
+
+        describe('.checkoutStarted()', function() {
+          it('should call InitiateCheckout with the top-level category', function() {
+            analytics.track('Checkout Started', {
+              category: 'NotGames',
+              order_id: '50314b8e9bcf000000000000',
+              affiliation: 'Google Store',
+              value: 30,
+              revenue: 25,
+              shipping: 3,
+              tax: 2,
+              discount: 2.5,
+              coupon: 'hasbros',
+              currency: 'USD',
+              products: [
+                {
+                  product_id: '507f1f77bcf86cd799439011',
+                  sku: '45790-32',
+                  name: 'Monopoly: 3rd Edition',
+                  price: 19,
+                  quantity: 1,
+                  category: 'Games',
+                  url: 'https://www.example.com/product/path',
+                  image_url: 'https://www.example.com/product/path.jpg'
+                },
+                {
+                  product_id: '505bd76785ebb509fc183733',
+                  sku: '46493-32',
+                  name: 'Uno Card Game',
+                  price: 3,
+                  quantity: 2,
+                  category: 'Games'
+                }
+              ]
+            })
+            analytics.called(window.fbq, 'track', 'InitiateCheckout', {
+              content_ids: ["507f1f77bcf86cd799439011", "505bd76785ebb509fc183733"],
+              value: "25.00",
+              contents: [{ "id": "507f1f77bcf86cd799439011", "quantity": 1, "item_price": 19 }, { "id": "505bd76785ebb509fc183733", "quantity": 2, "item_price": 3 }],
+              num_items: 2,
+              currency: 'USD',
+              content_category: 'NotGames',
+            })
+          })
+
+          it('should call InitiateCheckout with the first product category', function() {
+            analytics.track('Checkout Started', {
+              order_id: '50314b8e9bcf000000000000',
+              affiliation: 'Google Store',
+              value: 30,
+              revenue: 25,
+              shipping: 3,
+              tax: 2,
+              discount: 2.5,
+              coupon: 'hasbros',
+              currency: 'USD',
+              products: [
+                {
+                  product_id: '507f1f77bcf86cd799439011',
+                  sku: '45790-32',
+                  name: 'Monopoly: 3rd Edition',
+                  price: 19,
+                  quantity: 1,
+                  category: 'Games',
+                  url: 'https://www.example.com/product/path',
+                  image_url: 'https://www.example.com/product/path.jpg'
+                },
+                {
+                  product_id: '505bd76785ebb509fc183733',
+                  sku: '46493-32',
+                  name: 'Uno Card Game',
+                  price: 3,
+                  quantity: 2,
+                  category: 'Games'
+                }
+              ]
+            })
+            analytics.called(window.fbq, 'track', 'InitiateCheckout', {
+              content_ids: ["507f1f77bcf86cd799439011", "505bd76785ebb509fc183733"],
+              value: "25.00",
+              contents: [{ "id": "507f1f77bcf86cd799439011", "quantity": 1, "item_price": 19 }, { "id": "505bd76785ebb509fc183733", "quantity": 2, "item_price": 3 }],
+              num_items: 2,
+              currency: 'USD',
+              content_category: 'Games',
+            })
+          })
+        })
       });
     });
   });


### PR DESCRIPTION
**What does this PR do?**
Adds `Search` and `InitiateCheckout` events for parity with FB Pixel + SS.

NOTE: The version jumps from 2.5.2 to 2.5.4 because master is behind a version (2.5.3 is published and used in a.js private)

**Are there breaking changes in this PR?**
No

**Has this been tested end-to-end? Please provide screenshots on how the fix now populates in the end tool. If not, what was done to test?**
Yeup.

<img width="320" alt="screen shot 2018-09-17 at 8 47 06 am" src="https://user-images.githubusercontent.com/11635476/45635731-a56ce400-ba5a-11e8-9b19-2809d1114c21.png">
<img width="287" alt="screen shot 2018-09-17 at 8 46 28 am" src="https://user-images.githubusercontent.com/11635476/45635732-a56ce400-ba5a-11e8-92e0-285c618e7c7f.png">

**Any background context you want to provide?**


**Is there parity with the server-side/android/iOS integration (if applicable)?**
SS is in the works and this adds parity to that.

**Does this require a metadata change? If so, please link the PR from https://github.com/segmentio/destination-scripts.**


**What are the relevant tickets?**

**Link to CC ticket**
https://segment.atlassian.net/browse/CC-1650

**List all the tests accounts you have used to make sure this change works**
Personal Pixel account


**Helpful Docs**

