### PR TITLE
Prateek/enhanced match pinterest

### DIFF
--- a/integrations/pinterest-tag/HISTORY.md
+++ b/integrations/pinterest-tag/HISTORY.md
@@ -1,3 +1,8 @@
+1.1.0 / 2019-03-20
+==================
+
+  * Enables Pinterest Enhanced Match feature by sending an email address to the pinterest load function
+
 1.0.2 / 2017-12-04
 ==================
 

--- a/integrations/pinterest-tag/lib/index.js
+++ b/integrations/pinterest-tag/lib/index.js
@@ -1,78 +1,80 @@
-'use strict'
+'use strict';
 
 /**
  * Module dependencies.
  */
 
-var integration = require('@segment/analytics.js-integration')
-var analyticsEvents = require('analytics-events')
+var integration = require('@segment/analytics.js-integration');
+var analyticsEvents = require('analytics-events');
 
 /**
  * Expose `Pinterest` integration.
  */
 
-var Pinterest = module.exports = integration('Pinterest Tag')
+var Pinterest = (module.exports = integration('Pinterest Tag')
   .global('pintrk')
   .option('tid', '')
   .option('pinterestCustomProperties', [])
   .mapping('pinterestEventMapping')
-  .tag('<script src="https://s.pinimg.com/ct/core.js"></script>')
+  .tag('<script src="https://s.pinimg.com/ct/core.js"></script>'));
 
-Pinterest.prototype.initialize = function () {
+Pinterest.prototype.initialize = function() {
   // We require a Tag ID to run this integration.
-  if (!this.options.tid) return
+  if (!this.options.tid) return;
 
   // Preparation for loading the Pinterest script.
   (function(e){if(!window.pintrk){window.pintrk=function(){window.pintrk.queue.push(Array.prototype.slice.call(arguments))};var n=window.pintrk;n.queue=[],n.version="3.0";}})(); // eslint-disable-line
 
-  this.load(this.ready)
-  pintrk('load', this.options.tid)
-  pintrk('page') // This is treated semantically different than our own page implementation.
+  this.load(this.ready);
+  window.pintrk('load', this.options.tid);
+  window.pintrk('page'); // This is treated semantically different than our own page implementation.
 
-  this.createPropertyMapping()
-}
+  this.createPropertyMapping();
+};
 
-Pinterest.prototype.loaded = function () {
-  return !!(window.pintrk && window.pintrk.queue && window.pintrk.queue.push !== Array.prototype.push)
-}
+Pinterest.prototype.loaded = function() {
+  return !!(window.pintrk && window.pintrk.queue);
+};
 
-Pinterest.prototype.identify = function (identify) {
+Pinterest.prototype.identify = function(identify) {
   // If we have an email then enable Enhanced Match feature by reloading the Pinterest library.
   // TODO: We may want to add a toggle in the Pinterest integration UI as a configuration to enable enhanced match
   if (identify.email()) {
-    pintrk('load', this.options.tid, {
-      em: identify.email(),
-    })
+    window.pintrk('load', this.options.tid, {
+      em: identify.email()
+    });
   }
-}
+};
 
-Pinterest.prototype.page = function (page) {
+Pinterest.prototype.page = function(page) {
   // If we have a category, the use ViewCategory. Otherwise, use a normal PageVisit.
   if (page.category()) {
-    pintrk('track', 'ViewCategory', {
+    window.pintrk('track', 'ViewCategory', {
       category: page.category(),
       name: page.name() || ''
-    })
+    });
   } else {
-    pintrk('track', 'PageVisit', {
+    window.pintrk('track', 'PageVisit', {
       name: page.name() || ''
-    })
+    });
   }
-}
+};
 
