### PR TITLE
[FB Pixel] Add deduping with server-side

### DIFF
--- a/integrations/facebook-pixel/test/index.test.js
+++ b/integrations/facebook-pixel/test/index.test.js
@@ -211,9 +211,16 @@ describe('Facebook Pixel', function() {
             team: 'Warriors'
           });
 
-          analytics.called(window.fbq, 'trackCustom', 'event', {
-            team: 'Warriors'
-          });
+          analytics.called(
+            window.fbq,
+            'trackSingleCustom',
+            options.pixelId,
+            'event',
+            {
+              team: 'Warriors'
+            },
+            { eventID: undefined }
+          );
         });
 
         it('should send whitelisted PII properties', function() {
@@ -235,10 +242,17 @@ describe('Facebook Pixel', function() {
             team: 'Warriors'
           });
 
-          analytics.called(window.fbq, 'trackCustom', 'event', {
-            team: 'Warriors',
-            country: 'USA'
-          });
+          analytics.called(
+            window.fbq,
+            'trackSingleCustom',
+            options.pixelId,
+            'event',
+            {
+              team: 'Warriors',
+              country: 'USA'
+            },
+            { eventID: undefined }
+          );
         });
 
         it('should fallback to an empty array when whitelistPiiProperties is falsy', function() {
@@ -261,23 +275,44 @@ describe('Facebook Pixel', function() {
             team: 'Warriors'
           });
 
-          analytics.called(window.fbq, 'trackCustom', 'event', {
-            team: 'Warriors'
-          });
+          analytics.called(
+            window.fbq,
+            'trackSingleCustom',
+            options.pixelId,
+            'event',
+            {
+              team: 'Warriors'
+            },
+            { eventID: undefined }
+          );
         });
       });
 
       describe('event not mapped to legacy or standard', function() {
         it('should send a "custom" event', function() {
           analytics.track('event');
-          analytics.called(window.fbq, 'trackCustom', 'event');
+          analytics.called(
+            window.fbq,
+            'trackSingleCustom',
+            options.pixelId,
+            'event',
+            {},
+            { eventID: undefined }
+          );
         });
 
         it('should send a "custom" event and properties', function() {
           analytics.track('event', { property: true });
-          analytics.called(window.fbq, 'trackCustom', 'event', {
-            property: true
-          });
+          analytics.called(
+            window.fbq,
+            'trackSingleCustom',
+            options.pixelId,
+            'event',
+            {
+              property: true
+            },
+            { eventID: undefined }
+          );
         });
 
         it('should send properties correctly', function() {
@@ -286,45 +321,83 @@ describe('Facebook Pixel', function() {
             revenue: 13,
             property: true
           });
-          analytics.called(window.fbq, 'trackCustom', 'event', {
-            currency: 'XXX',
-            value: '13.00',
-            property: true
-          });
+          analytics.called(
+            window.fbq,
+            'trackSingleCustom',
+            options.pixelId,
+            'event',
+            {
+              currency: 'XXX',
+              value: '13.00',
+              property: true
+            },
+            { eventID: undefined }
+          );
         });
       });
 
       describe('event mapped to legacy', function() {
         it('should send a correctly mapped event', function() {
           analytics.track('legacyEvent');
-          analytics.called(window.fbq, 'track', 'asdFrkj', {
-            currency: 'USD',
-            value: '0.00'
-          });
+          analytics.called(
+            window.fbq,
+            'trackSingle',
+            options.pixelId,
+            'asdFrkj',
+            {
+              currency: 'USD',
+              value: '0.00'
+            },
+            { eventID: undefined }
+          );
         });
 
         it('should send an event and properties', function() {
           analytics.track('legacyEvent', { revenue: 10 });
-          analytics.called(window.fbq, 'track', 'asdFrkj', {
-            currency: 'USD',
-            value: '10.00'
-          });
+          analytics.called(
+            window.fbq,
+            'trackSingle',
+            options.pixelId,
+            'asdFrkj',
+            {
+              currency: 'USD',
+              value: '10.00'
+            },
+            { eventID: undefined }
+          );
         });
 
         it('should send only currency and revenue', function() {
           analytics.track('legacyEvent', { revenue: 13, property: true });
-          analytics.called(window.fbq, 'track', 'asdFrkj', {
-            currency: 'USD',
-            value: '13.00'
-          });
+          analytics.called(
+            window.fbq,
+            'trackSingle',
+            options.pixelId,
+            'asdFrkj',
+            {
+              currency: 'USD',
+              value: '13.00'
+            },
+            { eventID: undefined }
+          );
         });
       });
 
       describe('event mapped to standard', function() {
-        it('should send a correctly mapped event — no required properties', function() {
-          analytics.track('standardEvent');
-          analytics.called(window.fbq, 'track', 'standard', {});
-        });
+        it(
+          'should send a correctly mapped event — no required properties',
+          function() {
+            analytics.track('standardEvent');
+            analytics.called(
+              window.fbq,
+              'trackSingle',
+              options.pixelId,
+              'standard',
+              {}
+            );
+          },
+          { eventID: undefined }
+        );
 
         it('should send properties correctly', function() {
           analytics.track('standardEvent', {
@@ -332,11 +405,18 @@ describe('Facebook Pixel', function() {
             revenue: 13,
             property: true
           });
-          analytics.called(window.fbq, 'track', 'standard', {
-            currency: 'XXX',
-            value: '13.00',
-            property: true
-          });
+          analytics.called(
+            window.fbq,
+            'trackSingle',
+            options.pixelId,
+            'standard',
+            {
+              currency: 'XXX',
+              value: '13.00',
+              property: true
+            },
+            { eventID: undefined }
+          );
         });
 
         it('should default currency to USD if mapped to "Purchase"', function() {
@@ -344,11 +424,18 @@ describe('Facebook Pixel', function() {
             revenue: 13,
             property: true
           });
-          analytics.called(window.fbq, 'track', 'Purchase', {
-            currency: 'USD',
-            value: '13.00',
-            property: true
-          });
+          analytics.called(
+            window.fbq,
+            'trackSingle',
+            options.pixelId,
+            'Purchase',
+            {
+              currency: 'USD',
+              value: '13.00',
+              property: true
+            },
+            { eventID: undefined }
+          );
         });
         describe('Dyanmic Ads for Travel date parsing', function() {
           it('should correctly pass in iso8601 formatted date objects', function() {
@@ -356,9 +443,16 @@ describe('Facebook Pixel', function() {
               checkin_date: '2017-07-01T20:03:46Z'
             });
 
-            analytics.called(window.fbq, 'track', 'Search', {
-              checkin_date: '2017-07-01'
-            });
+            analytics.called(
+              window.fbq,
+              'trackSingle',
+              options.pixelId,
+              'Search',
+              {
+                checkin_date: '2017-07-01'
+              },
+              { eventID: undefined }
+            );
           });
 
           it('should pass through strings that we did not recognize as dates as-is', function() {
@@ -366,9 +460,16 @@ describe('Facebook Pixel', function() {
               checkin_date: '2017-06-23T15:30:00GMT'
             });
 
-            analytics.called(window.fbq, 'track', 'Search', {
-              checkin_date: '2017-06-23T15:30:00GMT'
-            });
+            analytics.called(
+              window.fbq,
+              'trackSingle',
+              options.pixelId,
+              'Search',
+              {
+                checkin_date: '2017-06-23T15:30:00GMT'
+              },
+              { eventID: undefined }
+            );
           });
         });
       });
@@ -402,18 +503,35 @@ describe('Facebook Pixel', function() {
             }
           ]
         });
