### PR TITLE
Hubspot/forms sdk

### DIFF
--- a/integrations/hubspot/HISTORY.md
+++ b/integrations/hubspot/HISTORY.md
@@ -1,3 +1,7 @@
+2.2.1 / 2018-11-14
+==================
+  * Fix script loading behavior to resolve issue with the Forms SDK and ad blockers.
+
 2.1.3 / 2018-07-06
 ==================
   * Add support for tabs, carriage returns, new lines, vertical tabs, form feeds

--- a/integrations/hubspot/lib/index.js
+++ b/integrations/hubspot/lib/index.js
@@ -39,7 +39,7 @@ HubSpot.prototype.initialize = function() {
   var self = this;
   if (shouldLoadLeadForms) {
     this.load('forms', function() {
-      self.load('lib', self.ready);
+      self.load('lib', { cacheBuster: cacheBuster }, self.ready);
     });
   } else {
     this.load('lib', { cacheBuster: cacheBuster }, this.ready);
@@ -55,6 +55,9 @@ HubSpot.prototype.initialize = function() {
 
 HubSpot.prototype.loaded = function() {
   var libLoaded = !!(window._hsq && window._hsq.push !== Array.prototype.push);
+  // Due to limitations with our testing framework, we cannot test more than a single script loading configuration.
+  // Therefore, we are ignoring this conditional in code coverage.
+  /* istanbul ignore if */
   if (!this.options.loadFormsSdk) {
     return libLoaded;
   }

--- a/integrations/hubspot/lib/index.js
+++ b/integrations/hubspot/lib/index.js
@@ -1,27 +1,30 @@
-'use strict'
+'use strict';
 
 /**
  * Module dependencies.
  */
 
-var Identify = require('segmentio-facade').Identify
-var convert = require('@segment/convert-dates')
-var integration = require('@segment/analytics.js-integration')
-var push = require('global-queue')('_hsq')
-var each = require('@ndhoule/each')
+var Identify = require('segmentio-facade').Identify;
+var convert = require('@segment/convert-dates');
+var integration = require('@segment/analytics.js-integration');
+var push = require('global-queue')('_hsq');
+var each = require('@ndhoule/each');
 
 /**
  * Expose `HubSpot` integration.
  */
 
-var HubSpot = module.exports = integration('HubSpot')
+var HubSpot = (module.exports = integration('HubSpot')
   .assumesPageview()
   .global('_hsq')
   .global('hbspt')
   .option('portalId', null)
   .option('loadFormsSdk', false)
-  .tag('lib', '<script id="hs-analytics" src="https://js.hs-analytics.net/analytics/{{ cacheBuster }}/{{ portalId }}.js">')
-  .tag('forms', '<script src="//js.hsforms.net/forms/shell.js">')
+  .tag(
+    'lib',
+    '<script id="hs-analytics" src="https://js.hs-analytics.net/analytics/{{ cacheBuster }}/{{ portalId }}.js">'
+  )
+  .tag('forms', '<script src="//js.hsforms.net/forms/shell.js">'));
 
 /**
  * Initialize.
@@ -30,18 +33,18 @@ var HubSpot = module.exports = integration('HubSpot')
  */
 
 HubSpot.prototype.initialize = function() {
-  window._hsq = window._hsq || []
-  var cacheBuster = Math.ceil(new Date() / 300000) * 300000
-  var shouldLoadLeadForms = this.options.loadFormsSdk
-  var self = this
-  this.load('lib', { cacheBuster: cacheBuster }, function() {
-    if (shouldLoadLeadForms) {
-      self.load('forms', self.ready)
-    } else {
-      self.ready()
-    }
-  })
-}
+  window._hsq = window._hsq || [];
+  var cacheBuster = Math.ceil(new Date() / 300000) * 300000;
+  var shouldLoadLeadForms = this.options.loadFormsSdk;
+  var self = this;
+  if (shouldLoadLeadForms) {
+    this.load('forms', function() {
+      self.load('lib', self.ready);
+    });
+  } else {
+    this.load('lib', { cacheBuster: cacheBuster }, this.ready);
+  }
+};
 
 /**
  * Loaded?
@@ -51,13 +54,12 @@ HubSpot.prototype.initialize = function() {
  */
 
 HubSpot.prototype.loaded = function() {
-  var libLoaded = !!(window._hsq && window._hsq.push !== Array.prototype.push)
+  var libLoaded = !!(window._hsq && window._hsq.push !== Array.prototype.push);
   if (!this.options.loadFormsSdk) {
-    return libLoaded
-  } else {
-    return libLoaded && !!(window.hbspt && window.hbspt.forms)
+    return libLoaded;
   }
-}
+  return libLoaded && !!(window.hbspt && window.hbspt.forms);
+};
 
 /**
  * Page.
@@ -66,9 +68,9 @@ HubSpot.prototype.loaded = function() {
  * @param {Page} page
  */
 
-HubSpot.prototype.page = function () {
-  push('trackPageView')
-}
+HubSpot.prototype.page = function() {
+  push('trackPageView');
+};
 
 /**
  * Identify.
@@ -77,27 +79,30 @@ HubSpot.prototype.page = function () {
  * @param {Identify} identify
  */
 
-HubSpot.prototype.identify = function (identify) {
+HubSpot.prototype.identify = function(identify) {
   // use newer version of Identify to have access to `companyName`
   var newIdentify = new Identify({
     traits: identify.traits(),
     userId: identify.userId()
-  })
+  });
 
   if (!newIdentify.email()) {
-    return
+    return;
   }
 
-  var traits = newIdentify.traits({ firstName: 'firstname', lastName: 'lastname' })
-  traits = convertDates(traits)
-  traits = formatTraits(traits)
+  var traits = newIdentify.traits({
+    firstName: 'firstname',
+    lastName: 'lastname'
+  });
+  traits = convertDates(traits);
+  traits = formatTraits(traits);
 
   if (newIdentify.companyName() !== undefined) {
-    traits.company = newIdentify.companyName()
+    traits.company = newIdentify.companyName();
   }
 
-  push('identify', traits)
-}
+  push('identify', traits);
+};
 
 /**
  * Track.
@@ -106,14 +111,14 @@ HubSpot.prototype.identify = function (identify) {
  * @param {Track} track
  */
 
