### PR TITLE
[WIP] Adds deviceId to Amplitude init if preferAnonymousIdForDeviceId is true

### DIFF
--- a/integrations/amplitude/lib/index.js
+++ b/integrations/amplitude/lib/index.js
@@ -77,7 +77,12 @@ Amplitude.prototype.initialize = function() {
     includeGclid: this.options.trackGclid,
     saveParamsReferrerOncePerSession: this.options
       .saveParamsReferrerOncePerSession,
-    deviceIdFromUrlParam: this.options.deviceIdFromUrlParam
+    deviceIdFromUrlParam: this.options.deviceIdFromUrlParam,
+    deviceId:
+      this.options.preferAnonymousIdForDeviceId &&
+      this.analytics &&
+      this.analytics.user() &&
+      this.analytics.user().anonymousId()
   });
 
   var loaded = bind(this, this.loaded);

--- a/integrations/amplitude/package.json
+++ b/integrations/amplitude/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-amplitude",
   "description": "The Amplitude analytics.js integration.",
-  "version": "2.94.2",
+  "version": "2.95.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/amplitude/test/index.test.js
+++ b/integrations/amplitude/test/index.test.js
@@ -139,6 +139,21 @@ describe('Amplitude', function() {
       );
     });
 
+    describe('preferAnonymousIdForDeviceId disabled', function() {
+      before(function() {
+        options.preferAnonymousIdForDeviceId = false;
+      });
+
+      it('should init without anonymousId as the deviceId', function() {
+        var config = window.amplitude.getInstance().options;
+        analytics.assert(config.deviceId !== analytics.user().anonymousId());
+      });
+
+      after(function() {
+        options.preferAnonymousIdForDeviceId = true;
+      });
+    });
+
     describe('#setDeviceId', function() {
       it('should call window.amplitude.setDeviceId', function() {
         analytics.spy(window.amplitude.getInstance(), 'setDeviceId');

--- a/integrations/amplitude/test/index.test.js
+++ b/integrations/amplitude/test/index.test.js
@@ -25,7 +25,8 @@ describe('Amplitude', function() {
     trackRevenuePerProduct: false,
     mapQueryParams: {},
     traitsToIncrement: [],
-    traitsToSetOnce: []
+    traitsToSetOnce: [],
+    preferAnonymousIdForDeviceId: true
   };
 
   beforeEach(function() {
@@ -129,6 +130,7 @@ describe('Amplitude', function() {
       analytics.assert(
         config.deviceIdFromUrlParam === options.deviceIdFromUrlParam
       );
+      analytics.assert(config.deviceId === analytics.user().anonymousId());
     });
 
     it('should set api key', function() {


### PR DESCRIPTION
**What does this PR do?**
Initializes the Amplitude SDK with the `deviceId` option set to the anonymous ID **if** the `preferAnonymousIdForDeviceId` setting is enabled.

This fixes unexpected behavior given a specific combination of settings: `deviceIdFromUrlParam`, `preferAnonymousIdForDeviceId` and `trackUtmProperties`. 

Today, if `preferAnonymousIdForDeviceId` and `trackUtmProperties` is enabled it queues an $identify request on load, but uses the Amplitude-generated ID. You can see in the [master branch](https://github.com/segmentio/analytics.js-integrations/blob/master/integrations/amplitude/lib/index.js#L71-L81) that we don't set `deviceId` to `anonymousId` on initialization, but only during spec'd calls. This missing configuration value causes Amplitude's SDK to not use the `anonymousId` as the `deviceId` for any onload events - in this case it's the $identify call with the UTM parameters.

**Are there breaking changes in this PR?**
Negative


**Has this been tested end-to-end? Please provide screenshots on how the fix now populates in the end tool. If not, what was done to test?**
Tested locally... will post console logs of staging tests!

**Any background context you want to provide?**


**Is there parity with the server-side/android/iOS integration (if applicable)?**


**Does this require a metadata change? If so, please link the PR from https://github.com/segmentio/destination-scripts.**


**What are the relevant tickets?**
[FCD-209](https://segment.atlassian.net/browse/FCD-209)

**Link to CC ticket**
https://segment.atlassian.net/browse/CC-2688

**List all the tests accounts you have used to make sure this change works**


**Helpful Docs**