-        analytics.called(window.fbq, 'track', 'ViewContent', {
-          content_ids: ['507f1f77bcf86cd799439011', '505bd76785ebb509fc183733'],
-          content_type: ['product']
-        });
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          'ViewContent',
+          {
+            content_ids: [
+              '507f1f77bcf86cd799439011',
+              '505bd76785ebb509fc183733'
+            ],
+            content_type: ['product']
+          },
+          { eventID: undefined }
+        );
       });
 
       it('Should fallback on mapping content_ids to the product category and content_type to "product_group"', function() {
         analytics.track('Product List Viewed', { category: 'Games' });
-        analytics.called(window.fbq, 'track', 'ViewContent', {
-          content_ids: ['Games'],
-          content_type: ['product_group']
-        });
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          'ViewContent',
+          {
+            content_ids: ['Games'],
+            content_type: ['product_group']
+          },
+          { eventID: undefined }
+        );
       });
 
       it('should send the custom content type if mapped', function() {
@@ -440,10 +558,20 @@ describe('Facebook Pixel', function() {
             }
           ]
         });
-        analytics.called(window.fbq, 'track', 'ViewContent', {
-          content_ids: ['507f1f77bcf86cd799439011', '505bd76785ebb509fc183733'],
-          content_type: ['vehicle']
-        });
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          'ViewContent',
+          {
+            content_ids: [
+              '507f1f77bcf86cd799439011',
+              '505bd76785ebb509fc183733'
+            ],
+            content_type: ['vehicle']
+          },
+          { eventID: undefined }
+        );
       });
 
       it('should send a legacy event', function() {
@@ -451,22 +579,43 @@ describe('Facebook Pixel', function() {
           'Product List Viewed': '123456'
         };
         analytics.track('Product List Viewed', { category: 'Games' });
-        analytics.called(window.fbq, 'track', 'ViewContent', {
-          content_ids: ['Games'],
-          content_type: ['product_group']
-        });
-        analytics.called(window.fbq, 'track', '123456', {
-          currency: 'USD',
-          value: '0.00'
-        });
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          'ViewContent',
+          {
+            content_ids: ['Games'],
+            content_type: ['product_group']
+          },
+          { eventID: undefined }
+        );
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          '123456',
+          {
+            currency: 'USD',
+            value: '0.00'
+          },
+          { eventID: undefined }
+        );
       });
 
       it('should default to an empty string for category', function() {
         analytics.track('Product List Viewed', { category: null });
-        analytics.called(window.fbq, 'track', 'ViewContent', {
-          content_ids: [''],
-          content_type: ['product_group']
-        });
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          'ViewContent',
+          {
+            content_ids: [''],
+            content_type: ['product_group']
+          },
+          { eventID: undefined }
+        );
       });
     });
 
@@ -485,14 +634,21 @@ describe('Facebook Pixel', function() {
           sku: 'p-298',
           value: 24.75
         });
