### PR TITLE
Add integration FullStory w/ Track support

### DIFF
--- a/integrations/fullstory/HISTORY.md
+++ b/integrations/fullstory/HISTORY.md
@@ -1,0 +1,100 @@
+2.1.5 / 2018-09-27
+==================
+
+  * Add support for Track API
+  * Update snippet
+
+2.1.4 / 2018-05-01
+==================
+
+  * Bump version in package.json to 2.1.4
+
+2.1.3 / 2018-05-01
+==================
+
+  * Remove redundant addition of fs.js
+  * Update recording snippet
+  * Bump a.js-int-tester version to ^3.1.0 (#7)
+  * Pin karma, karma-mocha dev dependencies
+
+2.1.2 / 2017-01-24
+==================
+
+  * Fix error when null is passed as a trait value
+
+2.1.1 / 2017-01-03
+==================
+
+  * Remove option to override default namespace
+
+2.1.0 / 2017-01-03
+==================
+
+  * Modernize FullStory's snippet
+  * Ignore objects or arrays in traits
+
+2.0.0 / 2016-06-21
+==================
+
+  * Remove Duo compatibility
+  * Add CI setup (coverage, linting, cross-browser compatibility, etc.)
+  * Update eslint configuration
+
+1.0.9 / 2016-05-07
+==================
+
+  * Bump Analytics.js core, tester, integration to use Facade 2.x
+
+1.0.8 / 2016-02-18
+==================
+
+  * allow objects and arrays to pass through
+
+1.0.7 / 2015-12-15
+==================
+
+  * Correction to handling of anonymous identifiers.
+
+1.0.6 / 2015-12-15
+==================
+
+  * Merge pull request #4 from fullstorydev/fka3/anonid
+  * Merge branch 'fka3/anonid' of https://github.com/fullstorydev/segment-integration-fullstory into fka3/anonid
+  * style nit
+  * Test fixes after find a bad node version
+  * Okay, that works now.  Had a stale node
+  * Correction to handling of anonymous identifiers.
+  * Review naming nit
+  * Probably need to stub this too...
+  * Correction to handling of anonymous identifiers.
+  * Correction to handling of anonymous identifiers.
+
+1.0.5 / 2015-06-30
+==================
+
+  * Replace analytics.js dependency with analytics.js-core
+
+1.0.4 / 2015-06-30
+==================
+
+  * Replace analytics.js dependency with analytics.js-core
+
+1.0.3 / 2015-06-24
+==================
+
+  * Bump analytics.js-integration version
+
+1.0.2 / 2015-06-24
+==================
+
+  * Bump analytics.js-integration version
+
+1.0.1 / 2015-06-10
+==================
+
+  * Bump dependency versions
+
+1.0.0 / 2015-06-09
+==================
+
+  * Initial commit :sparkles:

--- a/integrations/fullstory/README.md
+++ b/integrations/fullstory/README.md
@@ -1,0 +1,12 @@
+# analytics.js-integration-fullstory [![Build Status][ci-badge]][ci-link]
+
+Fullstory integration for [Analytics.js][].
+
+## License
+
+Released under the [MIT license](LICENSE).
+
+
+[Analytics.js]: https://segment.com/docs/libraries/analytics.js/
+[ci-link]: https://circleci.com/gh/segment-integrations/analytics.js-integration-fullstory
+[ci-badge]: https://circleci.com/gh/segment-integrations/analytics.js-integration-fullstory.svg?style=svg

--- a/integrations/fullstory/lib/index.js
+++ b/integrations/fullstory/lib/index.js
@@ -1,0 +1,192 @@
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+
+var camel = require('camelcase');
+var foldl = require('@ndhoule/foldl');
+var integration = require('@segment/analytics.js-integration');
+var is = require('is');
+
+/**
+ * Expose `FullStory` integration.
+ *
+ * https://www.fullstory.com/docs/developer
+ */
+
+var FullStory = (module.exports = integration('FullStory')
+  .option('org', '')
+  .option('debug', false)
+  .option('passEvents', false)
+  .tag('<script src="https://www.fullstory.com/s/fs.js"></script>'));
+
+/**
+ * Initialize.
+ */
+
+FullStory.prototype.initialize = function() {
+  window._fs_debug = this.options.debug;
+  window._fs_host = 'www.fullstory.com';
+  window._fs_org = this.options.org;
+  window._fs_namespace = 'FS';
+
+  /* eslint-disable */
+  (function(m, n, e, t, l, o, g, y) {
+    if (e in m) {
+      if (m.console && m.console.log) {
+        m.console.log(
+          'FullStory namespace conflict. Please set window["_fs_namespace"].'
+        );
+      }
+      return;
+    }
+    g = m[e] = function(a, b) {
+      g.q ? g.q.push([a, b]) : g._api(a, b);
+    };
+    g.q = [];
+    g.identify = function(i, v) {
+      g(l, { uid: i });
+      if (v) g(l, v);
+    };
+    g.setUserVars = function(v) {
+      g(l, v);
+    };
+    g.event = function(i, v) {
+      g('event', { n: i, p: v });
+    };
+    g.shutdown = function() {
+      g('rec', !1);
+    };
+    g.restart = function() {
+      g('rec', !0);
+    };
+    g.consent = function(a) {
+      g('consent', !arguments.length || a);
+    };
+    g.identifyAccount = function(i, v) {
+      o = 'account';
+      v = v || {};
+      v.acctId = i;
+      g(o, v);
+    };
+    g.clearUserCookie = function() {};
+  })(window, document, window['_fs_namespace'], 'script', 'user');
+  /* eslint-enable */
+
+  this.load(this.ready);
+};
+
+/**
+ * Loaded?
+ *
+ * @return {Boolean}
+ */
+
+FullStory.prototype.loaded = function() {
+  return !!window.FS;
+};
+
+/**
+ * Identify.  But, use FS.setUserVars if we only have an anonymous id, keeping the
+ * user id unbound until we (hopefully) get a login page or similar and another call
+ * to identify with more useful contents.  (This because FullStory doesn't like the
+ * user id changing once set.)
+ *
+ * @param {Identify} identify
+ */
+
+FullStory.prototype.identify = function(identify) {
+  var traits = identify.traits({ name: 'displayName' });
+
+  var newTraits = foldl(
+    function(results, value, key) {
+      if (
+        value !== null &&
+        typeof value === 'object' &&
+        value.constructor !== Date
+      ) {
+        return results;
+      }
+      if (key !== 'id')
+        results[
+          key === 'displayName' || key === 'email' ? key : convert(key, value)
+        ] = value;
+      return results;
+    },
+    {},
+    traits
+  );
+  if (identify.userId()) {
+    window.FS.identify(String(identify.userId()), newTraits);
+  } else {
+    newTraits.segmentAnonymousId_str = String(identify.anonymousId());
+    window.FS.setUserVars(newTraits);
+  }
+};
+
+/**
+ * Track. Passes the events directly to FullStory via FS.event API only when the
+ * option passEvents is set to true. passEvents is set to false by default.
+ *
+ * @param {Track} track
+ */
+
+FullStory.prototype.track = function(track) {
+  if (this.options.passEvents) {
+    window.FS.event(track.event(), track.properties());
+  }
+};
+
+/**
+ * Convert to FullStory format.
+ *
+ * @param {string} trait
+ * @param {*} value
+ */
+
+function convert(key, value) {
+  // Handle already-tagged keys without changing it.  This means both that a
+  // user passing avg_spend_real *gets* avg_spend_real not avg_spend_real_real,
+  // AND that they get avg_spend_real even if the value happens to be a perfect
+  // integer.  (Or a string, although FullStory will flag that as an error.)
+  var parts = key.split('_');
+  if (parts.length > 1) {
+    // If we have an underbar, we have at least 2 parts; check the last as a tag
+    var tag = parts.pop();
+    if (
+      tag === 'str' ||
+      tag === 'int' ||
+      tag === 'date' ||
+      tag === 'real' ||
+      tag === 'bool'
+    ) {
+      return camel(parts.join('_')) + '_' + tag;
+    }
+  }
+
+  // No tag found, try to infer one from the value.
+  key = camel(key);
+  if (is.string(value)) return key + '_str';
+  if (isInt(value)) return key + '_int';
+  if (isFloat(value)) return key + '_real';
+  if (is.date(value)) return key + '_date';
+  if (is.bool(value)) return key + '_bool';
+  return key; // Bad FullStory type, but don't mess with the key so error messages name it
+}
+
+/**
+ * Check if n is a float.
+ */
+
+function isFloat(n) {
+  return Number(n) === n && n % 1 !== 0;
+}
+
+/**
+ * Check if n is an integer.
+ */
+
+function isInt(n) {
+  return Number(n) === n && n % 1 === 0;
+}

--- a/integrations/fullstory/package.json
+++ b/integrations/fullstory/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@segment/analytics.js-integration-fullstory",
+  "description": "The Fullstory analytics.js integration.",
+  "version": "2.1.5",
+  "keywords": [
+    "analytics.js",
+    "analytics.js-integration",
+    "segment",
+    "fullstory"
+  ],
+  "main": "lib/index.js",
+  "scripts": {
+    "test": "make test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/segment-integrations/analytics.js-integration-fullstory.git"
+  },
+  "author": "Segment <friends@segment.com>",
+  "license": "SEE LICENSE IN LICENSE",
+  "bugs": {
+    "url": "https://github.com/segment-integrations/analytics.js-integration-fullstory/issues"
+  },
+  "homepage": "https://github.com/segment-integrations/analytics.js-integration-fullstory#readme",
+  "dependencies": {
+    "@ndhoule/foldl": "^2.0.1",
+    "@segment/analytics.js-integration": "^2.1.0",
+    "camelcase": "^3.0.0",
+    "is": "^3.1.0"
+  },
+  "devDependencies": {
+    "@segment/analytics.js-core": "^3.0.0",
+    "@segment/analytics.js-integration-tester": "^3.1.0",
+    "@segment/clear-env": "^2.0.0",
+    "@segment/eslint-config": "^3.1.1",
+    "browserify": "^13.0.0",
+    "browserify-istanbul": "^2.0.0",
+    "eslint": "^2.9.0",
+    "eslint-plugin-mocha": "^2.2.0",
+    "eslint-plugin-require-path-exists": "^1.1.5",
+    "istanbul": "^0.4.3",
+    "karma": "1.3.0",
+    "karma-browserify": "^5.0.4",
+    "karma-chrome-launcher": "^1.0.1",
+    "karma-coverage": "^1.0.0",
+    "karma-junit-reporter": "^1.0.0",
+    "karma-mocha": "1.0.1",
+    "karma-phantomjs-launcher": "^1.0.0",
+    "karma-sauce-launcher": "^1.0.0",
+    "karma-spec-reporter": "0.0.26",
+    "mocha": "^2.2.5",
+    "npm-check": "^5.2.1",
+    "phantomjs-prebuilt": "^2.1.7",
+    "watchify": "^3.7.0"
+  }
+}