-HubSpot.prototype.track = function (track) {
+HubSpot.prototype.track = function(track) {
   // Hubspot expects properties.id to be the name of the .track() event
   // Ref: http://developers.hubspot.com/docs/methods/enterprise_events/javascript_api
-  var props = convertDates(track.properties({ id: '_id', revenue: 'value' }))
-  props.id = track.event()
+  var props = convertDates(track.properties({ id: '_id', revenue: 'value' }));
+  props.id = track.event();
 
-  push('trackEvent', track.event(), props)
-}
+  push('trackEvent', track.event(), props);
+};
 
 /**
  * Convert all the dates in the HubSpot properties to millisecond times
@@ -122,8 +127,10 @@ HubSpot.prototype.track = function (track) {
  * @param {Object} properties
  */
 
-function convertDates (properties) {
-  return convert(properties, function (date) { return date.getTime() })
+function convertDates(properties) {
+  return convert(properties, function(date) {
+    return date.getTime();
+  });
 }
 
 /**
@@ -135,21 +142,29 @@ function convertDates (properties) {
  * @return {Object} ret
  */
 
-function formatTraits (traits) {
-  var ret = {}
-  each(function (value, key) {
+function formatTraits(traits) {
+  var ret = {};
+  each(function(value, key) {
     // Using split/join due to IE 11 failing to properly support regex in str.replace()
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@replace
-    var k = key.toLowerCase()
-      .split(' ').join('_') // spaces
-      .split('.').join('_') // Periods
-      .split('\n').join('_') // new lines
-      .split('\v').join('_') // Vertical tabs
-      .split('\t').join('_') // Regular tabs
-      .split('\f').join('_') // form feeds
-      .split('\r').join('_') // Carriage returns
-    ret[k] = value
-  }, traits)
+    var k = key
+      .toLowerCase()
+      .split(' ')
+      .join('_') // spaces
+      .split('.')
+      .join('_') // Periods
+      .split('\n')
+      .join('_') // new lines
+      .split('\v')
+      .join('_') // Vertical tabs
+      .split('\t')
+      .join('_') // Regular tabs
+      .split('\f')
+      .join('_') // form feeds
+      .split('\r')
+      .join('_'); // Carriage returns
+    ret[k] = value;
+  }, traits);
 
-  return ret
+  return ret;
 }

--- a/integrations/hubspot/package.json
+++ b/integrations/hubspot/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-hubspot",
   "description": "The Hubspot analytics.js integration.",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/hubspot/test/index.test.js
+++ b/integrations/hubspot/test/index.test.js
@@ -1,57 +1,60 @@
-'use strict'
+'use strict';
 
-var Analytics = require('@segment/analytics.js-core').constructor
-var integration = require('@segment/analytics.js-integration')
-var sandbox = require('@segment/clear-env')
-var tester = require('@segment/analytics.js-integration-tester')
-var HubSpot = require('../lib/')
+var Analytics = require('@segment/analytics.js-core').constructor;
+var integration = require('@segment/analytics.js-integration');
+var sandbox = require('@segment/clear-env');
+var tester = require('@segment/analytics.js-integration-tester');
+var HubSpot = require('../lib/');
 
-describe('HubSpot', function () {
-  var analytics
-  var hubspot
+describe('HubSpot', function() {
+  var analytics;
+  var hubspot;
   var options = {
     portalId: 62515,
     loadFormsSdk: false
-  }
+  };
 
-  beforeEach(function () {
-    analytics = new Analytics()
-    hubspot = new HubSpot(options)
-    analytics.use(HubSpot)
-    analytics.use(tester)
-    analytics.add(hubspot)
-  })
+  beforeEach(function() {
+    analytics = new Analytics();
+    hubspot = new HubSpot(options);
+    analytics.use(HubSpot);
+    analytics.use(tester);
+    analytics.add(hubspot);
+  });
 
   afterEach(function() {
-    analytics.restore()
-    analytics.reset()
-    hubspot.reset()
-    sandbox()
-  })
+    analytics.restore();
+    analytics.reset();
+    hubspot.reset();
+    sandbox();
+  });
 
-  it('should have the right settings', function () {
-    analytics.compare(HubSpot, integration('HubSpot')
-      .assumesPageview()
-      .global('_hsq')
-      .global('hbspt')
-      .option('loadFormsSdk', false)
-      .option('portalId', null))
-  })
+  it('should have the right settings', function() {
+    analytics.compare(
+      HubSpot,
+      integration('HubSpot')
+        .assumesPageview()
+        .global('_hsq')
+        .global('hbspt')
+        .option('loadFormsSdk', false)
+        .option('portalId', null)
+    );
+  });
 
-  describe('before loading', function () {
-    beforeEach(function () {
-      analytics.stub(hubspot, 'load')
-    })
+  describe('before loading', function() {
+    beforeEach(function() {
+      analytics.stub(hubspot, 'load');
+    });
 
-    describe('#initialize', function () {
-      it('should create window._hsq', function () {
-        analytics.assert(!window._hsq)
-        analytics.initialize()
-        analytics.page()
-        analytics.assert(window._hsq instanceof Array)
-      })
-    })
-  })
+    describe('#initialize', function() {
+      it('should create window._hsq', function() {
+        analytics.assert(!window._hsq);
+        analytics.initialize();
+        analytics.page();
+        analytics.assert(window._hsq instanceof Array);
+      });
+    });
+  });
 
   describe('loading', function() {
     // It's currently very difficult to run multiple tests against the loading behavior of a third-party script.
@@ -60,169 +63,220 @@ describe('HubSpot', function () {
     // Ideally we would have a test here as well that ensure the form DOES NOT load if the option is false but limitations with Karma make this very tricky.
     // TODO: look into solutions for full browser refreshes between tests to ensure clean loading behavior.
     it('should load the analytics lib and the forms lib if that option is true', function(done) {
-      hubspot.options.loadFormsSdk = true
+      hubspot.options.loadFormsSdk = true;
       analytics.load(hubspot, function() {
         try {
-          var formsSdkLoaded = !!(window.hbspt && window.hbspt.forms)
-          analytics.assert(formsSdkLoaded, 'Expected Hubspot Forms SDK to be loaded on the page')
-          done()
+          var formsSdkLoaded = !!(window.hbspt && window.hbspt.forms);
+          analytics.assert(
+            formsSdkLoaded,
+            'Expected Hubspot Forms SDK to be loaded on the page'
+          );
+          done();
         } catch (e) {
-          done(e)
+          done(e);
         }
-      })
-    })
-  })
+      });
+    });
+  });
 