-        analytics.called(window.fbq, 'track', 'ViewContent', {
-          content_ids: ['507f1f77bcf86cd799439011'],
-          content_type: ['product'],
-          content_name: 'my product',
-          content_category: 'cat 1',
-          currency: 'USD',
-          value: '24.75'
-        });
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          'ViewContent',
+          {
+            content_ids: ['507f1f77bcf86cd799439011'],
+            content_type: ['product'],
+            content_name: 'my product',
+            content_category: 'cat 1',
+            currency: 'USD',
+            value: '24.75'
+          },
+          { eventID: undefined }
+        );
       });
 
       it('should send a legacy event', function() {
@@ -508,18 +664,32 @@ describe('Facebook Pixel', function() {
           sku: 'p-298',
           value: 24.75
         });
-        analytics.called(window.fbq, 'track', 'ViewContent', {
-          content_ids: ['507f1f77bcf86cd799439011'],
-          content_type: ['product'],
-          content_name: 'my product',
-          content_category: 'cat 1',
-          currency: 'USD',
-          value: '24.75'
-        });
-        analytics.called(window.fbq, 'track', '123456', {
-          currency: 'USD',
-          value: '24.75'
-        });
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          'ViewContent',
+          {
+            content_ids: ['507f1f77bcf86cd799439011'],
+            content_type: ['product'],
+            content_name: 'my product',
+            content_category: 'cat 1',
+            currency: 'USD',
+            value: '24.75'
+          },
+          { eventID: undefined }
+        );
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          '123456',
+          {
+            currency: 'USD',
+            value: '24.75'
+          },
+          { eventID: undefined }
+        );
       });
 
       it('Should map properties.price to facebooks value if price is selected', function() {
@@ -534,14 +704,21 @@ describe('Facebook Pixel', function() {
           sku: 'p-298',
           value: 24.75
         });
-        analytics.called(window.fbq, 'track', 'ViewContent', {
-          content_ids: ['507f1f77bcf86cd799439011'],
-          content_type: ['product'],
-          content_name: 'my product',
-          content_category: 'cat 1',
-          currency: 'USD',
-          value: '44.33'
-        });
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          'ViewContent',
+          {
+            content_ids: ['507f1f77bcf86cd799439011'],
+            content_type: ['product'],
+            content_name: 'my product',
+            content_category: 'cat 1',
+            currency: 'USD',
+            value: '44.33'
+          },
+          { eventID: undefined }
+        );
       });
 
       it('should send the custom content type if mapped', function() {
@@ -555,14 +732,21 @@ describe('Facebook Pixel', function() {
           sku: 'p-298',
           value: 24.75
         });
-        analytics.called(window.fbq, 'track', 'ViewContent', {
-          content_ids: ['507f1f77bcf86cd799439011'],
-          content_type: ['vehicle'],
-          content_name: 'my product',
-          content_category: 'Cars',
-          currency: 'USD',
-          value: '24.75'
-        });
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          'ViewContent',
+          {
+            content_ids: ['507f1f77bcf86cd799439011'],
+            content_type: ['vehicle'],
+            content_name: 'my product',
+            content_category: 'Cars',
+            currency: 'USD',
+            value: '24.75'
+          },
+          { eventID: undefined }
+        );
       });
 
       it('should fallback to id for content_id', function() {
@@ -576,14 +760,21 @@ describe('Facebook Pixel', function() {
           sku: 'p-298',
           value: 24.75
         });
-        analytics.called(window.fbq, 'track', 'ViewContent', {
-          content_ids: ['507f1f77bcf86cd799439011'],
-          content_type: ['vehicle'],
-          content_name: 'my product',
-          content_category: 'Cars',
-          currency: 'USD',
-          value: '24.75'
-        });
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          'ViewContent',
+          {
+            content_ids: ['507f1f77bcf86cd799439011'],
+            content_type: ['vehicle'],
+            content_name: 'my product',
+            content_category: 'Cars',
+            currency: 'USD',
+            value: '24.75'
+          },
+          { eventID: undefined }
+        );
       });
 
       it('should fallback to sku for content_id', function() {
@@ -596,14 +787,21 @@ describe('Facebook Pixel', function() {
           sku: 'p-298',
           value: 24.75
         });
-        analytics.called(window.fbq, 'track', 'ViewContent', {
-          content_ids: ['p-298'],
-          content_type: ['vehicle'],
-          content_name: 'my product',
-          content_category: 'Cars',
-          currency: 'USD',
-          value: '24.75'
-        });
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          'ViewContent',
+          {
+            content_ids: ['p-298'],
+            content_type: ['vehicle'],
+            content_name: 'my product',
+            content_category: 'Cars',
+            currency: 'USD',
+            value: '24.75'
+          },
+          { eventID: undefined }
+        );
       });
 
       it('should fallback to an empty string for content_id', function() {
@@ -615,14 +813,21 @@ describe('Facebook Pixel', function() {
           category: 'Cars',
           value: 24.75
         });
-        analytics.called(window.fbq, 'track', 'ViewContent', {
-          content_ids: [''],
-          content_type: ['vehicle'],
-          content_name: 'my product',
-          content_category: 'Cars',
-          currency: 'USD',
-          value: '24.75'
-        });
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          'ViewContent',
+          {
+            content_ids: [''],
+            content_type: ['vehicle'],
+            content_name: 'my product',
+            content_category: 'Cars',
+            currency: 'USD',
+            value: '24.75'
+          },
+          { eventID: undefined }
+        );
       });
 
       it('should fallback to an empty string for content_name', function() {
@@ -635,14 +840,21 @@ describe('Facebook Pixel', function() {
           sku: 'p-298',
           value: 24.75
         });
-        analytics.called(window.fbq, 'track', 'ViewContent', {
-          content_ids: ['507f1f77bcf86cd799439011'],
-          content_type: ['vehicle'],
-          content_name: '',
-          content_category: 'Cars',
-          currency: 'USD',
-          value: '24.75'
-        });
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          'ViewContent',
+          {
+            content_ids: ['507f1f77bcf86cd799439011'],
+            content_type: ['vehicle'],
+            content_name: '',
+            content_category: 'Cars',
+            currency: 'USD',
+            value: '24.75'
+          },
+          { eventID: undefined }
+        );
       });
 
       it('should fallback to an empty string for content_category', function() {
@@ -655,14 +867,21 @@ describe('Facebook Pixel', function() {
           sku: 'p-298',
           value: 24.75
         });
-        analytics.called(window.fbq, 'track', 'ViewContent', {
-          content_ids: ['507f1f77bcf86cd799439011'],
-          content_type: ['product'],
-          content_name: 'my product',
-          content_category: '',
-          currency: 'USD',
-          value: '24.75'
-        });
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          'ViewContent',
+          {
+            content_ids: ['507f1f77bcf86cd799439011'],
+            content_type: ['product'],
+            content_name: 'my product',
+            content_category: '',
+            currency: 'USD',
+            value: '24.75'
+          },
+          { eventID: undefined }
+        );
       });
 
       it('should use price in the legacy event', function() {
@@ -679,18 +898,32 @@ describe('Facebook Pixel', function() {
           sku: 'p-298',
           value: 24.75
         });
-        analytics.called(window.fbq, 'track', 'ViewContent', {
-          content_ids: ['507f1f77bcf86cd799439011'],
-          content_type: ['product'],
-          content_name: 'my product',
-          content_category: 'cat 1',
-          currency: 'USD',
-          value: '44.33'
-        });
-        analytics.called(window.fbq, 'track', '123456', {
-          currency: 'USD',
-          value: '44.33'
-        });
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          'ViewContent',
+          {
+            content_ids: ['507f1f77bcf86cd799439011'],
+            content_type: ['product'],
+            content_name: 'my product',
+            content_category: 'cat 1',
+            currency: 'USD',
+            value: '44.33'
+          },
+          { eventID: undefined }
+        );
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          '123456',
+          {
+            currency: 'USD',
+            value: '44.33'
+          },
+          { eventID: undefined }
+        );
       });
 
       it('should not map products if its falsy', function() {
@@ -698,10 +931,17 @@ describe('Facebook Pixel', function() {
           category: 'Games',
           products: null
         });
-        analytics.called(window.fbq, 'track', 'ViewContent', {
-          content_ids: ['Games'],
-          content_type: ['product_group']
-        });
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          'ViewContent',
+          {
+            content_ids: ['Games'],
+            content_type: ['product_group']
+          },
+          { eventID: undefined }
+        );
       });
     });
 