-Pinterest.prototype.track = function (track) {
+Pinterest.prototype.track = function(track) {
   // Send a Pinterest Event if mapped. Otherwise, send the call as-is.
-  var segmentEvent = track.event()
-  var pinterestEvent = this.getPinterestEvent(segmentEvent)
-  var pinterestObject = this.generatePropertiesObject(track)
+  var segmentEvent = track.event();
+  var pinterestEvent = this.getPinterestEvent(segmentEvent);
+  var pinterestObject = this.generatePropertiesObject(track);
 
-  pinterestEvent ? pintrk('track', pinterestEvent, pinterestObject) : pintrk('track', segmentEvent, pinterestObject)
-}
+  pinterestEvent
+    ? window.pintrk('track', pinterestEvent, pinterestObject)
+    : window.pintrk('track', segmentEvent, pinterestObject);
+};
 
-Pinterest.prototype.getPinterestEvent = function (segmentEvent) {
+Pinterest.prototype.getPinterestEvent = function(segmentEvent) {
   for (var mappedEvent in this.options.pinterestEventMapping) {
     if (mappedEvent.toLowerCase() === segmentEvent.toLowerCase()) {
-      return this.options.pinterestEventMapping[mappedEvent]
+      return this.options.pinterestEventMapping[mappedEvent];
     }
   }
 
@@ -83,96 +85,100 @@ Pinterest.prototype.getPinterestEvent = function (segmentEvent) {
     [analyticsEvents.productAdded, 'AddToCart'],
     [analyticsEvents.orderCompleted, 'Checkout'],
     [analyticsEvents.videoPlaybackStarted, 'WatchVideo']
-  ]
+  ];
 
   for (var index in eventMap) {
-    var eventRegex = eventMap[index][0]
-    var pinterestEvent = eventMap[index][1]
+    if (!eventMap.hasOwnProperty(index)) continue;
+    var eventRegex = eventMap[index][0];
+    var pinterestEvent = eventMap[index][1];
 
     if (eventRegex.test(segmentEvent)) {
-      return pinterestEvent
+      return pinterestEvent;
     }
   }
-}
+};
 
 /**
  * Generate the property mappings for the integration. Account for product information being nested in a `products` array.
  */
 
-Pinterest.prototype.createPropertyMapping = function () {
+Pinterest.prototype.createPropertyMapping = function() {
   this.propertyMap = {
     // Segment Property: Pinterest Property
-    'query': 'search_query',
-    'order_id': 'order_id',
-    'coupon': 'coupon',
-    'value': 'value',
-    'currency': 'currency'
-  }
+    query: 'search_query',
+    order_id: 'order_id',
+    coupon: 'coupon',
+    value: 'value',
+    currency: 'currency'
+  };
 
   // This is a second map to allow us to loop over specific potentially-nested properties.
   this.productPropertyMap = {
     // Segment Property: Pinterest Property
-    'name': 'product_name',
-    'product_id': 'product_id',
-    'sku': 'product_id',
-    'category': 'product_category',
-    'variant': 'product_variant',
-    'price': 'product_price',
-    'quantity': 'product_quantity',
-    'brand': 'product_brand'
-  }
-}
+    name: 'product_name',
+    product_id: 'product_id',
+    sku: 'product_id',
+    category: 'product_category',
+    variant: 'product_variant',
+    price: 'product_price',
+    quantity: 'product_quantity',
+    brand: 'product_brand'
+  };
+};
 
 /**
  * Fill our Properties for the pintrk() call.
  */
 
