### PR TITLE
Rockerbox: adding userId to identify calls

### DIFF
--- a/integrations/hindsight/lib/index.js
+++ b/integrations/hindsight/lib/index.js
@@ -80,7 +80,7 @@ Hindsight.prototype.identify = function(identify) {
 function format(props) {
   var ret = {"implementation":"segment"};
   each(function(value, key) {
-    return ret[key] = is.object(value) || is.array(value) ? window.JSON.stringify(value) : value; 
+    ret[key] = is.object(value) || is.array(value) ? window.JSON.stringify(value) : value; 
   }, props);
 
   return ret;

--- a/integrations/hindsight/lib/index.js
+++ b/integrations/hindsight/lib/index.js
@@ -64,7 +64,10 @@ Hindsight.prototype.track = function(track) {
  */
 
 Hindsight.prototype.identify = function(identify) {
-  window.RB.track('identify', identify.traits());
+  var traits = identify.traits();
+  if (identify['userId']) traits['customer_id'] = identify['userId'];
+  
+  window.RB.track('identify', format(traits) );
 };
 
 /**

--- a/integrations/hindsight/lib/index.js
+++ b/integrations/hindsight/lib/index.js
@@ -65,7 +65,8 @@ Hindsight.prototype.track = function(track) {
 
 Hindsight.prototype.identify = function(identify) {
   var traits = identify.traits();
-  if (identify['userId']) traits['customer_id'] = identify['userId'];
+  if (identify['userId']) traits['segmentUserId'] = identify['userId'];
+  if (identify['anonymousId']) traits['segmentAnonymousId'] = identify['anonymousId'];
   
   window.RB.track('identify', format(traits) );
 };

--- a/integrations/hindsight/lib/index.js
+++ b/integrations/hindsight/lib/index.js
@@ -78,7 +78,7 @@ Hindsight.prototype.identify = function(identify) {
  */
 
 function format(props) {
-  var ret = {};
+  var ret = {"implementation":"segment"};
   each(function(value, key) {
     return ret[key] = is.object(value) || is.array(value) ? window.JSON.stringify(value) : value; 
   }, props);

--- a/integrations/hindsight/lib/index.js
+++ b/integrations/hindsight/lib/index.js
@@ -80,7 +80,7 @@ Hindsight.prototype.identify = function(identify) {
 function format(props) {
   var ret = {};
   each(function(value, key) {
-    return ret[key] = is.object(value) ? window.JSON.stringify(value) : value; 
+    return ret[key] = is.object(value) || is.array(value) ? window.JSON.stringify(value) : value; 
   }, props);
 
   return ret;


### PR DESCRIPTION
**What does this PR do?**
- Adds format to identify call before sending to Rockerbox
- Adds customer_id overridden as userId if userId is present

**Are there breaking changes in this PR?**
No

**Has this been tested end-to-end? Please provide screenshots on how the fix now populates in the end tool. If not, what was done to test?**
This populates a new set of fields that we can use to override the default customer identifier in our system. This is a feature supported by our product currently but now passes userId and anonymousId from segment to our product.

**Any background context you want to provide?**
This will enable our customers to use the segment userID in place of the Rockerbox customer_id and simplify setup by relying on segments userID

**Is there parity with the server-side/android/iOS integration (if applicable)?**
NA

**Does this require a metadata change? If so, please link the PR from https://github.com/segmentio/destination-scripts.**
NA

**What are the relevant tickets?**
NA

**Link to CC ticket**
NA

**List all the tests accounts you have used to make sure this change works**


**Helpful Docs**