@@ -721,14 +961,21 @@ describe('Facebook Pixel', function() {
           sku: 'p-298',
           value: 24.75
         });
-        analytics.called(window.fbq, 'track', 'AddToCart', {
-          content_ids: ['507f1f77bcf86cd799439011'],
-          content_type: ['product'],
-          content_name: 'my product',
-          content_category: 'cat 1',
-          currency: 'USD',
-          value: '24.75'
-        });
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          'AddToCart',
+          {
+            content_ids: ['507f1f77bcf86cd799439011'],
+            content_type: ['product'],
+            content_name: 'my product',
+            content_category: 'cat 1',
+            currency: 'USD',
+            value: '24.75'
+          },
+          { eventID: undefined }
+        );
       });
 
       it('should send a legacy event for product added', function() {
@@ -745,19 +992,33 @@ describe('Facebook Pixel', function() {
           value: 24.75
         });
 
-        analytics.called(window.fbq, 'track', 'AddToCart', {
-          content_ids: ['507f1f77bcf86cd799439011'],
-          content_type: ['product'],
-          content_name: 'my product',
-          content_category: 'cat 1',
-          currency: 'USD',
-          value: '24.75'
-        });
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          'AddToCart',
+          {
+            content_ids: ['507f1f77bcf86cd799439011'],
+            content_type: ['product'],
+            content_name: 'my product',
+            content_category: 'cat 1',
+            currency: 'USD',
+            value: '24.75'
+          },
+          { eventID: undefined }
+        );
 
-        analytics.called(window.fbq, 'track', '123456', {
-          currency: 'USD',
-          value: '24.75'
-        });
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          '123456',
+          {
+            currency: 'USD',
+            value: '24.75'
+          },
+          { eventID: undefined }
+        );
       });
 
       it('Should map properties.price to facebooks value if price is selected', function() {
@@ -772,14 +1033,21 @@ describe('Facebook Pixel', function() {
           sku: 'p-298',
           value: 24.75
         });
-        analytics.called(window.fbq, 'track', 'AddToCart', {
-          content_ids: ['507f1f77bcf86cd799439011'],
-          content_type: ['product'],
-          content_name: 'my product',
-          content_category: 'cat 1',
-          currency: 'USD',
-          value: '44.33'
-        });
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          'AddToCart',
+          {
+            content_ids: ['507f1f77bcf86cd799439011'],
+            content_type: ['product'],
+            content_name: 'my product',
+            content_category: 'cat 1',
+            currency: 'USD',
+            value: '44.33'
+          },
+          { eventID: undefined }
+        );
       });
 
       it('should send the custom content type if mapped', function() {
@@ -794,14 +1062,21 @@ describe('Facebook Pixel', function() {
           value: 24.75,
           content_type: 'stuff'
         });
-        analytics.called(window.fbq, 'track', 'AddToCart', {
-          content_ids: ['507f1f77bcf86cd799439011'],
-          content_type: ['vehicle'],
-          content_name: 'my product',
-          content_category: 'Cars',
-          currency: 'USD',
-          value: '24.75'
-        });
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          'AddToCart',
+          {
+            content_ids: ['507f1f77bcf86cd799439011'],
+            content_type: ['vehicle'],
+            content_name: 'my product',
+            content_category: 'Cars',
+            currency: 'USD',
+            value: '24.75'
+          },
+          { eventID: undefined }
+        );
       });
 
       it('should fallback to id for content_id', function() {
@@ -815,14 +1090,21 @@ describe('Facebook Pixel', function() {
           sku: 'p-298',
           value: 24.75
         });
-        analytics.called(window.fbq, 'track', 'AddToCart', {
-          content_ids: ['507f1f77bcf86cd799439011'],
-          content_type: ['product'],
-          content_name: 'my product',
-          content_category: 'cat 1',
-          currency: 'USD',
-          value: '24.75'
-        });
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          'AddToCart',
+          {
+            content_ids: ['507f1f77bcf86cd799439011'],
+            content_type: ['product'],
+            content_name: 'my product',
+            content_category: 'cat 1',
+            currency: 'USD',
+            value: '24.75'
+          },
+          { eventID: undefined }
+        );
       });
 
       it('should fallback to sku for content_id', function() {
@@ -835,14 +1117,21 @@ describe('Facebook Pixel', function() {
           sku: 'p-298',
           value: 24.75
         });
-        analytics.called(window.fbq, 'track', 'AddToCart', {
-          content_ids: ['p-298'],
-          content_type: ['product'],
-          content_name: 'my product',
-          content_category: 'cat 1',
-          currency: 'USD',
-          value: '24.75'
-        });
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          'AddToCart',
+          {
+            content_ids: ['p-298'],
+            content_type: ['product'],
+            content_name: 'my product',
+            content_category: 'cat 1',
+            currency: 'USD',
+            value: '24.75'
+          },
+          { eventID: undefined }
+        );
       });
 
       it('should fallback to an empty string for content_id', function() {
@@ -854,14 +1143,21 @@ describe('Facebook Pixel', function() {
           category: 'cat 1',
           value: 24.75
         });
-        analytics.called(window.fbq, 'track', 'AddToCart', {
-          content_ids: [''],
-          content_type: ['product'],
-          content_name: 'my product',
-          content_category: 'cat 1',
-          currency: 'USD',
-          value: '24.75'
-        });
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          'AddToCart',
+          {
+            content_ids: [''],
+            content_type: ['product'],
+            content_name: 'my product',
+            content_category: 'cat 1',
+            currency: 'USD',
+            value: '24.75'
+          },
+          { eventID: undefined }
+        );
       });
 
       it('should fallback to an empty string for content_name', function() {
@@ -874,14 +1170,21 @@ describe('Facebook Pixel', function() {
           sku: 'p-298',
           value: 24.75
         });
-        analytics.called(window.fbq, 'track', 'AddToCart', {
-          content_ids: ['507f1f77bcf86cd799439011'],
-          content_type: ['product'],
-          content_name: '',
-          content_category: 'cat 1',
-          currency: 'USD',
-          value: '24.75'
-        });
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          'AddToCart',
+          {
+            content_ids: ['507f1f77bcf86cd799439011'],
+            content_type: ['product'],
+            content_name: '',
+            content_category: 'cat 1',
+            currency: 'USD',
+            value: '24.75'
+          },
+          { eventID: undefined }
+        );
       });
 
       it('should fallback to an empty string for content_category', function() {
@@ -894,14 +1197,21 @@ describe('Facebook Pixel', function() {
           sku: 'p-298',
           value: 24.75
         });
-        analytics.called(window.fbq, 'track', 'AddToCart', {
-          content_ids: ['507f1f77bcf86cd799439011'],
-          content_type: ['product'],
-          content_name: 'my product',
-          content_category: '',
-          currency: 'USD',
-          value: '24.75'
-        });
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          'AddToCart',
+          {
+            content_ids: ['507f1f77bcf86cd799439011'],
+            content_type: ['product'],
+            content_name: 'my product',
+            content_category: '',
+            currency: 'USD',
+            value: '24.75'
+          },
+          { eventID: undefined }
+        );
       });
 
       it('should use price in the legacy event', function() {
@@ -918,18 +1228,32 @@ describe('Facebook Pixel', function() {
           sku: 'p-298',
           value: 24.75
         });
-        analytics.called(window.fbq, 'track', 'AddToCart', {
-          content_ids: ['507f1f77bcf86cd799439011'],
-          content_type: ['product'],
-          content_name: 'my product',
-          content_category: 'cat 1',
-          currency: 'USD',
-          value: '44.33'
-        });
-        analytics.called(window.fbq, 'track', '123456', {
-          currency: 'USD',
-          value: '44.33'
-        });
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          'AddToCart',
+          {
+            content_ids: ['507f1f77bcf86cd799439011'],
+            content_type: ['product'],
+            content_name: 'my product',
+            content_category: 'cat 1',
+            currency: 'USD',
+            value: '44.33'
+          },
+          { eventID: undefined }
+        );
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          '123456',
+          {
+            currency: 'USD',
+            value: '44.33'
+          },
+          { eventID: undefined }
+        );
       });
     });
 