-Pinterest.prototype.generatePropertiesObject = function (track) {
+Pinterest.prototype.generatePropertiesObject = function(track) {
   // Generate the properties object to send with the call.
-  var pinterestProps = {}
-  var trackValue
+  var pinterestProps = {};
+  var trackValue;
   for (var prop in this.propertyMap) {
-    trackValue = track.proxy('properties.' + prop)
-    if (trackValue) pinterestProps[this.propertyMap[prop]] = trackValue
+    if (!this.propertyMap.hasOwnProperty(prop)) continue;
+    trackValue = track.proxy('properties.' + prop);
+    if (trackValue) pinterestProps[this.propertyMap[prop]] = trackValue;
   }
 
   // Determine if there's a 'products' Array, then add in the specific features on that decision.
-  var products = track.proxy('properties.products')
-  var lineItemsArray
+  var products = track.proxy('properties.products');
+  var lineItemsArray;
   if (Array.isArray(products)) {
-    lineItemsArray = []
+    lineItemsArray = [];
     for (var i = 0; i < products.length; i++) {
       for (prop in this.productPropertyMap) {
-        trackValue = products[i][prop]
+        if (!this.productPropertyMap.hasOwnProperty(prop)) continue;
+        trackValue = products[i][prop];
         if (trackValue) {
           // Product values are added into a `line_items` array, with a nested object. If that doesn't exist, make it first.
-          if (lineItemsArray[i] === undefined) lineItemsArray[i] = {}
-          lineItemsArray[i][this.productPropertyMap[prop]] = trackValue
+          if (lineItemsArray[i] === undefined) lineItemsArray[i] = {};
+          lineItemsArray[i][this.productPropertyMap[prop]] = trackValue;
         }
       }
     }
-    if (lineItemsArray.length) pinterestProps['line_items'] = lineItemsArray
+    if (lineItemsArray.length) pinterestProps.line_items = lineItemsArray;
   } else {
     // There will only be a single layer, since we have, at most, one product.
-    lineItemsArray = [{}]
-    var propAdded = false
+    lineItemsArray = [{}];
+    var propAdded = false;
     for (prop in this.productPropertyMap) {
-      trackValue = track.proxy('properties.' + prop)
+      if (!this.productPropertyMap.hasOwnProperty(prop)) continue;
+      trackValue = track.proxy('properties.' + prop);
       if (trackValue) {
-        lineItemsArray[0][this.productPropertyMap[prop]] = trackValue
-        propAdded = true
+        lineItemsArray[0][this.productPropertyMap[prop]] = trackValue;
+        propAdded = true;
       }
     }
-    if (propAdded) pinterestProps['line_items'] = lineItemsArray
+    if (propAdded) pinterestProps.line_items = lineItemsArray;
   }
 
   // Finally, add in any custom properties defined by the user.
-  var customProps = this.options.pinterestCustomProperties
+  var customProps = this.options.pinterestCustomProperties;
   for (var j = 0; j < customProps.length; j++) {
-    prop = customProps[j]
-    trackValue = track.proxy('properties.' + prop)
-    if (trackValue) pinterestProps[prop] = trackValue
+    prop = customProps[j];
+    trackValue = track.proxy('properties.' + prop);
+    if (trackValue) pinterestProps[prop] = trackValue;
   }
 
-  return pinterestProps
-}
+  return pinterestProps;
+};

--- a/integrations/pinterest-tag/lib/index.js
+++ b/integrations/pinterest-tag/lib/index.js
@@ -36,6 +36,16 @@ Pinterest.prototype.loaded = function () {
   return !!(window.pintrk && window.pintrk.queue && window.pintrk.queue.push !== Array.prototype.push)
 }
 
