### PR TITLE
Revert "Prevent SFDMP from throwing internal errors"

### DIFF
--- a/integrations/salesforce-dmp/HISTORY.md
+++ b/integrations/salesforce-dmp/HISTORY.md
@@ -1,10 +1,4 @@
 
-2.0.3 / 2018-10-10
-==================
-
-  * Add logic to prevent errors when an un-whitelisted `track` event is invoked 
-    while the `sendEventNames` option is set to `true`.
-
 2.0.2 / 2018-07-09
 ==================
 

--- a/integrations/salesforce-dmp/lib/index.js
+++ b/integrations/salesforce-dmp/lib/index.js
@@ -106,7 +106,7 @@ SalesforceDMP.prototype.identifyV2 = SalesforceDMP.prototype.trackV2 = function 
 
   if (type === 'track') {
     // Verify that this event is one we want to fire on, if a whitelist exists.
-    if (this.options.trackFireEvents.length > 0) {
+    if (this.options.trackFireEvents.length) {
       for (var i = 0; i < this.options.trackFireEvents.length; i++) {
         var event = this.options.trackFireEvents[i]
         // Continue execution if we find the event in the list. Otherwise, bail out.
@@ -117,10 +117,6 @@ SalesforceDMP.prototype.identifyV2 = SalesforceDMP.prototype.trackV2 = function 
         }
         if (i === this.options.trackFireEvents.length - 1) return
       }
-    } else {
-      // if no track events are mapped in settings, return early for 
-      // efficiency: none of the following logic will send data to SFDMP
-      return
     }
 
     // Modify the dataLayer with any defined adjustments. It's okay if they choose to make none.
@@ -141,23 +137,21 @@ SalesforceDMP.prototype.identifyV2 = SalesforceDMP.prototype.trackV2 = function 
     resetDataLayer = createDataLayer()
   }
 
-  if (window.kruxDataLayer) {
-    if (this.options.sendEventNames && !window.kruxDataLayer['event_name']) {
-      var name
-      if (type === 'track') {
-        name = msg.event()
-      } else {
-        if (this.options.sendIdentifyAsEventName) {
-          name = type
-        }
+  if (this.options.sendEventNames && !window.kruxDataLayer['event_name']) {
+    var name
+    if (type === 'track') {
+      name = msg.event()
+    } else {
+      if (this.options.sendIdentifyAsEventName) {
+        name = type
       }
-      if (name) window.kruxDataLayer['event_name'] = name
     }
-  
-    if (msg.userId()) window.kruxDataLayer['segmentio_user_id'] = msg.userId()
-    if (msg.anonymousId()) window.kruxDataLayer['segmentio_anonymous_id'] = msg.anonymousId()
-    if (msg.proxy('context.traits.crossDomainId')) window.kruxDataLayer['segmentio_xid'] = msg.proxy('context.traits.crossDomainId')
+    if (name) window.kruxDataLayer['event_name'] = name
   }
+
+  if (msg.userId()) window.kruxDataLayer['segmentio_user_id'] = msg.userId()
+  if (msg.anonymousId()) window.kruxDataLayer['segmentio_anonymous_id'] = msg.anonymousId()
+  if (msg.proxy('context.traits.crossDomainId')) window.kruxDataLayer['segmentio_xid'] = msg.proxy('context.traits.crossDomainId')
 
   this.firePixel(resetDataLayer)
 }

--- a/integrations/salesforce-dmp/package.json
+++ b/integrations/salesforce-dmp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-salesforce-dmp",
   "description": "The Salesforce DMP analytics.js integration.",
-  "version": "2.0.3",
+  "version": "2.0.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/salesforce-dmp/test/index.test.js
+++ b/integrations/salesforce-dmp/test/index.test.js
@@ -5,13 +5,12 @@ var integration = require('@segment/analytics.js-integration')
 var tester = require('@segment/analytics.js-integration-tester')
 var sandbox = require('@segment/clear-env')
 var SalesforceDMP = require('../lib/')
-var Track = require('segmentio-facade').Track;
 
 describe('Salesforce DMP', function () {
   var analytics
   var salesforceDMP
   var options = {
-    confId: '123',
+    confId: 'rw1to29bb',
     useV2LogicClient: false
   }
 
@@ -56,7 +55,7 @@ describe('Salesforce DMP V2', function () {
   var analytics
   var salesforceDMP
   var optionsV2 = {
-    confId: '123',
+    confId: 'rw1to29bb',
     useV2LogicClient: true,
     sendEventNames: true,
     sendIdentifyAsEventName: true,
@@ -188,27 +187,6 @@ describe('Salesforce DMP V2', function () {
         window.kruxDataLayer['event_name'] = 'do not override'
         analytics.track('event')
         analytics.assert(window.kruxDataLayer['event_name'] === 'do not override')
-      })
-
-      // previously SFDMP would throw an error if a customer invoked an 
-      // unmapped `track` event while `sendEventNames` setting was enabled
-      // this edge case has been resolved, but we test for it anyway
-      it('does not throw an error if `sendEventNames` setting is enabled but no track events are whitelisted', function () {
-        var edgeCaseOptions = {
-          confId: '123',
-          useV2LogicClient: true,
-          sendEventNames: true,
-          sendIdentifyAsEventName: true,
-          namespace: 'test',
-          trackFireEvents: [],
-          eventAttributeMap: {},
-          contextTraitsMap: { trait: 'context_trait' }
-        }
-
-        salesforceDMP = new SalesforceDMP(edgeCaseOptions)
-        analytics.doesNotThrow(function() {
-          salesforceDMP.track(new Track({ name: 'Testing' }))
-        })
       })
     })
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -241,7 +241,7 @@
     slug-component "^1.1.0"
     to-no-case "^0.1.3"
 
-"@segment/analytics.js-integration@^3.0.0", "@segment/analytics.js-integration@^3.1.0", "@segment/analytics.js-integration@^3.2.0", "@segment/analytics.js-integration@^3.3.0":
+"@segment/analytics.js-integration@^3.0.0", "@segment/analytics.js-integration@^3.1.0", "@segment/analytics.js-integration@^3.2.0":
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/@segment/analytics.js-integration/-/analytics.js-integration-3.3.0.tgz#a44eac133e0ba1a26dc7387adc59c84b0ab15178"
   dependencies:


### PR DESCRIPTION
Reverts segmentio/analytics.js-integrations#76

Reverting previous PR so CI tests aren't failing on master overnight.