@@ -947,12 +1271,22 @@ describe('Facebook Pixel', function() {
           currency: 'USD',
           total: 0.5
         });
-        analytics.called(window.fbq, 'track', 'Purchase', {
-          content_ids: ['507f1f77bcf86cd799439011', '505bd76785ebb509fc183733'],
-          content_type: ['product'],
-          currency: 'USD',
-          value: '0.50'
-        });
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          'Purchase',
+          {
+            content_ids: [
+              '507f1f77bcf86cd799439011',
+              '505bd76785ebb509fc183733'
+            ],
+            content_type: ['product'],
+            currency: 'USD',
+            value: '0.50'
+          },
+          { eventID: undefined }
+        );
       });
 
       it('Should send both pixel and standard event if mapped', function() {
@@ -965,16 +1299,33 @@ describe('Facebook Pixel', function() {
           currency: 'USD',
           total: 0.5
         });
-        analytics.called(window.fbq, 'track', 'Purchase', {
-          content_ids: ['507f1f77bcf86cd799439011', '505bd76785ebb509fc183733'],
-          content_type: ['product'],
-          currency: 'USD',
-          value: '0.50'
-        });
-        analytics.called(window.fbq, 'track', '123456', {
-          currency: 'USD',
-          value: '0.50'
-        });
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          'Purchase',
+          {
+            content_ids: [
+              '507f1f77bcf86cd799439011',
+              '505bd76785ebb509fc183733'
+            ],
+            content_type: ['product'],
+            currency: 'USD',
+            value: '0.50'
+          },
+          { eventID: undefined }
+        );
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          '123456',
+          {
+            currency: 'USD',
+            value: '0.50'
+          },
+          { eventID: undefined }
+        );
       });
 
       it('should default to id for content_id', function() {
@@ -986,12 +1337,22 @@ describe('Facebook Pixel', function() {
           currency: 'USD',
           total: 0.5
         });
-        analytics.called(window.fbq, 'track', 'Purchase', {
-          content_ids: ['507f1f77bcf86cd799439011', '505bd76785ebb509fc183733'],
-          content_type: ['product'],
-          currency: 'USD',
-          value: '0.50'
-        });
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          'Purchase',
+          {
+            content_ids: [
+              '507f1f77bcf86cd799439011',
+              '505bd76785ebb509fc183733'
+            ],
+            content_type: ['product'],
+            currency: 'USD',
+            value: '0.50'
+          },
+          { eventID: undefined }
+        );
       });
 
       it('should default to sku for content_id', function() {
@@ -1003,12 +1364,22 @@ describe('Facebook Pixel', function() {
           currency: 'USD',
           total: 0.5
         });
-        analytics.called(window.fbq, 'track', 'Purchase', {
-          content_ids: ['507f1f77bcf86cd799439011', '505bd76785ebb509fc183733'],
-          content_type: ['product'],
-          currency: 'USD',
-          value: '0.50'
-        });
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          'Purchase',
+          {
+            content_ids: [
+              '507f1f77bcf86cd799439011',
+              '505bd76785ebb509fc183733'
+            ],
+            content_type: ['product'],
+            currency: 'USD',
+            value: '0.50'
+          },
+          { eventID: undefined }
+        );
       });
 
       it('should send the custom content type if mapped', function() {
@@ -1020,12 +1391,22 @@ describe('Facebook Pixel', function() {
           currency: 'USD',
           total: 0.5
         });
-        analytics.called(window.fbq, 'track', 'Purchase', {
-          content_ids: ['507f1f77bcf86cd799439011', '505bd76785ebb509fc183733'],
-          content_type: ['vehicle'],
-          currency: 'USD',
-          value: '0.50'
-        });
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          'Purchase',
+          {
+            content_ids: [
+              '507f1f77bcf86cd799439011',
+              '505bd76785ebb509fc183733'
+            ],
+            content_type: ['vehicle'],
+            currency: 'USD',
+            value: '0.50'
+          },
+          { eventID: undefined }
+        );
       });
     });
 