--- a/integrations/fullstory/test/.eslintrc
+++ b/integrations/fullstory/test/.eslintrc
@@ -1,0 +1,3 @@
+{
+  "extends": "@segment/eslint-config/mocha"
+}

--- a/integrations/fullstory/test/index.test.js
+++ b/integrations/fullstory/test/index.test.js
@@ -1,0 +1,212 @@
+'use strict';
+
+var Analytics = require('@segment/analytics.js-core').constructor;
+var integration = require('@segment/analytics.js-integration');
+var sandbox = require('@segment/clear-env');
+var tester = require('@segment/analytics.js-integration-tester');
+var FullStory = require('../lib/');
+
+describe('FullStory', function() {
+  var analytics;
+  var fullstory;
+  var options = {
+    org: '1JO',
+    debug: false,
+    passEvents: false
+  };
+
+  beforeEach(function() {
+    analytics = new Analytics();
+    fullstory = new FullStory(options);
+    analytics.use(FullStory);
+    analytics.use(tester);
+    analytics.add(fullstory);
+  });
+
+  afterEach(function() {
+    analytics.restore();
+    analytics.reset();
+    fullstory.reset();
+    sandbox();
+  });
+
+  it('should have the right settings', function() {
+    analytics.compare(
+      FullStory,
+      integration('FullStory')
+        .option('org', '')
+        .option('debug', false)
+    );
+  });
+
+  describe('before loading', function() {
+    beforeEach(function() {
+      analytics.stub(fullstory, 'load');
+    });
+
+    describe('#initialize', function() {
+      it('should create window.FS and window.FS.clearUserCookie', function() {
+        analytics.assert(!window.FS);
+        analytics.initialize();
+        analytics.assert(window.FS);
+        analytics.assert(window.FS.clearUserCookie);
+      });
+
+      it('should call #load', function() {
+        analytics.initialize();
+        analytics.called(fullstory.load);
+      });
+    });
+  });
+
+  describe('after loading', function() {
+    beforeEach(function(done) {
+      analytics.once('ready', done);
+      analytics.initialize();
+    });
+
+    describe('#identify', function() {
+      beforeEach(function() {
+        analytics.stub(window.FS, 'identify');
+        analytics.stub(window.FS, 'setUserVars');
+      });
+
+      it('should default to anonymousId', function() {
+        analytics.identify();
+        analytics.didNotCall(window.FS.identify);
+        analytics.called(window.FS.setUserVars);
+        var traits = window.FS.setUserVars.args[0][0];
+        analytics.assert(
+          traits && traits.hasOwnProperty('segmentAnonymousId_str'),
+          'did not set anonymous id correctly'
+        );
+      });
+
+      it('should only send strings as the id', function() {
+        analytics.identify(1);
+        analytics.called(window.FS.identify, '1');
+        analytics.didNotCall(window.FS.setUserVars);
+        var traits = window.FS.identify.args[0][0];
+        analytics.assert(
+          traits && !traits.hasOwnProperty('segmentAnonymousId_str'),
+          'did set anonymous id despite user id'
+        );
+      });
+
+      it('should send an id', function() {
+        analytics.identify('id');
+        analytics.called(window.FS.identify, 'id');
+      });
+
+      it('should camel case custom props', function() {
+        analytics.identify('id', {
+          name: 'Abc123',
+          email: 'example@pizza.com',
+          'First Name': 'Steven'
+        });
+        analytics.called(window.FS.identify, 'id', {
+          displayName: 'Abc123',
+          email: 'example@pizza.com',
+          firstName_str: 'Steven'
+        });
+      });
+
+      it('should map name and email', function() {
+        analytics.identify('id', { name: 'Test', email: 'test@test.com' });
+        analytics.called(window.FS.identify, 'id', {
+          displayName: 'Test',
+          email: 'test@test.com'
+        });
+      });
+
+      it('should map integers properly', function() {
+        // JavaScript only has Number, so 3.0 === 3 and is an "int"
+        analytics.identify('id', { name: 'Test', revenue: 7, number: 3.0 });
+        analytics.called(window.FS.identify, 'id', {
+          displayName: 'Test',
+          revenue_int: 7,
+          number_int: 3
+        });
+      });
+
+      it('should map floats properly', function() {
+        analytics.identify('id1', {
+          name: 'Example',
+          amtAbandonedInCart: 3.84
+        });
+        analytics.called(window.FS.identify, 'id1', {
+          displayName: 'Example',
+          amtAbandonedInCart_real: 3.84
+        });
+      });
+
+      it('should map dates properly', function() {
+        analytics.identify('id2', {
+          name: 'Test123',
+          signupDate: new Date('2014-03-11T13:19:23Z')
+        });
+        analytics.called(window.FS.identify, 'id2', {
+          displayName: 'Test123',
+          signupDate_date: new Date('2014-03-11T13:19:23Z')
+        });
+      });
+
+      it('should map booleans properly', function() {
+        analytics.identify('id3', { name: 'Steven', registered: true });
+        analytics.called(window.FS.identify, 'id3', {
+          displayName: 'Steven',
+          registered_bool: true
+        });
+      });
+
+      it('should skip arrays entirely', function() {
+        analytics.identify('id3', { ok: 'string', teams: ['eng', 'redsox'] });
+        analytics.called(window.FS.identify, 'id3', { ok_str: 'string' });
+      });
+
+      it('should skip user objects entirely', function() {
+        analytics.identify('id3', {
+          ok: 7,
+          account: { level: 'premier', avg_annual: 30000 }
+        });
+        analytics.called(window.FS.identify, 'id3', { ok_int: 7 });
+      });
+
+      it('should respect existing type tags', function() {
+        analytics.identify('id3', {
+          my_real: 17,
+          my_int_str: 17,
+          my_str_int: 'foo',
+          my_int_date: 3,
+          my_int_bool: 4,
+          mystr_real: 'plugh'
+        });
+        analytics.called(window.FS.identify, 'id3', {
+          my_real: 17, // didn't become my_real_real (double tag)
+          myInt_str: 17, // all other tests check type mismatch isn't
+          myStr_int: 'foo', // "fixed" to e.g. myInt_str_int, but keeps
+          myInt_date: 3, // the user's tag (and their mismatch error)
+          myInt_bool: 4,
+          mystr_real: 'plugh'
+        });
+      });
+    });
+
+    describe('#track', function() {
+      beforeEach(function() {
+        analytics.stub(window.FS, 'event');
+      });
+
+      it('should not send events when passEvents option is false', function() {
+        analytics.track('foo', { some_field: 'field_value' });
+        analytics.didNotCall(window.FS.event);
+      });
+
+      it('should send track event name and properties when passEvents option is true', function() {
+        fullstory.options.passEvents = true;
+        analytics.track('foo', { some_field: 'field_value' });
+        analytics.called(window.FS.event, 'foo', { some_field: 'field_value' });
+      });
+    });
+  });
+});


### PR DESCRIPTION
What does this PR do?
Moves FullStory into the monorepo with Track support.

Original repo: https://github.com/segment-integrations/analytics.js-integration-fullstory
Readme: https://github.com/segment-integrations/analytics.js-integration-fullstory/blob/master/README.md

Are there breaking changes in this PR?
No breaking changes. Adds support for Track calls in FullStory (see https://github.com/segment-integrations/analytics.js-integration-fullstory/pull/11)

Has this been tested end-to-end? Please provide screenshots on how the fix now populates in the end tool. If not, what was done to test?
Tests with PhantomJS pass locally. SauceLabs tests to run after this PR.

What are the relevant tickets?
n/a

Link to CC ticket
n/a