### PR TITLE
Adds exit link tracking support for specific events

### DIFF
--- a/integrations/adobe-analytics/lib/index.js
+++ b/integrations/adobe-analytics/lib/index.js
@@ -83,6 +83,7 @@ AdobeAnalytics
   .option('preferVisitorId', false)
   .option('heartbeatTrackingServerUrl', '')
   .option('ssl', false)
+  .option('exitLinkEvents', [])
 
   .sOption('visitorID')
   .sOption('channel')
@@ -420,11 +421,16 @@ AdobeAnalytics.prototype.processEvent = function(msg, adobeEvent) {
 
   window.s.linkTrackVars = dynamicKeys.join(',');
 
+  var linkType = 'o';
+  if (this.options.exitLinkEvents.indexOf(msg.event()) !== -1) {
+    linkType = 'e';
+  }
+
   // Send request off to Adobe Analytics
   // 1st param: sets 500ms delay to give browser time, also means you are tracking something other than a href link
   // 2nd param: 'o' means 'Other' as opposed to 'd' for 'Downloads' and 'e' for Exit links
   // 3rd param: link name you will see in reports
-  window.s.tl(true, 'o', msg.event());
+  window.s.tl(true, linkType, msg.event());
 };
 
 /**

--- a/integrations/adobe-analytics/test/index.test.js
+++ b/integrations/adobe-analytics/test/index.test.js
@@ -742,6 +742,15 @@ describe('Adobe Analytics', function() {
           analytics.equal(window.s.events, 'prodView,event1,event38');
         });
       });
+
+      it('should track event as custom link', function () {
+        analytics.track('Drank Some Milk');
+        analytics.called(window.s.tl, true, 'o', 'Drank Some Milk');
+      });
+       it('should track event as exit link', function () {
+        analytics.track('Played a Song');
+        analytics.called(window.s.tl, true, 'e', 'Played a Song');
+      });
     });
 
     describe('#page', function() {

--- a/integrations/adobe-analytics/test/index.test.js
+++ b/integrations/adobe-analytics/test/index.test.js
@@ -21,7 +21,8 @@ describe('Adobe Analytics', function() {
     events: [
       { segmentEvent: 'Played a Song', adobeEvents: ['event1'] },
       { segmentEvent: 'Drank Some Milk', adobeEvents: ['event6'] },
-      { segmentEvent: 'Overlord exploded', adobeEvents: ['event7'] }
+      { segmentEvent: 'Overlord exploded', adobeEvents: ['event7'] },
+      { segmentEvent: 'Played a Game', adobeEvents: ['event1'] },
     ],
     eVars: {
       Car: 'eVar1',
@@ -50,7 +51,8 @@ describe('Adobe Analytics', function() {
     enableTrackPageName: true,
     disableVisitorId: false,
     preferVisitorId: false,
-    enableHeartbeat: true
+    enableHeartbeat: true,
+    exitLinkEvents: ['Played a Game']
   };
 
   beforeEach(function() {
@@ -748,8 +750,8 @@ describe('Adobe Analytics', function() {
         analytics.called(window.s.tl, true, 'o', 'Drank Some Milk');
       });
        it('should track event as exit link', function () {
-        analytics.track('Played a Song');
-        analytics.called(window.s.tl, true, 'e', 'Played a Song');
+         analytics.called(window.s.tl, true, 'e', 'Played a Game');
+        analytics.track('Played a Game');
       });
     });
 


### PR DESCRIPTION
**What does this PR do?**
Adds support for a new settings which lists events which Segment Events we should track as exit links. 

**Are there breaking changes in this PR?**
Negative

**Has this been tested end-to-end? Please provide screenshots on how the fix now populates in the end tool. If not, what was done to test?**
<img width="999" alt="screen shot 2018-12-13 at 10 47 48 am" src="https://user-images.githubusercontent.com/11635476/49960224-90bab380-fec4-11e8-8ed9-9ab072acd654.png">

**Any background context you want to provide?**


**Is there parity with the server-side/android/iOS integration (if applicable)?**
Will update with SS PR.

**Does this require a metadata change? If so, please link the PR from https://github.com/segmentio/destination-scripts.**


**What are the relevant tickets?**
https://segment.atlassian.net/browse/FCD-70

**Link to CC ticket**
TODO

**List all the tests accounts you have used to make sure this change works**


**Helpful Docs**