@@ -1036,9 +1417,16 @@ describe('Facebook Pixel', function() {
 
       it('should send pixel the search string', function() {
         analytics.track('Products Searched', { query: 'yo' });
-        analytics.called(window.fbq, 'track', 'Search', {
-          search_string: 'yo'
-        });
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          'Search',
+          {
+            search_string: 'yo'
+          },
+          { eventID: undefined }
+        );
       });
 
       it('should send standard and legacy events', function() {
@@ -1047,10 +1435,17 @@ describe('Facebook Pixel', function() {
         };
 
         analytics.track('Products Searched', { query: 'yo' });
-        analytics.called(window.fbq, 'track', 'Search', {
-          search_string: 'yo'
-        });
-        analytics.called(window.fbq, 'track', '123456');
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          'Search',
+          {
+            search_string: 'yo'
+          },
+          { eventID: undefined }
+        );
+        analytics.called(window.fbq, 'trackSingle', options.pixelId, '123456');
       });
     });
 
@@ -1092,17 +1487,27 @@ describe('Facebook Pixel', function() {
             }
           ]
         });
-        analytics.called(window.fbq, 'track', 'InitiateCheckout', {
-          content_ids: ['507f1f77bcf86cd799439011', '505bd76785ebb509fc183733'],
-          value: '25.00',
-          contents: [
-            { id: '507f1f77bcf86cd799439011', quantity: 1, item_price: 19 },
-            { id: '505bd76785ebb509fc183733', quantity: 2, item_price: 3 }
-          ],
-          num_items: 2,
-          currency: 'USD',
-          content_category: 'NotGames'
-        });
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          'InitiateCheckout',
+          {
+            content_ids: [
+              '507f1f77bcf86cd799439011',
+              '505bd76785ebb509fc183733'
+            ],
+            value: '25.00',
+            contents: [
+              { id: '507f1f77bcf86cd799439011', quantity: 1, item_price: 19 },
+              { id: '505bd76785ebb509fc183733', quantity: 2, item_price: 3 }
+            ],
+            num_items: 2,
+            currency: 'USD',
+            content_category: 'NotGames'
+          },
+          { eventID: undefined }
+        );
       });
 
       it('should call InitiateCheckout with the first product category', function() {
@@ -1137,17 +1542,27 @@ describe('Facebook Pixel', function() {
             }
           ]
         });
-        analytics.called(window.fbq, 'track', 'InitiateCheckout', {
-          content_ids: ['507f1f77bcf86cd799439011', '505bd76785ebb509fc183733'],
-          value: '25.00',
-          contents: [
-            { id: '507f1f77bcf86cd799439011', quantity: 1, item_price: 19 },
-            { id: '505bd76785ebb509fc183733', quantity: 2, item_price: 3 }
-          ],
-          num_items: 2,
-          currency: 'USD',
-          content_category: 'Games'
-        });
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          'InitiateCheckout',
+          {
+            content_ids: [
+              '507f1f77bcf86cd799439011',
+              '505bd76785ebb509fc183733'
+            ],
+            value: '25.00',
+            contents: [
+              { id: '507f1f77bcf86cd799439011', quantity: 1, item_price: 19 },
+              { id: '505bd76785ebb509fc183733', quantity: 2, item_price: 3 }
+            ],
+            num_items: 2,
+            currency: 'USD',
+            content_category: 'Games'
+          },
+          { eventID: undefined }
+        );
       });
 
       it('should send a standard and legacy events', function() {
@@ -1185,21 +1600,38 @@ describe('Facebook Pixel', function() {
             }
           ]
         });
-        analytics.called(window.fbq, 'track', 'InitiateCheckout', {
-          content_ids: ['507f1f77bcf86cd799439011', '505bd76785ebb509fc183733'],
-          value: '25.00',
-          contents: [
-            { id: '507f1f77bcf86cd799439011', quantity: 1, item_price: 19 },
-            { id: '505bd76785ebb509fc183733', quantity: 2, item_price: 3 }
-          ],
-          num_items: 2,
-          currency: 'USD',
-          content_category: 'Games'
-        });
-        analytics.called(window.fbq, 'track', '123456', {
-          currency: 'USD',
-          value: '25.00'
-        });
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          'InitiateCheckout',
+          {
+            content_ids: [
+              '507f1f77bcf86cd799439011',
+              '505bd76785ebb509fc183733'
+            ],
+            value: '25.00',
+            contents: [
+              { id: '507f1f77bcf86cd799439011', quantity: 1, item_price: 19 },
+              { id: '505bd76785ebb509fc183733', quantity: 2, item_price: 3 }
+            ],
+            num_items: 2,
+            currency: 'USD',
+            content_category: 'Games'
+          },
+          { eventID: undefined }
+        );
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          '123456',
+          {
+            currency: 'USD',
+            value: '25.00'
+          },
+          { eventID: undefined }
+        );
       });
 
       it('should default to id for content_ids', function() {
@@ -1234,17 +1666,27 @@ describe('Facebook Pixel', function() {
             }
           ]
         });
-        analytics.called(window.fbq, 'track', 'InitiateCheckout', {
-          content_ids: ['507f1f77bcf86cd799439011', '505bd76785ebb509fc183733'],
-          value: '25.00',
-          contents: [
-            { id: '507f1f77bcf86cd799439011', quantity: 1, item_price: 19 },
-            { id: '505bd76785ebb509fc183733', quantity: 2, item_price: 3 }
-          ],
-          num_items: 2,
-          currency: 'USD',
-          content_category: 'Games'
-        });
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          'InitiateCheckout',
+          {
+            content_ids: [
+              '507f1f77bcf86cd799439011',
+              '505bd76785ebb509fc183733'
+            ],
+            value: '25.00',
+            contents: [
+              { id: '507f1f77bcf86cd799439011', quantity: 1, item_price: 19 },
+              { id: '505bd76785ebb509fc183733', quantity: 2, item_price: 3 }
+            ],
+            num_items: 2,
+            currency: 'USD',
+            content_category: 'Games'
+          },
+          { eventID: undefined }
+        );
       });
 
       it('should default to sku for content_ids', function() {
@@ -1278,17 +1720,24 @@ describe('Facebook Pixel', function() {
             }
           ]
         });
