### PR TITLE
Convert Segment address trait to Hubspot contact properties

### DIFF
--- a/integrations/hubspot/lib/index.js
+++ b/integrations/hubspot/lib/index.js
@@ -98,6 +98,7 @@ HubSpot.prototype.identify = function(identify) {
     lastName: 'lastname'
   });
   traits = convertDates(traits);
+  traits = convertAddress(traits);
   traits = formatTraits(traits);
 
   if (newIdentify.companyName() !== undefined) {
@@ -134,6 +135,47 @@ function convertDates(properties) {
   return convert(properties, function(date) {
     return date.getTime();
   });
+}
+
+/**
+ * Convert Segment reserved address trait to HubSpot contact properties
+ *
+ * @api private
+ * @param {Object} traits
+ * @return {Object} ret
+ */
+function convertAddress(traits) {
+  if (!traits.address) {
+    return traits;
+  }
+
+  var country = traits.address.country;
+  var state = traits.address.state;
+  var city = traits.address.city;
+  var postalCode = traits.address.postalCode;
+  var street = traits.address.street;
+
+  if (street) {
+    traits.address = street;
+  }
+
+  if (city) {
+    traits.city = city;
+  }
+
+  if (country) {
+    traits.country = country;
+  }
+
+  if (state) {
+    traits.state = state;
+  }
+
+  if (postalCode) {
+    traits.zip = postalCode;
+  }
+
+  return traits;
 }
 
 /**

--- a/integrations/hubspot/test/index.test.js
+++ b/integrations/hubspot/test/index.test.js
@@ -115,6 +115,30 @@ describe('HubSpot', function() {
         ]);
       });
 
+      it('should map reserved address trait to hubspot contact properties', function() {
+        analytics.identify({
+          email: 'name@example.com',
+          address: {
+            city: 'Melbourne',
+            country: 'Australia',
+            postalCode: '3121',
+            state: 'Richmond',
+            street: 'Stewart St'
+          }
+        });
+        analytics.called(window._hsq.push, [
+          'identify',
+          {
+            email: 'name@example.com',
+            address: 'Stewart St',
+            city: 'Melbourne',
+            country: 'Australia',
+            state: 'Richmond',
+            zip: '3121'
+          }
+        ]);
+      });
+
       it('should convert dates to milliseconds', function() {
         var date = new Date();
         analytics.identify({


### PR DESCRIPTION
**What does this PR do?**
The PR updates the Hubspot integration to handle the reserved Segment `address` [identify trait](https://segment.com/docs/spec/identify/) and map the relevant fields to [default Hubspot Contact properties](https://knowledge.hubspot.com/articles/kcs_article/contacts/hubspots-default-contact-properties#contact):

* `address` (Street address)
* `zip` (Postal code)
* `country`
* `state`
* `city`

**Are there breaking changes in this PR?**
No

**Has this been tested end-to-end? Please provide screenshots on how the fix now populates in the end tool. If not, what was done to test?**
No, I've only tested with unit tests.

**Any background context you want to provide?**
At 99designs we use the Hubspot integration and pass through `address` as a trait on `identify()` calls. Unfortunately, Hubspot maps `address` to a contact's Street address which is a string causing this issue:

<img width="789" alt="Screenshot 2019-03-20 16 27 19" src="https://user-images.githubusercontent.com/656826/54661125-16d24000-4b2d-11e9-888e-e0748b687a47.png">



**Is there parity with the server-side/android/iOS integration (if applicable)?**
N/A

**Does this require a metadata change? If so, please link the PR from https://github.com/segmentio/destination-scripts.**
No

**What are the relevant tickets?**
N/A

**Link to CC ticket**
N/A

**List all the tests accounts you have used to make sure this change works**
None

