### PR TITLE
support quora events

### DIFF
--- a/integrations/quora-conversion-pixel/lib/index.js
+++ b/integrations/quora-conversion-pixel/lib/index.js
@@ -1,44 +1,49 @@
-'use strict'
+'use strict';
 
 /**
  * Module dependencies.
  */
 
-var integration = require('@segment/analytics.js-integration')
+var integration = require('@segment/analytics.js-integration');
+var each = require('@ndhoule/each');
 
 /**
  * Expose `Quora Conversion Pixel` integration.
  */
 
-var Quora = module.exports = integration('Quora Conversion Pixel')
+var Quora = (module.exports = integration('Quora Conversion Pixel')
   .global('qp')
   .option('writeKey', '')
   .option('trackEvents', [])
-  .tag('<script src="https://a.quora.com/qevents.js"></script>')
+  .mapping('events')
+  .tag('<script src="https://a.quora.com/qevents.js"></script>'));
 
-Quora.prototype.initialize = function () {
+Quora.prototype.initialize = function() {
   // We require a write key to run this integration.
-  if (!this.options.writeKey) return
+  if (!this.options.writeKey) return;
 
   (function () {if(window.qp) return; var n=window.qp=function(){n.qp?n.qp.apply(n,arguments):n.queue.push(arguments);}; n.queue=[];})() // eslint-disable-line
 
-  this.load(this.ready)
-  window.qp('init', this.options.writeKey)
-  window.qp('track', 'ViewContent')
-}
+  this.load(this.ready);
+  window.qp('init', this.options.writeKey);
+  window.qp('track', 'ViewContent');
+};
 
-Quora.prototype.loaded = function () {
-  return window.qp
-  //return !!(window.qp && window.qp.uuid)
-}
+Quora.prototype.loaded = function() {
+  return window.qp;
+};
 