-  describe('after loading', function () {
-    beforeEach(function (done) {
-      analytics.once('ready', done)
-      analytics.initialize()
-      analytics.page()
-    })
+  describe('after loading', function() {
+    beforeEach(function(done) {
+      analytics.once('ready', done);
+      analytics.initialize();
+      analytics.page();
+    });
 
-    describe('#identify', function () {
-      beforeEach(function () {
-        analytics.stub(window._hsq, 'push')
-      })
+    describe('#identify', function() {
+      beforeEach(function() {
+        analytics.stub(window._hsq, 'push');
+      });
 
-      it('should not send traits without an email', function () {
-        analytics.identify('id')
-        analytics.didNotCall(window._hsq.push)
-      })
+      it('should not send traits without an email', function() {
+        analytics.identify('id');
+        analytics.didNotCall(window._hsq.push);
+      });
 
-      it('should send traits with an email', function () {
-        analytics.identify({ email: 'name@example.com' })
-        analytics.called(window._hsq.push, ['identify', { email: 'name@example.com' }])
-      })
+      it('should send traits with an email', function() {
+        analytics.identify({ email: 'name@example.com' });
+        analytics.called(window._hsq.push, [
+          'identify',
+          { email: 'name@example.com' }
+        ]);
+      });
 
-      it('should send an id and traits with an email', function () {
-        analytics.identify('id', { email: 'name@example.com' })
-        analytics.called(window._hsq.push, ['identify', {
-          id: 'id',
-          email: 'name@example.com'
-        }])
-      })
+      it('should send an id and traits with an email', function() {
+        analytics.identify('id', { email: 'name@example.com' });
+        analytics.called(window._hsq.push, [
+          'identify',
+          {
+            id: 'id',
+            email: 'name@example.com'
+          }
+        ]);
+      });
 
-      it('should convert dates to milliseconds', function () {
-        var date = new Date()
+      it('should convert dates to milliseconds', function() {
+        var date = new Date();
         analytics.identify({
           email: 'name@example.com',
           date: date
-        })
-        analytics.called(window._hsq.push, ['identify', {
-          email: 'name@example.com',
-          date: date.getTime()
-        }])
-      })
+        });
+        analytics.called(window._hsq.push, [
+          'identify',
+          {
+            email: 'name@example.com',
+            date: date.getTime()
+          }
+        ]);
+      });
 
-      it('should normalize name fields to firstname and lastname', function () {
+      it('should normalize name fields to firstname and lastname', function() {
         analytics.identify({
           email: 'name@example.com',
           firstName: 'First',
           lastName: 'Last'
-        })
-        analytics.called(window._hsq.push, ['identify', {
-          email: 'name@example.com',
-          firstname: 'First',
-          lastname: 'Last'
-        }])
-      })
+        });
+        analytics.called(window._hsq.push, [
+          'identify',
+          {
+            email: 'name@example.com',
+            firstname: 'First',
+            lastname: 'Last'
+          }
+        ]);
+      });
 
-      it('should lowercase any uppercase traits', function () {
+      it('should lowercase any uppercase traits', function() {
         analytics.identify({
           email: 'name@example.com',
           yOlO: 'yolo'
-        })
-        analytics.called(window._hsq.push, ['identify', {
-          email: 'name@example.com',
-          yolo: 'yolo'
-        }])
-      })
+        });
+        analytics.called(window._hsq.push, [
+          'identify',
+          {
+            email: 'name@example.com',
+            yolo: 'yolo'
+          }
+        ]);
+      });
 
-      it('should replace all spaces (tab, new lines, ect) with _', function () {
+      it('should replace all spaces (tab, new lines, ect) with _', function() {
         analytics.identify({
           email: 'name@example.com',
           'gogurts are\tlife\rand\vgood\ntoday\fhorray': 'yolo'
-        })
-        analytics.called(window._hsq.push, ['identify', {
-          email: 'name@example.com',
-          gogurts_are_life_and_good_today_horray: 'yolo'
-        }])
-      })
+        });
+        analytics.called(window._hsq.push, [
+          'identify',
+          {
+            email: 'name@example.com',
+            gogurts_are_life_and_good_today_horray: 'yolo'
+          }
+        ]);
+      });
 
