### PR TITLE
enabled enhanced match by intercepting the identify call

### DIFF
--- a/integrations/pinterest-tag/lib/index.js
+++ b/integrations/pinterest-tag/lib/index.js
@@ -36,6 +36,16 @@ Pinterest.prototype.loaded = function () {
   return !!(window.pintrk && window.pintrk.queue && window.pintrk.queue.push !== Array.prototype.push)
 }
 
+Pinterest.prototype.identify = function (identify) {
+  // If we have an email then enable Enhanced Match feature by reloading the Pinterest library. 
+  // TODO: We may want to add a toggle in the Pinterest integration UI as a configuration to enable enhanced match
+  if (identify.email()) {
+    pintrk('load', this.options.tid, {
+      em: identify.email(),
+    })
+  }
+}
+
 Pinterest.prototype.page = function (page) {
   // If we have a category, the use ViewCategory. Otherwise, use a normal PageVisit.
   if (page.category()) {


### PR DESCRIPTION
**What does this PR do?**
Enables Pinterest Enhanced Match feature by sending an email address to the pinterest load function

**Are there breaking changes in this PR?**
Since this requires re-loading the Pinterest library, not sure of the unintended consequences.  Need to isolate this to a given customer;s workspace for testing.  

**Has this been tested end-to-end? Please provide screenshots on how the fix now populates in the end tool. If not, what was done to test?**
No

**Any background context you want to provide?**
Ritual, a Segment customer, needs enhanced match to improve their conversion tracking on Pinterest especially when the Pinterest 3rd party cookie is not available.  This requires passing the user's email to Pinterest during an identify call.  

**Is there parity with the server-side/android/iOS integration (if applicable)?**
N/A

**Does this require a metadata change? If so, please link the PR from https://github.com/segmentio/destination-scripts.**


**What are the relevant tickets?**


**Link to CC ticket**


**List all the tests accounts you have used to make sure this change works**


**Helpful Docs**
https://help.pinterest.com/en/business/article/track-conversions-with-pinterest-tag