-Quora.prototype.track = function (track) {
-  // Right now, Quora only supports a single kind of track event. If the user wants a specific event name to fire it, then do so.
-  for (var i = 0; i < this.options.trackEvents.length; i++) {
-    var currentPermittedEvent = this.options.trackEvents[i]
-    if (currentPermittedEvent.toLowerCase() === track.event().toLowerCase()) {
-      window.qp('track', 'Generic')
-      return
+Quora.prototype.track = function(track) {
+  each(function(e) {
+    window.qp('track', e);
+  }, this.events(track.event()));
+
+  // Historically, Quora only supported a single kind of track event (Generic)
+  // We allowed the user to map any number of events to that Generic type
+  // We'll remove this after migrating existing `trackEvents` into `events` setting
+  each(function(e) {
+    if (e.toLowerCase() === track.event().toLowerCase()) {
+      window.qp('track', 'Generic');
     }
-  }
-}
+  }, this.options.trackEvents);
+};

--- a/integrations/quora-conversion-pixel/package.json
+++ b/integrations/quora-conversion-pixel/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@segment/analytics.js-integration": "^2.1.0",
+    "@ndhoule/each": "^2.0.1",
     "global-queue": "^1.0.1"
   },
   "devDependencies": {

--- a/integrations/quora-conversion-pixel/test/index.test.js
+++ b/integrations/quora-conversion-pixel/test/index.test.js
@@ -1,66 +1,107 @@
-'use strict'
+'use strict';
 
-var Analytics = require('@segment/analytics.js-core').constructor
-var integration = require('@segment/analytics.js-integration')
-var tester = require('@segment/analytics.js-integration-tester')
-var sandbox = require('@segment/clear-env')
-var Quora = require('../lib/')
+var Analytics = require('@segment/analytics.js-core').constructor;
+var integration = require('@segment/analytics.js-integration');
+var tester = require('@segment/analytics.js-integration-tester');
+var sandbox = require('@segment/clear-env');
+var Quora = require('../lib/');
 
-describe('Quora', function () {
-  var analytics
-  var quora
+describe('Quora', function() {
+  var analytics;
+  var quora;
   var options = {
-    writeKey: 'fde52bd8df46412bad5fb5ceff512dc1' // Destinations testing account
-  }
+    writeKey: 'fde52bd8df46412bad5fb5ceff512dc1', // Destinations testing account
+    trackEvents: ['order completed'],
+    events: {
+      randomEvent: 'Generate Lead',
+      'booking completed': 'Purchase',
+      search: 'Search'
+    }
+  };
 
-  beforeEach(function () {
-    analytics = new Analytics()
-    quora = new Quora(options)
-    analytics.use(Quora)
-    analytics.use(tester)
-    analytics.add(quora)
-  })
+  beforeEach(function() {
+    analytics = new Analytics();
+    quora = new Quora(options);
+    analytics.use(Quora);
+    analytics.use(tester);
+    analytics.add(quora);
+  });
 
-  afterEach(function () {
-    analytics.restore()
-    analytics.reset()
-    quora.reset()
-    sandbox()
-  })
+  afterEach(function() {
+    analytics.restore();
+    analytics.reset();
+    quora.reset();
+    sandbox();
+  });
 
-  it('should have the right settings', function () {
-    analytics.compare(Quora, integration('Quora Conversion Pixel')
-      .option('writeKey', ''))
-  })
+  it('should have the right settings', function() {
+    analytics.compare(
+      Quora,
+      integration('Quora Conversion Pixel').option('writeKey', '')
+    );
+  });
 
-  describe('before loading', function () {
-    beforeEach(function () {
-      analytics.stub(quora, 'load')
-    })
+  describe('before loading', function() {
+    beforeEach(function() {
+      analytics.stub(quora, 'load');
+    });
 
-    describe('#initialize', function () {
-      it('should call #load', function () {
-        analytics.initialize()
-        analytics.page()
-        analytics.called(quora.load)
-      })
-    })
-  })
+    describe('#initialize', function() {
+      it('should call #load', function() {
+        analytics.initialize();
+        analytics.page();
+        analytics.called(quora.load);
+      });
+    });
+  });
 
-  describe('loading', function () {
-    it('should load', function (done) {
+  describe('loading', function() {
+    it('should load', function(done) {
       // We can't use analytics.load directly
-      analytics.assert(!quora.loaded(), 'Expected `integration.loaded()` to be false before loading.');
+      analytics.assert(
+        !quora.loaded(),
+        'Expected `integration.loaded()` to be false before loading.'
+      );
       analytics.once('ready', function() {
         try {
-          analytics.assert(quora.loaded(), 'Expected `integration.loaded()` to be true after loading.');    
+          analytics.assert(
+            quora.loaded(),
+            'Expected `integration.loaded()` to be true after loading.'
+          );
           done();
         } catch (err) {
-          done(err)
+          done(err);
         }
       });
       analytics.initialize();
       analytics.page({}, { Marketo: true });
-    })
-  })
-})
+    });
+  });
+
+  describe('after loading', function() {
+    beforeEach(function(done) {
+      analytics.once('ready', done);
+      analytics.initialize();
+    });
+
+    describe('#track', function() {
+      beforeEach(function() {
+        analytics.stub(window, 'qp');
+      });
+
+      describe('generic events', function() {
+        it('should fire generic events for old setting', function() {
+          analytics.track('order completed');
+          analytics.called(window.qp, 'track', 'Generic');
+        });
+      });
+
+      describe('event mapping', function() {
+        it('should fire mapped events for new setting', function() {
+          analytics.track('booking completed');
+          analytics.called(window.qp, 'track', 'Purchase');
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
**What does this PR do?**
Quora has [added support](https://business.quora.com/Enhanced-conversion-and-attribution-tracking-for-Quora-Ads) for additional "standard" events like Facebook beyond "Generic."
<img width="677" alt="screenshot 2018-12-13 16 53 28" src="https://user-images.githubusercontent.com/3130232/49976648-aac1b980-fef7-11e8-80a7-c2f179fdc6b6.png">

They can *only* accept events that map to these conversion categories. They have no concept of event properties and they don't accept "custom events".

![image](https://user-images.githubusercontent.com/3130232/49976367-6d106100-fef6-11e8-8238-76c4c6e95a75.png)

We already support listing events that you wanted to send as a "Generic" conversion. **This pull requests adds additional support for a new setting to map Segment events to new Quora Custom Conversion Categories.**

Proposed roll out:
1. Add "events" map type setting to the destination with values matching the possible values (values will be the same as the image above with spaces removed)
2. Deploy this addititive code path that separately handles the new events setting stuff
3. Run a [migration]() to port the old `trackEvents`  to the new setting field (for all users with any generic trackEvents, add a mapping entry for that event name to "Generic") and delete 
4. Delete the trackEvents setting type from the destination definition. (Is this possible with partner portal?)
4. Ship another update here to remove the now-dead code path.

Crucially — I have no idea how to release analytics.js integrations and am not confident owning the execution of these migrations and deployments. So the Destinations team may choose to ignore this PR in the case that they don't have bandwidth to prioritize support for it!

(total aside — eslint was yelling at me so i fixed this with prettier. if you'd prefer i revert that to focus on the actual change (see the `track` method and the added `track` tests).

**Are there breaking changes in this PR?**
No.

**Has this been tested end-to-end? Please provide screenshots on how the fix now populates in the end tool. If not, what was done to test?**
No. I need to work with the team to determine and execute our process for that. 

**Any background context you want to provide?**
This is meant to unblock quora from deploying the "enable with segment" button on their site and convince them to actively refer us customers (as they used to, but now refuse to).

**Is there parity with the server-side/android/iOS integration (if applicable)?**
N/A

**Does this require a metadata change? If so, please link the PR from https://github.com/segmentio/destination-scripts.**

Linked above.

**What are the relevant tickets?**

Jira ticket to come.

**Link to CC ticket**

Jira ticket to come.

**List all the tests accounts you have used to make sure this change works**

None yet. 