-      it('should replace periods with _', function () {
+      it('should replace periods with _', function() {
         analytics.identify({
           email: 'name@example.com',
           'gogurts.are.life': 'yolo'
-        })
-        analytics.called(window._hsq.push, ['identify', {
-          email: 'name@example.com',
-          gogurts_are_life: 'yolo'
-        }])
-      })
+        });
+        analytics.called(window._hsq.push, [
+          'identify',
+          {
+            email: 'name@example.com',
+            gogurts_are_life: 'yolo'
+          }
+        ]);
+      });
 
-      it('should fill in company name', function () {
+      it('should fill in company name', function() {
         analytics.identify({
           email: 'name@example.com',
           company: {
             name: 'Example Company'
           }
-        })
-        analytics.called(window._hsq.push, ['identify', {
-          email: 'name@example.com',
-          company: 'Example Company'
-        }])
-      })
-    })
+        });
+        analytics.called(window._hsq.push, [
+          'identify',
+          {
+            email: 'name@example.com',
+            company: 'Example Company'
+          }
+        ]);
+      });
+    });
 
-    describe('#track', function () {
-      beforeEach(function () {
-        analytics.stub(window._hsq, 'push')
-      })
+    describe('#track', function() {
+      beforeEach(function() {
+        analytics.stub(window._hsq, 'push');
+      });
 
-      it('should send an event', function () {
-        analytics.track('event')
-        analytics.called(window._hsq.push, ['trackEvent', 'event', { id: 'event' }])
-      })
+      it('should send an event', function() {
+        analytics.track('event');
+        analytics.called(window._hsq.push, [
+          'trackEvent',
+          'event',
+          { id: 'event' }
+        ]);
+      });
 
-      it('should send an event and properties', function () {
-        analytics.track('event', { property: true })
-        analytics.called(window._hsq.push, ['trackEvent', 'event', { property: true, id: 'event' }])
-      })
+      it('should send an event and properties', function() {
+        analytics.track('event', { property: true });
+        analytics.called(window._hsq.push, [
+          'trackEvent',
+          'event',
+          { property: true, id: 'event' }
+        ]);
+      });
 
-      it('should convert dates to milliseconds', function () {
-        var date = new Date()
-        var ms = date.getTime()
+      it('should convert dates to milliseconds', function() {
+        var date = new Date();
+        var ms = date.getTime();
 
-        analytics.track('event', { date: date })
-        analytics.called(window._hsq.push, ['trackEvent', 'event', { date: ms, id: 'event' }])
-      })
+        analytics.track('event', { date: date });
+        analytics.called(window._hsq.push, [
+          'trackEvent',
+          'event',
+          { date: ms, id: 'event' }
+        ]);
+      });
 
-      it('should attach track.event to properties.id', function () {
-        analytics.track('Viewed Product', {})
-        analytics.called(window._hsq.push, ['trackEvent', 'Viewed Product', { id: 'Viewed Product' }])
-      })
+      it('should attach track.event to properties.id', function() {
+        analytics.track('Viewed Product', {});
+        analytics.called(window._hsq.push, [
+          'trackEvent',
+          'Viewed Product',
+          { id: 'Viewed Product' }
+        ]);
+      });
 
-      it('should move properties.id to properties._id', function () {
-        analytics.track('Viewed Product', { id: '12345' })
-        analytics.called(window._hsq.push, ['trackEvent', 'Viewed Product', { id: 'Viewed Product', _id: '12345' }])
-      })
+      it('should move properties.id to properties._id', function() {
+        analytics.track('Viewed Product', { id: '12345' });
+        analytics.called(window._hsq.push, [
+          'trackEvent',
+          'Viewed Product',
+          { id: 'Viewed Product', _id: '12345' }
+        ]);
+      });
 
-      it('should send revenue as value', function () {
-        analytics.track('Did Something Valuable', { id: '12345', revenue: 13 })
-        analytics.called(window._hsq.push, ['trackEvent', 'Did Something Valuable', { id: 'Did Something Valuable', _id: '12345', value: 13 }])
-      })
-    })
+      it('should send revenue as value', function() {
+        analytics.track('Did Something Valuable', { id: '12345', revenue: 13 });
+        analytics.called(window._hsq.push, [
+          'trackEvent',
+          'Did Something Valuable',
+          { id: 'Did Something Valuable', _id: '12345', value: 13 }
+        ]);
+      });
+    });
 