-        analytics.called(window.fbq, 'track', 'InitiateCheckout', {
-          content_ids: ['45790-32', '505bd76785ebb509fc183733'],
-          value: '25.00',
-          contents: [
-            { id: '45790-32', quantity: 1, item_price: 19 },
-            { id: '505bd76785ebb509fc183733', quantity: 2, item_price: 3 }
-          ],
-          num_items: 2,
-          currency: 'USD',
-          content_category: 'Games'
-        });
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          'InitiateCheckout',
+          {
+            content_ids: ['45790-32', '505bd76785ebb509fc183733'],
+            value: '25.00',
+            contents: [
+              { id: '45790-32', quantity: 1, item_price: 19 },
+              { id: '505bd76785ebb509fc183733', quantity: 2, item_price: 3 }
+            ],
+            num_items: 2,
+            currency: 'USD',
+            content_category: 'Games'
+          },
+          { eventID: undefined }
+        );
       });
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1462,7 +1462,6 @@ browserify@^16.1.0:
 browserify@^16.2.3:
   version "16.2.3"
   resolved "https://registry.yarnpkg.com/browserify/-/browserify-16.2.3.tgz#7ee6e654ba4f92bce6ab3599c3485b1cc7a0ad0b"
-  integrity sha512-zQt/Gd1+W+IY+h/xX2NYMW4orQWhqSwyV+xsblycTtpOuB27h1fZhhNQuipJ4t79ohw4P4mMem0jp/ZkISQtjQ==
   dependencies:
     JSONStream "^1.0.3"
     assert "^1.4.0"
@@ -1788,7 +1787,6 @@ circular-json@^0.3.1:
 circular-json@^0.5.5:
   version "0.5.9"
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.5.9.tgz#932763ae88f4f7dead7a0d09c8a51a4743a53b1d"
-  integrity sha512-4ivwqHpIFJZBuhN3g/pEcdbnGUywkBblloGbkglyloVjjR3uT6tieI89MVOfbP2tHX5sgb01FuLgAOzebNlJNQ==
 
 class-utils@^0.3.5:
   version "0.3.6"
@@ -2680,7 +2678,6 @@ engine.io-client@1.6.9:
 engine.io-client@~3.2.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/engine.io-client/-/engine.io-client-3.2.1.tgz#6f54c0475de487158a1a7c77d10178708b6add36"
-  integrity sha512-y5AbkytWeM4jQr7m/koQLc5AxpRKC1hEVUb/s1FUAWEJq5AzJJ4NLvzuKPuxtDi5Mq755WuDvZ6Iv2rXj4PTzw==
   dependencies:
     component-emitter "1.2.1"
     component-inherit "0.0.3"
@@ -2728,7 +2725,6 @@ engine.io@1.6.10:
 engine.io@~3.2.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/engine.io/-/engine.io-3.2.1.tgz#b60281c35484a70ee0351ea0ebff83ec8c9522a2"
-  integrity sha512-+VlKzHzMhaU+GsCIg4AoXF1UdDFjHHwMmMKqMJNDNLlUlejz58FCy4LBqB2YVJskHGYl06BatYWKP2TVdVXE5w==
   dependencies:
     accepts "~1.3.4"
     base64id "1.0.0"
@@ -3624,7 +3620,6 @@ flat-cache@^1.2.1:
 flatted@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.0.tgz#55122b6536ea496b4b44893ee2608141d10d9916"
-  integrity sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==
 
 follow-redirects@^1.0.0:
   version "1.5.0"
@@ -4729,7 +4724,6 @@ isobject@^3.0.0, isobject@^3.0.1:
 isostring@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/isostring/-/isostring-0.0.1.tgz#ddb608efbfc89cda86db9cb16be090a788134c7f"
-  integrity sha1-3bYI77/InNqG25yxa+CQp4gTTH8=
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -5001,7 +4995,6 @@ karma-browserify@^5.0.4, karma-browserify@^5.1.1:
 karma-browserify@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/karma-browserify/-/karma-browserify-6.0.0.tgz#423b719fe80d064ad5ec36f8eb15c399305b9aba"
-  integrity sha512-G3dGjoy1/6P8I6qTp799fbcAxs4P+1JcyEKUzy9g1/xMakqf9FFPwW2T9iEtCbWoH5WIKD3z+YwGL5ysBhzrsg==
   dependencies:
     convert-source-map "^1.1.3"
     hat "^0.0.3"
@@ -5113,7 +5106,6 @@ karma@1.3.0:
 karma@^3.0.0:
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/karma/-/karma-3.1.4.tgz#3890ca9722b10d1d14b726e1335931455788499e"
-  integrity sha512-31Vo8Qr5glN+dZEVIpnPCxEGleqE0EY6CtC2X9TagRV3rRQ3SNrvfhddICkJgUK3AgqpeKSZau03QumTGhGoSw==
   dependencies:
     bluebird "^3.3.0"
     body-parser "^1.16.1"
@@ -5425,11 +5417,6 @@ lodash@4.17.10, "lodash@4.6.1 || ^4.16.1", lodash@^4.0.0, lodash@^4.0.1, lodash@
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
-lodash@4.17.11:
-  version "4.17.11"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
-  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
-
 lodash@^3.8.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
@@ -5463,7 +5450,6 @@ log4js@^0.6.31:
 log4js@^3.0.0:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/log4js/-/log4js-3.0.6.tgz#e6caced94967eeeb9ce399f9f8682a4b2b28c8ff"
-  integrity sha512-ezXZk6oPJCWL483zj64pNkMuY/NcRX5MPiB0zE6tjZM137aeusrOnW1ecxgF9cmwMWkBMhjteQxBPoZBh9FDxQ==
   dependencies:
     circular-json "^0.5.5"
     date-format "^1.2.0"
@@ -5732,7 +5718,6 @@ mime@^1.3.4:
 mime@^2.3.1:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.0.tgz#e051fd881358585f3279df333fe694da0bcffdd6"
-  integrity sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w==
 
 mimic-fn@^1.0.0:
   version "1.2.0"
@@ -7070,31 +7055,6 @@ request@2.85.0:
     tunnel-agent "^0.6.0"
     uuid "^3.1.0"
 
