### PR TITLE
Add Completed Order Parity

### DIFF
--- a/integrations/amplitude/lib/index.js
+++ b/integrations/amplitude/lib/index.js
@@ -397,6 +397,7 @@ function mapRevenueAttributes(track) {
   // Using mapper here to support future ecomm event => revenue mappings (Order Refund, etc.)
   var mapRevenueType = {
     'order completed': 'Purchase',
+    'completed order': 'Purchase',
     'product purchased': 'Purchase'
   };
 

--- a/integrations/amplitude/package.json
+++ b/integrations/amplitude/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-amplitude",
   "description": "The Amplitude analytics.js integration.",
-  "version": "2.91.0",
+  "version": "2.92.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",


### PR DESCRIPTION
Our docs state that 'Completed Order' should be interchangeable with 'Order Completed'. This fixes an area of logic which caused a disparity.