### PR TITLE
HubSpot: Add setPagePath setting support

### DIFF
--- a/integrations/hubspot/lib/index.js
+++ b/integrations/hubspot/lib/index.js
@@ -20,6 +20,7 @@ var HubSpot = (module.exports = integration('HubSpot')
   .global('hbspt')
   .option('portalId', null)
   .option('loadFormsSdk', false)
+  .option('setPagePath', false)
   .tag(
     'lib',
     '<script id="hs-analytics" src="https://js.hs-analytics.net/analytics/{{ cacheBuster }}/{{ portalId }}.js">'
@@ -71,7 +72,11 @@ HubSpot.prototype.loaded = function() {
  * @param {Page} page
  */
 
-HubSpot.prototype.page = function() {
+HubSpot.prototype.page = function(page) {
+  if (this.options.setPagePath) {
+    push('setPath', page.path());
+  }
+
   push('trackPageView');
 };
 

--- a/integrations/hubspot/test/index.test.js
+++ b/integrations/hubspot/test/index.test.js
@@ -38,6 +38,7 @@ describe('HubSpot', function() {
         .global('hbspt')
         .option('loadFormsSdk', false)
         .option('portalId', null)
+        .option('setPagePath', false)
     );
   });
 
@@ -275,6 +276,19 @@ describe('HubSpot', function() {
 
       it('should send a page view', function() {
         analytics.page();
+        analytics.called(window._hsq.push, ['trackPageView']);
+      });
+
+      it('should set the page path', function() {
+        hubspot.options.setPagePath = true;
+        analytics.page({ path: '/my-path' });
+        analytics.called(window._hsq.push, ['setPath', '/my-path']);
+        analytics.called(window._hsq.push, ['trackPageView']);
+      });
+
+      it('should not set the page path', function() {
+        analytics.page({ path: '/my-path' });
+        analytics.didNotCall(window._hsq.push, ['setPath', '/my-path']);
         analytics.called(window._hsq.push, ['trackPageView']);
       });
     });


### PR DESCRIPTION
**What does this PR do?**
Adds support for a Set Page Path setting. The setting was introduced for backward compatibility. If the setting is enabled we explicitly set the path in HubSpot's SDK.

**Are there breaking changes in this PR?**
NO

**Has this been tested end-to-end? Please provide screenshots on how the fix now populates in the end tool. If not, what was done to test?**
TODO

**Any background context you want to provide?**


**Is there parity with the server-side/android/iOS integration (if applicable)?**


**Does this require a metadata change? If so, please link the PR from https://github.com/segmentio/destination-scripts.**


**What are the relevant tickets?**


**Link to CC ticket**
TODO

**List all the tests accounts you have used to make sure this change works**


**Helpful Docs**