-request@2.88.0, request@^2.87.0:
-  version "2.88.0"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
-  dependencies:
-    aws-sign2 "~0.7.0"
-    aws4 "^1.8.0"
-    caseless "~0.12.0"
-    combined-stream "~1.0.6"
-    extend "~3.0.2"
-    forever-agent "~0.6.1"
-    form-data "~2.3.2"
-    har-validator "~5.1.0"
-    http-signature "~1.2.0"
-    is-typedarray "~1.0.0"
-    isstream "~0.1.2"
-    json-stringify-safe "~5.0.1"
-    mime-types "~2.1.19"
-    oauth-sign "~0.9.0"
-    performance-now "^2.1.0"
-    qs "~6.5.2"
-    safe-buffer "^5.1.2"
-    tough-cookie "~2.4.3"
-    tunnel-agent "^0.6.0"
-    uuid "^3.3.2"
-
 request@^2.81.0:
   version "2.87.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.87.0.tgz#32f00235cd08d482b4d0d68db93a829c0ed5756e"
@@ -7119,6 +7079,31 @@ request@^2.81.0:
     tough-cookie "~2.3.3"
     tunnel-agent "^0.6.0"
     uuid "^3.1.0"
+
+request@^2.87.0:
+  version "2.88.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
+  dependencies:
+    aws-sign2 "~0.7.0"
+    aws4 "^1.8.0"
+    caseless "~0.12.0"
+    combined-stream "~1.0.6"
+    extend "~3.0.2"
+    forever-agent "~0.6.1"
+    form-data "~2.3.2"
+    har-validator "~5.1.0"
+    http-signature "~1.2.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.19"
+    oauth-sign "~0.9.0"
+    performance-now "^2.1.0"
+    qs "~6.5.2"
+    safe-buffer "^5.1.2"
+    tough-cookie "~2.4.3"
+    tunnel-agent "^0.6.0"
+    uuid "^3.3.2"
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -7201,7 +7186,6 @@ ret@~0.1.10:
 rfdc@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.1.2.tgz#e6e72d74f5dc39de8f538f65e00c36c18018e349"
-  integrity sha512-92ktAgvZhBzYTIK0Mja9uen5q5J3NRVMoDkJL2VMwq6SXjVCgqvQeVP2XAaUY6HT+XpQYeLSjb3UoitBryKmdA==
 
 right-align@^0.1.1:
   version "0.1.3"
@@ -7575,7 +7559,6 @@ socket.io-client@1.4.6:
 socket.io-client@2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/socket.io-client/-/socket.io-client-2.1.1.tgz#dcb38103436ab4578ddb026638ae2f21b623671f"
-  integrity sha512-jxnFyhAuFxYfjqIgduQlhzqTcOEQSn+OHKVfAxWaNWa7ecP7xSNk2Dx/3UEsDcY7NcFafxvNvKPmmO7HTwTxGQ==
   dependencies:
     backo2 "1.0.2"
     base64-arraybuffer "0.1.5"
@@ -7615,7 +7598,6 @@ socket.io-parser@2.2.6:
 socket.io-parser@~3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-3.2.0.tgz#e7c6228b6aa1f814e6148aea325b51aa9499e077"
-  integrity sha512-FYiBx7rc/KORMJlgsXysflWx/RIvtqZbyGLlHZvjfmPTPeuD/I8MaW7cfFrj5tRltICJdgwflhfZ3NVVbVLFQA==
   dependencies:
     component-emitter "1.2.1"
     debug "~3.1.0"
@@ -7635,7 +7617,6 @@ socket.io@1.4.7:
 socket.io@2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/socket.io/-/socket.io-2.1.1.tgz#a069c5feabee3e6b214a75b40ce0652e1cfb9980"
-  integrity sha512-rORqq9c+7W0DAK3cleWNSyfv/qKXV99hV4tZe+gGLfBECw3XEhBy7x85F3wypA9688LKjtwO9pX9L33/xQI8yA==
   dependencies:
     debug "~3.1.0"
     engine.io "~3.2.0"
@@ -8194,7 +8175,6 @@ to-regex@^3.0.1, to-regex@^3.0.2:
 to-snake-case@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/to-snake-case/-/to-snake-case-1.0.0.tgz#ce746913897946019a87e62edfaeaea4c608ab8c"
-  integrity sha1-znRpE4l5RgGah+Yu366upMYIq4w=
   dependencies:
     to-space-case "^1.0.0"
 
@@ -8375,7 +8355,6 @@ unique-string@^1.0.0:
 unix-time@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/unix-time/-/unix-time-1.0.1.tgz#50f84139bacda6a0d830b28729824eead52c1652"
-  integrity sha1-UPhBObrNpqDYMLKHKYJO6tUsFlI=
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
@@ -8455,7 +8434,6 @@ user-home@^2.0.0:
 useragent@2.3.0, useragent@^2.1.9:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/useragent/-/useragent-2.3.0.tgz#217f943ad540cb2128658ab23fc960f6a88c9972"
-  integrity sha512-4AoH4pxuSvHCjqLO04sU6U/uE65BYza8l/KKBS0b0hnUPWi+cQ2BpeTEwejCSx9SPV5/U03nniDTrWx5NrmKdw==
   dependencies:
     lru-cache "4.1.x"
     tmp "0.0.x"
@@ -8583,19 +8561,6 @@ watchify@^3.11.0, watchify@^3.7.0, watchify@^3.9.0:
     outpipe "^1.1.0"
     through2 "^2.0.0"
     xtend "^4.0.0"
-
-wd@^1.11.1:
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/wd/-/wd-1.11.1.tgz#21a33e21977ad20522bb189f6529c3b55ac3862c"
-  integrity sha512-XNK6EbOrXF7cG8f3pbps6mb/+xPGZH2r1AL1zGJluGynA/Xt6ip1Tvqj2AkavyDFworreaGXoe+0AP/r7EX9pg==
-  dependencies:
-    archiver "2.1.1"
-    async "2.0.1"
-    lodash "4.17.11"
-    mkdirp "^0.5.1"
-    q "1.4.1"
-    request "2.88.0"
-    vargs "0.1.0"
 
 wd@^1.4.0:
   version "1.10.0"


### PR DESCRIPTION
In advance of allowing customers to use the client-side pixel integration with the server-side component simultaneously, we need to add deduping functionality. This adds `messageId` in the `eventID` field for Pixel events to achieve that (the server-side will do the same).

In addition, at Pixel's recommendation we're changing `track` calls to `trackSingle` calls. The difference between the two is that `track` makes track calls for all registered pixel instances on the page whereas `trackSingle` only makes the track call for the specified pixel instance. This will not result in any functional change for the integration as the integration only registers one pixel instance but it prevents a scenario where customers have other native FB pixel instances loaded and our code triggers a track for that pixel.