+Pinterest.prototype.identify = function (identify) {
+  // If we have an email then enable Enhanced Match feature by reloading the Pinterest library.
+  // TODO: We may want to add a toggle in the Pinterest integration UI as a configuration to enable enhanced match
+  if (identify.email()) {
+    pintrk('load', this.options.tid, {
+      em: identify.email(),
+    })
+  }
+}
+
 Pinterest.prototype.page = function (page) {
   // If we have a category, the use ViewCategory. Otherwise, use a normal PageVisit.
   if (page.category()) {

--- a/integrations/pinterest-tag/package.json
+++ b/integrations/pinterest-tag/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-pinterest-tag",
   "description": "The Pinterest Tag analytics.js integration.",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/pinterest-tag/test/index.test.js
+++ b/integrations/pinterest-tag/test/index.test.js
@@ -1,14 +1,14 @@
-'use strict'
+'use strict';
 
-var Analytics = require('@segment/analytics.js-core').constructor
-var integration = require('@segment/analytics.js-integration')
-var tester = require('@segment/analytics.js-integration-tester')
-var sandbox = require('@segment/clear-env')
-var Pinterest = require('../lib/')
+var Analytics = require('@segment/analytics.js-core').constructor;
+var integration = require('@segment/analytics.js-integration');
+var tester = require('@segment/analytics.js-integration-tester');
+var sandbox = require('@segment/clear-env');
+var Pinterest = require('../lib/');
 
-describe('Pinterest', function () {
-  var analytics
-  var pinterest
+describe('Pinterest', function() {
+  var analytics;
+  var pinterest;
   var options = {
     tid: '2620795819800',
     pinterestEventMapping: {
@@ -16,74 +16,77 @@ describe('Pinterest', function () {
       'Lead Generated': 'Lead',
       'User Signed Up': 'Signup'
     },
-    pinterestCustomProperties: [
-      'custom_prop'
-    ]
-  }
+    pinterestCustomProperties: ['custom_prop']
+  };
 
-  beforeEach(function () {
-    analytics = new Analytics()
-    pinterest = new Pinterest(options)
-    analytics.use(Pinterest)
-    analytics.use(tester)
-    analytics.add(pinterest)
-  })
+  beforeEach(function() {
+    analytics = new Analytics();
+    pinterest = new Pinterest(options);
+    analytics.use(Pinterest);
+    analytics.use(tester);
+    analytics.add(pinterest);
+  });
 
-  afterEach(function () {
-    analytics.restore()
-    analytics.reset()
-    pinterest.reset()
-    sandbox()
-  })
+  afterEach(function() {
+    analytics.restore();
+    analytics.reset();
+    pinterest.reset();
+    sandbox();
+  });
 
-  it('should have the right settings', function () {
-    analytics.compare(Pinterest, integration('Pinterest Tag')
-      .global('pintrk')
-      .mapping('pinterestEventMapping')
-      .option('pinterestCustomProperties', [])
-      .option('tid', ''))
-  })
+  it('should have the right settings', function() {
+    analytics.compare(
+      Pinterest,
+      integration('Pinterest Tag')
+        .global('pintrk')
+        .mapping('pinterestEventMapping')
+        .option('pinterestCustomProperties', [])
+        .option('tid', '')
+    );
+  });
 
-  describe('before loading', function () {
-    beforeEach(function () {
-      analytics.stub(pinterest, 'load')
-    })
+  describe('before loading', function() {
+    beforeEach(function() {
+      analytics.stub(pinterest, 'load');
+    });
 
-    describe('#initialize', function () {
-      it('should call #load', function () {
-        analytics.initialize()
-        analytics.page()
-        analytics.called(pinterest.load, 2620795819800)
-      })
-    })
-  })
+    describe('#initialize', function() {
+      it('should call #load', function() {
+        analytics.initialize();
+        analytics.page();
+        analytics.called(pinterest.load);
+      });
+    });
+  });
 
-  describe('loading', function () {
-    it('should load', function (done) {
-      analytics.load(pinterest, done)
-    })
-  })
+  describe('loading', function() {
+    it('should load', function(done) {
+      analytics.load(pinterest, done);
+    });
+  });
 
-  describe('after loading', function () {
-    beforeEach(function (done) {
-      analytics.once('ready', done)
-      analytics.initialize()
-      analytics.stub(pinterest, 'load')
-    })
+  describe('after loading', function() {
+    beforeEach(function(done) {
+      analytics.once('ready', done);
+      analytics.initialize();
+      analytics.stub(pinterest, 'load');
+    });
 
-    describe('#identify', function () {
-      beforeEach(function () {
-        analytics.stub(window, 'Pinterest')
-      })
+    describe('#identify', function() {
+      beforeEach(function() {
+        analytics.spy(window, 'pintrk');
+      });
 
-      it('should not fire the Pinterest pixel tag', function () {
-        analytics.identify()
-	analytics.didNotCall(pinterest.load)
-      })
-      it('should push Segment email to Pinterest Enhanced Match', function () {
-        analytics.identify('123', { email: 'prakash@segment.com'})
-        analytics.called(pinterest.load, 2620795819800, {em: "prakash@segment.com"})
-      })
-    })
-  })
-})
+      it('should not fire the Pinterest pixel tag', function() {
+        analytics.identify();
+        analytics.didNotCall(window.pintrk);
+      });
+      it('should push Segment email to Pinterest Enhanced Match', function() {
+        analytics.identify('123', { email: 'prakash@segment.com' });
+        analytics.called(window.pintrk, 'load', '2620795819800', {
+          em: 'prakash@segment.com'
+        });
+      });
+    });
+  });
+});

--- a/integrations/pinterest-tag/test/index.test.js
+++ b/integrations/pinterest-tag/test/index.test.js
@@ -78,12 +78,11 @@ describe('Pinterest', function () {
 
       it('should not fire the Pinterest pixel tag', function () {
         analytics.identify()
-
+	analytics.didNotCall(pinterest.load)
       })
-
       it('should push Segment email to Pinterest Enhanced Match', function () {
         analytics.identify('123', { email: 'prakash@segment.com'})
-        analytics.called(window.Pinterest)
+        analytics.called(pinterest.load)
       })
     })
   })

--- a/integrations/pinterest-tag/test/index.test.js
+++ b/integrations/pinterest-tag/test/index.test.js
@@ -53,7 +53,7 @@ describe('Pinterest', function () {
       it('should call #load', function () {
         analytics.initialize()
         analytics.page()
-        analytics.called(pinterest.load)
+        analytics.called(pinterest.load, 2620795819800)
       })
     })
   })
