### PR TITLE
Woopra set context

### DIFF
--- a/integrations/woopra/lib/index.js
+++ b/integrations/woopra/lib/index.js
@@ -43,7 +43,7 @@ var Woopra = (module.exports = integration('Woopra')
 
 Woopra.prototype.initialize = function() {
   /* eslint-disable */
-  (function(){var i, s, z, w = window, d = document, a = arguments, q = 'script', f = ['config', 'track', 'identify', 'visit', 'push', 'call'], c = function(){var i, self = this; self._e = []; for (i = 0; i < f.length; i++){(function(f){self[f] = function(){self._e.push([f].concat(Array.prototype.slice.call(arguments, 0))); return self; }; })(f[i]); } }; w._w = w._w || {}; for (i = 0; i < a.length; i++){ w._w[a[i]] = w[a[i]] = w[a[i]] || new c(); } })('woopra');
+  (function () { var i, s, z, w = window, d = document, a = arguments, q = 'script', f = ['config', 'track', 'identify', 'visit', 'push', 'call'], c = function () { var i, self = this; self._e = []; for (i = 0; i < f.length; i++) { (function (f) { self[f] = function () { self._e.push([f].concat(Array.prototype.slice.call(arguments, 0))); return self; }; })(f[i]); } }; w._w = w._w || {}; for (i = 0; i < a.length; i++) { w._w[a[i]] = w[a[i]] = w[a[i]] || new c(); } })('woopra');
   /* eslint-enable */
 
   this.load(this.ready);
@@ -72,6 +72,8 @@ Woopra.prototype.loaded = function() {
  */
 
 Woopra.prototype.page = function(page) {
+  setContext(page);
+
   var props = page.properties();
   var name = page.fullName();
   if (name) props.title = name;
@@ -85,6 +87,8 @@ Woopra.prototype.page = function(page) {
  */
 
 Woopra.prototype.identify = function(identify) {
+  setContext(identify);
+
   var traits = identify.traits();
 
   // Woopra likes timestamps in milliseconds
@@ -107,12 +111,8 @@ Woopra.prototype.identify = function(identify) {
  */
 
 Woopra.prototype.track = function(track) {
-  var properties = track.properties();
-  if (!properties.context) {
-    properties.context = track.options();
-  }
-
-  window.woopra.track(track.event(), stringifyNested(properties));
+  setContext(track);
+  window.woopra.track(track.event(), stringifyNested(track.properties()));
 };
 
 /**
@@ -139,4 +139,12 @@ function stringifyNested(obj) {
     {},
     obj
   );
+}
+
+function setContext(event) {
+  var options = event.options();
+  if (!options) {
+    return;
+  }
+  window.woopra.config({ context: options });
 }

--- a/integrations/woopra/lib/index.js
+++ b/integrations/woopra/lib/index.js
@@ -143,8 +143,7 @@ function stringifyNested(obj) {
 
 function setContext(event) {
   var options = event.options();
-  if (!options) {
-    return;
+  if (options) {
+    window.woopra.config({ context: options });
   }
-  window.woopra.config({ context: options });
 }

--- a/integrations/woopra/package.json
+++ b/integrations/woopra/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-woopra",
   "description": "The Woopra analytics.js integration.",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/woopra/test/index.test.js
+++ b/integrations/woopra/test/index.test.js
@@ -136,12 +136,7 @@ describe('Woopra', function() {
           referrer: document.referrer,
           title: document.title,
           search: window.location.search,
-          url:
-            window.location.protocol +
-            '//' +
-            window.location.hostname +
-            (window.location.port ? ':' + window.location.port : '') +
-            window.location.pathname
+          url: windowURL()
         });
       });
 
@@ -152,12 +147,7 @@ describe('Woopra', function() {
           path: window.location.pathname,
           referrer: document.referrer,
           search: window.location.search,
-          url:
-            window.location.protocol +
-            '//' +
-            window.location.hostname +
-            (window.location.port ? ':' + window.location.port : '') +
-            window.location.pathname
+          url: windowURL()
         });
       });
 
@@ -169,12 +159,7 @@ describe('Woopra', function() {
           path: window.location.pathname,
           referrer: document.referrer,
           search: window.location.search,
-          url:
-            window.location.protocol +
-            '//' +
-            window.location.hostname +
-            (window.location.port ? ':' + window.location.port : '') +
-            window.location.pathname
+          url: windowURL()
         });
       });
 
@@ -187,13 +172,13 @@ describe('Woopra', function() {
           path: window.location.pathname,
           referrer: document.referrer,
           search: window.location.search,
-          url:
-            window.location.protocol +
-            '//' +
-            window.location.hostname +
-            (window.location.port ? ':' + window.location.port : '') +
-            window.location.pathname
+          url: windowURL()
         });
+      });
+
+      it('context is set', function() {
+        analytics.page('name', { title: 'hello' });
+        assertContext(analytics, 'hello');
       });
     });
 
@@ -237,6 +222,10 @@ describe('Woopra', function() {
           testdate: 1446628822000
         });
       });
+
+      it('context is set', function() {
+        assertContext(analytics, '');
+      });
     });
 
     describe('#track', function() {
@@ -252,24 +241,7 @@ describe('Woopra', function() {
       it('should send properties', function() {
         analytics.track('event', { property: 'Property' });
         analytics.called(window.woopra.track, 'event', {
-          property: 'Property',
-          context: {
-            page: {
-              path: window.location.pathname,
-              referrer: document.referrer,
-              search: window.location.search,
-              title: document.title,
-              url: windowURL()
-            }
-          }
-        });
-      });
-
-      it('should not override context', function() {
-        analytics.track('event', { property: 'Property', context: {} });
-        analytics.called(window.woopra.track, 'event', {
-          property: 'Property',
-          context: {}
+          property: 'Property'
         });
       });
 
@@ -290,17 +262,12 @@ describe('Woopra', function() {
         analytics.called(window.woopra.track, 'event', {
           products:
             '[{"sku":"45790-32","name":"Monopoly: 3rd Edition"},{"sku":"46493-32","name":"Uno Card Game"}]',
-          orderId: 1,
-          context: {
-            page: {
-              path: window.location.pathname,
-              referrer: document.referrer,
-              search: window.location.search,
-              title: document.title,
-              url: windowURL()
-            }
-          }
+          orderId: 1
         });
+      });
+
+      it('context is set', function() {
+        assertContext(analytics, '');
       });
     });
   });
@@ -314,4 +281,18 @@ function windowURL() {
     (window.location.port ? ':' + window.location.port : '') +
     window.location.pathname
   );
+}
+
+function assertContext(analytics, pageTitle) {
+  var ctx = window.woopra.config().context;
+
+  analytics.deepEqual(ctx, {
+    page: {
+      path: '/context.html',
+      referrer: document.referrer,
+      search: '',
+      title: pageTitle,
+      url: windowURL()
+    }
+  });
 }


### PR DESCRIPTION
**What does this PR do?**
This PR set Woopra event context properly.

**Are there breaking changes in this PR?**
No

**Has this been tested end-to-end? Please provide screenshots on how the fix now populates in the end tool. If not, what was done to test?**
See below.

**Any background context you want to provide?**
From conversation with Woopra:

**Question**:

I tried it and put a log to ensure that the context is populated in the config.

![screen shot 2019-03-04 at 12 22 00 pm](https://user-images.githubusercontent.com/2692731/53767105-956e8280-3e89-11e9-8380-44f71ff1a4ef.png)

Tough, look like the context is not passed as a query parameter when I’m sending a track event right after the config call:
![screen shot 2019-03-04 at 12 22 51 pm](https://user-images.githubusercontent.com/2692731/53767119-9e5f5400-3e89-11e9-972a-ca4c351e79e1.png)
Is it expected?

**Answer**:

Hi Maxence, 
Yes it makes perfect sense, we will be rolling out a new tracker script shortly that would pass it, we have our segment customers using the new tracker script already. So we should be fine.
Thank you.


**Is there parity with the server-side/android/iOS integration (if applicable)?**
This ensures parity with server side.

**Does this require a metadata change? If so, please link the PR from https://github.com/segmentio/destination-scripts.**
No

**What are the relevant tickets?**
https://segment.atlassian.net/browse/FCD-405

**Link to CC ticket**


**List all the tests accounts you have used to make sure this change works**


**Helpful Docs**