-    describe('#page', function () {
-      beforeEach(function () {
-        analytics.stub(window._hsq, 'push')
-      })
+    describe('#page', function() {
+      beforeEach(function() {
+        analytics.stub(window._hsq, 'push');
+      });
 
-      it('should send a page view', function () {
-        analytics.page()
-        analytics.called(window._hsq.push, ['trackPageView'])
-      })
-    })
-  })
-})
+      it('should send a page view', function() {
+        analytics.page();
+        analytics.called(window._hsq.push, ['trackPageView']);
+      });
+    });
+  });
+});


### PR DESCRIPTION
**What does this PR do?**
Addresses an issue where adblockers were blocking the Hubspot analytics SDK and thus preventing the Hubspot Forms SDK from loading. This is a critical issue for anyone that wants to load the Forms SDK via Segment. 

It fixes the issue by first loading the Forms SDK and then loading the analytics SDK.

**Are there breaking changes in this PR?**
No

**Has this been tested end-to-end? Please provide screenshots on how the fix now populates in the end tool. If not, what was done to test?**
Tested locally and it is behaving as expected.

**Any background context you want to provide?**


**Is there parity with the server-side/android/iOS integration (if applicable)?**


**Does this require a metadata change? If so, please link the PR from https://github.com/segmentio/destination-scripts.**


**What are the relevant tickets?**
https://segment.atlassian.net/browse/FCD-149

**Link to CC ticket**
https://segment.atlassian.net/browse/CC-2343

**List all the tests accounts you have used to make sure this change works**


**Helpful Docs**

