### PR TITLE
[Amplitude] Send Referrer Information Inside Integration

### DIFF
--- a/integrations/amplitude/lib/index.js
+++ b/integrations/amplitude/lib/index.js
@@ -411,12 +411,12 @@ Amplitude.prototype.sendReferrer = function() {
   }
 
   window.amplitude.getInstance().identify(identify);
-}
+};
 
 // wrapper for testing purposes
 Amplitude.prototype.getReferrer = function() {
   return document.referrer;
-}
+};
 
 function mapRevenueAttributes(track) {
   // Revenue type can be anything such as Refund, Tax, etc.

--- a/integrations/amplitude/lib/index.js
+++ b/integrations/amplitude/lib/index.js
@@ -69,7 +69,6 @@ Amplitude.prototype.initialize = function() {
 
   window.amplitude.getInstance().init(this.options.apiKey, null, {
     includeUtm: this.options.trackUtmProperties,
-    includeReferrer: this.options.trackReferrer,
     batchEvents: this.options.batchEvents,
     eventUploadThreshold: this.options.eventUploadThreshold,
     eventUploadPeriodMillis: this.options.eventUploadPeriodMillis,
@@ -125,6 +124,8 @@ Amplitude.prototype.loaded = function() {
 
 Amplitude.prototype.page = function(page) {
   this.setDeviceIdFromAnonymousId(page);
+
+  if (this.options.trackReferrer) this.sendReferrer();
 
   var category = page.category();
   var name = page.fullName();
@@ -391,6 +392,31 @@ Amplitude.prototype.setRevenue = function(properties) {
       .logRevenue(revenue || price * quantity, quantity, productId);
   }
 };
+
+// equivalent of sending includeReferrer=true in the amplitude config object when we initialize
+Amplitude.prototype.sendReferrer = function() {
+  var identify = new window.amplitude.Identify();
+
+  var referrer = this.getReferrer();
+  if (!referrer || referrer.length === 0) return;
+
+  identify.setOnce('initial_referrer', referrer);
+  identify.set('referrer', referrer);
+
+  var parts = referrer.split('/');
+  if (parts.length >= 3) {
+    var referring_domain = parts[2];
+    identify.setOnce('initial_referring_domain', referring_domain);
+    identify.set('referring_domain', referring_domain);
+  }
+
+  window.amplitude.getInstance().identify(identify);
+}
+
+// wrapper for testing purposes
+Amplitude.prototype.getReferrer = function() {
+  return document.referrer;
+}
 
 function mapRevenueAttributes(track) {
   // Revenue type can be anything such as Refund, Tax, etc.

--- a/integrations/amplitude/test/index.test.js
+++ b/integrations/amplitude/test/index.test.js
@@ -254,6 +254,30 @@ describe('Amplitude', function() {
         analytics.identify('id');
         analytics.called(window.amplitude.getInstance().setDeviceId, 'example');
       });
+
+      it('should send referrer if "trackReferrer" is set', function() {
+        var spy = sinon.spy(window.amplitude.getInstance(), 'identify');
+
+        var stub = sinon.stub(amplitude, 'getReferrer')
+        stub.returns('http://examplepage.com/')
+
+        amplitude.options.trackReferrer = true;
+
+        analytics.page();
+
+        sinon.assert.calledWith(spy, sinon.match({
+          userPropertiesOperations: sinon.match({
+            $setOnce: sinon.match({
+              initial_referrer: 'http://examplepage.com/',
+              initial_referring_domain: 'examplepage.com'
+            }),
+            $set: sinon.match({
+              referrer: 'http://examplepage.com/',
+              referring_domain: 'examplepage.com'
+            })
+          })
+        }));
+      })
     });
 
     describe('#identify', function() {

--- a/integrations/amplitude/test/index.test.js
+++ b/integrations/amplitude/test/index.test.js
@@ -258,26 +258,29 @@ describe('Amplitude', function() {
       it('should send referrer if "trackReferrer" is set', function() {
         var spy = sinon.spy(window.amplitude.getInstance(), 'identify');
 
-        var stub = sinon.stub(amplitude, 'getReferrer')
-        stub.returns('http://examplepage.com/')
+        var stub = sinon.stub(amplitude, 'getReferrer');
+        stub.returns('http://examplepage.com/');
 
         amplitude.options.trackReferrer = true;
 
         analytics.page();
 
-        sinon.assert.calledWith(spy, sinon.match({
-          userPropertiesOperations: sinon.match({
-            $setOnce: sinon.match({
-              initial_referrer: 'http://examplepage.com/',
-              initial_referring_domain: 'examplepage.com'
-            }),
-            $set: sinon.match({
-              referrer: 'http://examplepage.com/',
-              referring_domain: 'examplepage.com'
+        sinon.assert.calledWith(
+          spy,
+          sinon.match({
+            userPropertiesOperations: sinon.match({
+              $setOnce: sinon.match({
+                initial_referrer: 'http://examplepage.com/',
+                initial_referring_domain: 'examplepage.com'
+              }),
+              $set: sinon.match({
+                referrer: 'http://examplepage.com/',
+                referring_domain: 'examplepage.com'
+              })
             })
           })
-        }));
-      })
+        );
+      });
     });
 
     describe('#identify', function() {


### PR DESCRIPTION
Customers have been writing in saying that they’ve been seeing inconsistent Amplitude ‘device id’s attached to their events when using the setting ‘Prefer Anonymous ID for Device ID’. While they would expect to see their Segment anonymous IDs as the attached device ID for all events sent to Amplitude via Segment, they’re seeing the first event going to Amplitude using the default Amplitude-generated value, while all subsequent calls use the anonymous ID as expected. This is only happening when the page is opened via a referrer like Google and in all other cases the integration behaves as it should.

It turns out that all those customers were also using the setting ‘Track Referrer’, which is just a proxy setting for us to know whether or not to pass Amplitude their native setting ‘includeReferrer’, a boolean indicating whether or not to send Amplitude referrer information when the page loads. What happens when both this setting and ‘Prefer Anonymous ID for Device ID’ are enabled is as follows.

1. Segment loads on page, initializes Amplitude integration which in turn initializes Amplitude instance
2. Upon reading ‘includeReferrer’ as true, the Amplitude instance fires a native Amplitude `identify` call with that referrer information (this is that first Amplitude call that uses the default Amplitude-generated device ID)
3. Customer calls a Segment method (track, page, identify, etc), which in turn fires the Amplitude `setDeviceId` to switch the device ID to the Segment anonymous ID. All subsequent calls will now use the Segment anonymous ID.

To summarize, the inconsistency is stemming from the fact that Amplitude fires a tracking call with referrer information as part of their initialize logic when `trackReferrer` is switched on, but we don’t change device ID to anonymous ID until after initialization, causing the first Amplitude call to send with the default Amplitude device ID while all other Amplitude calls send with the Segment anonymous ID as the device ID.

This PR solves this issue by sending the referrer information ourselves instead of delegating that responsibility to the Amplitude initialization logic via a configuration option. This way we can make sure we're sending this information _after_ the device ID is changed to anonymous ID.

Note: This is a breaking change for any customers that don't fire `page` on their Segment enabled webpages.