### PR TITLE
[Amplitude] Support Alias

### DIFF
--- a/integrations/amplitude/lib/index.js
+++ b/integrations/amplitude/lib/index.js
@@ -11,8 +11,8 @@ var when = require('do-when');
 var is = require('is');
 var each = require('@ndhoule/each');
 var Track = require('segmentio-facade').Track;
-var https = require('https');
 var JSON = require('json3');
+var request = require('request');
 
 /**
  * UMD?
@@ -455,24 +455,6 @@ function mapRevenueAttributes(track) {
 
 Amplitude.prototype.alias = function(alias) {
   if (!this.options.sendAlias) return;
-
-  var request = {
-    hostname: 'api.amplitude.com',
-    port: 443,
-    path: '/usermap',
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded'
-    }
-  };
-
-  var req = https.request(request);
-
-  req.on('error', function(e) {
-    /* istanbul ignore next */
-    console.error(e);
-  });
-
   // Amplitude returns a 400 if either `user_id` or `global_user_id` is null
   // or undefined. We won't bail if either is undefined or null, since
   // the error should be surfaced to the customer for visbility.
@@ -496,6 +478,16 @@ Amplitude.prototype.alias = function(alias) {
     JSON.stringify(this.aliasData) +
     ']';
 
-  req.write(this.aliasFormData);
-  req.end();
+  var options = {
+    url: 'https://api.amplitude.com/usermap',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded'
+    },
+    body: this.aliasFormData
+  };
+
+  request.post(options, function(e) {
+    /* istanbul ignore next */
+    if (e) console.error(e);
+  });
 };

--- a/integrations/amplitude/lib/index.js
+++ b/integrations/amplitude/lib/index.js
@@ -469,6 +469,7 @@ Amplitude.prototype.alias = function(alias) {
   var req = https.request(request);
 
   req.on('error', function(e) {
+    /* istanbul ignore next */
     console.error(e);
   });
 

--- a/integrations/amplitude/lib/index.js
+++ b/integrations/amplitude/lib/index.js
@@ -12,7 +12,7 @@ var is = require('is');
 var each = require('@ndhoule/each');
 var Track = require('segmentio-facade').Track;
 var https = require('https');
-var stringify = require('json-stable-stringify');
+var JSON = require('json3');
 
 /**
  * UMD?
@@ -493,7 +493,7 @@ Amplitude.prototype.alias = function(alias) {
     'api_key=' +
     this.options.apiKey +
     '&mapping=[' +
-    stringify(this.aliasData) +
+    JSON.stringify(this.aliasData) +
     ']';
 
   req.write(this.aliasFormData);

--- a/integrations/amplitude/package.json
+++ b/integrations/amplitude/package.json
@@ -29,7 +29,6 @@
     "component-bind": "^1.0.0",
     "do-when": "^1.0.0",
     "is": "^3.2.1",
-    "json-stable-stringify": "^1.0.1",
     "segmentio-facade": "^3.2.1"
   },
   "devDependencies": {

--- a/integrations/amplitude/package.json
+++ b/integrations/amplitude/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-amplitude",
   "description": "The Amplitude analytics.js integration.",
-  "version": "2.95.0",
+  "version": "2.96.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/amplitude/package.json
+++ b/integrations/amplitude/package.json
@@ -29,6 +29,7 @@
     "component-bind": "^1.0.0",
     "do-when": "^1.0.0",
     "is": "^3.2.1",
+    "json-stable-stringify": "^1.0.1",
     "segmentio-facade": "^3.2.1"
   },
   "devDependencies": {

--- a/integrations/amplitude/test/index.test.js
+++ b/integrations/amplitude/test/index.test.js
@@ -7,7 +7,7 @@ var tester = require('@segment/analytics.js-integration-tester');
 var Amplitude = require('../lib/');
 var sinon = require('sinon');
 var assert = require('assert');
-var stringify = require('json-stable-stringify');
+var JSON = require('json3');
 
 describe('Amplitude', function() {
   var amplitude;
@@ -776,7 +776,7 @@ describe('Amplitude', function() {
            'api_key=' +
            amplitude.options.apiKey +
            '&mapping=[' +
-           stringify(amplitude.aliasData) +
+           JSON.stringify(amplitude.aliasData) +
            ']'
           );
       });
@@ -798,7 +798,7 @@ describe('Amplitude', function() {
            'api_key=' +
            amplitude.options.apiKey +
            '&mapping=[' +
-           stringify(amplitude.aliasData) +
+           JSON.stringify(amplitude.aliasData) +
            ']'
           );
       });

--- a/integrations/amplitude/test/index.test.js
+++ b/integrations/amplitude/test/index.test.js
@@ -65,6 +65,7 @@ describe('Amplitude', function() {
         .option('traitsToSetOnce', [])
         .option('traitsToIncrement', [])
         .option('deviceIdFromUrlParam', false)
+        .option('sendAlias', false)
     );
   });
 
@@ -766,16 +767,18 @@ describe('Amplitude', function() {
 
       it('should format data correctly to send to Amplitude', function() {
         analytics.alias('global_id', 'user_id');
-        assert(Object.keys(amplitude.aliasData.length === 2));
+        assert(Object.keys(amplitude.aliasData).length === 2);
         assert(amplitude.aliasData.user_id === 'user_id');
         assert(amplitude.aliasData.global_user_id === 'global_id');
+        /* prettier-ignore */
         assert(
           amplitude.aliasFormData ===
            'api_key=' +
            amplitude.options.apiKey +
            '&mapping=[' +
            stringify(amplitude.aliasData) +
-           ']');
+           ']'
+          );
       });
 
       it('should unmap user_id from global_id', function() {
@@ -786,16 +789,18 @@ describe('Amplitude', function() {
             }
           }
         });
-        assert(Object.keys(amplitude.aliasData.length === 3));
+        assert(Object.keys(amplitude.aliasData).length === 2);
         assert(amplitude.aliasData.user_id === 'user_id');
         assert(amplitude.aliasData.unmap === true);
+        /* prettier-ignore */
         assert(
           amplitude.aliasFormData ===
            'api_key=' +
            amplitude.options.apiKey +
            '&mapping=[' +
            stringify(amplitude.aliasData) +
-           ']');
+           ']'
+          );
       });
     });
 


### PR DESCRIPTION
**What does this PR do?**
This PR maps Segment's `alias` method to Amplitude's `usermap` API endpoint, per a request from IBM. Amplitude's `usermap` documentation is [available here](https://amplitude.zendesk.com/hc/en-us/articles/360002750712#user-mapping-aliasing).

**Are there breaking changes in this PR?**
No, these changes are backwards compatible. In addition, customers need to explicitly enable `alias` support by toggling a new UI setting to true. Otherwise, the `alias` method here will noop.

Next step is to release this version of Amplitude to npm so I can test end to end on staging.