@@ -82,7 +82,7 @@ describe('Pinterest', function () {
       })
       it('should push Segment email to Pinterest Enhanced Match', function () {
         analytics.identify('123', { email: 'prakash@segment.com'})
-        analytics.called(pinterest.load)
+        analytics.called(pinterest.load, 2620795819800, {em: "prakash@segment.com"})
       })
     })
   })

--- a/integrations/pinterest-tag/test/index.test.js
+++ b/integrations/pinterest-tag/test/index.test.js
@@ -63,4 +63,28 @@ describe('Pinterest', function () {
       analytics.load(pinterest, done)
     })
   })
+
+  describe('after loading', function () {
+    beforeEach(function (done) {
+      analytics.once('ready', done)
+      analytics.initialize()
+      analytics.stub(pinterest, 'load')
+    })
+
+    describe('#identify', function () {
+      beforeEach(function () {
+        analytics.stub(window, 'Pinterest')
+      })
+
+      it('should not fire the Pinterest pixel tag', function () {
+        analytics.identify()
+
+      })
+
+      it('should push Segment email to Pinterest Enhanced Match', function () {
+        analytics.identify('123', { email: 'prakash@segment.com'})
+        analytics.called(window.Pinterest)
+      })
+    })
+  })
 })


### PR DESCRIPTION

What does this PR do?
Enables Pinterest Enhanced Match feature by sending an email address to the pinterest load function

Are there breaking changes in this PR?
Since this requires re-loading the Pinterest library, not sure of the unintended consequences. Need to isolate this to a given customer;s workspace for testing.

Has this been tested end-to-end? Please provide screenshots on how the fix now populates in the end tool. If not, what was done to test?
No

Any background context you want to provide?
A Segment customer needs enhanced match to improve their conversion tracking on Pinterest especially when the Pinterest 3rd party cookie is not available. This requires passing the user's email to Pinterest during an identify call.

Is there parity with the server-side/android/iOS integration (if applicable)?
N/A

Does this require a metadata change? If so, please link the PR from https://github.com/segmentio/destination-scripts.

What are the relevant tickets?

Link to CC ticket

List all the tests accounts you have used to make sure this change works

Helpful Docs
https://help.pinterest.com/en/business/article/track-conversions-with-pinterest-tag