### PR TITLE
[Amplitude] Update analytics.js-integration dependency

### DIFF
--- a/integrations/amplitude/package.json
+++ b/integrations/amplitude/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-amplitude",
   "description": "The Amplitude analytics.js integration.",
-  "version": "2.92.0",
+  "version": "2.92.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/amplitude/package.json
+++ b/integrations/amplitude/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@ndhoule/each": "^2.0.1",
-    "@segment/analytics.js-integration": "^2.1.0",
+    "@segment/analytics.js-integration": "^3.3.0",
     "@segment/top-domain": "^3.0.0",
     "component-bind": "^1.0.0",
     "do-when": "^1.0.0",


### PR DESCRIPTION
Amplitude's `analytics.js-integration` dependency has been outdated, causing it to interpret specced events like `Completed Order` as `completedOrder`, rather than `orderCompleted` as we document today.

Here's the specific change in `analytics-events` from 2+ years ago that we're pulling in by upping the `analytics.js-integration` dependency: https://github.com/segmentio/analytics-events/commit/c4ddef81349c71af75d725fbb40162d7752bd8ea#diff-168726dbe96b3ce427e7fedce31bb0bcR218