### PR TITLE
Add support for pii blacklist setting

### DIFF
--- a/integrations/facebook-pixel/HISTORY.md
+++ b/integrations/facebook-pixel/HISTORY.md
@@ -1,3 +1,8 @@
+2.7.0/ 2019-06-10
+==================
+
+  * Add support for a custom property blacklist setting
+
 2.6.0/ 2019-03-08
 ==================
 

--- a/integrations/facebook-pixel/package.json
+++ b/integrations/facebook-pixel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-facebook-pixel",
   "description": "The Facebook Pixel analytics.js integration.",
-  "version": "2.7.0-beta",
+  "version": "2.7.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/facebook-pixel/package.json
+++ b/integrations/facebook-pixel/package.json
@@ -28,6 +28,7 @@
     "@segment/analytics.js-integration": "^3.1.0",
     "dateformat": "^1.0.12",
     "is": "^3.2.1",
+    "js-sha256": "^0.9.0",
     "reject": "0.0.1",
     "segmentio-facade": "^3.1.0",
     "to-camel-case": "^1.0.0"

--- a/integrations/facebook-pixel/package.json
+++ b/integrations/facebook-pixel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-facebook-pixel",
   "description": "The Facebook Pixel analytics.js integration.",
-  "version": "2.6.0",
+  "version": "2.7.0-beta",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/facebook-pixel/test/index.test.js
+++ b/integrations/facebook-pixel/test/index.test.js
@@ -1445,8 +1445,8 @@ describe('Facebook Pixel', function() {
       });
 
       it('Should send both pixel and standard event if mapped', function() {
-        facebookPixel.options.legacyEvents = { 'Completed Order': '123456' };
-        analytics.track('Completed Order', {
+        facebookPixel.options.legacyEvents = { 'Order Completed': '123456' };
+        analytics.track('Order Completed', {
           products: [
             { product_id: '507f1f77bcf86cd799439011' },
             { product_id: '505bd76785ebb509fc183733' }

--- a/integrations/facebook-pixel/test/index.test.js
+++ b/integrations/facebook-pixel/test/index.test.js
@@ -24,7 +24,8 @@ describe('Facebook Pixel', function() {
     pixelId: '123123123',
     agent: 'test',
     initWithExistingTraits: false,
-    whitelistPiiProperties: []
+    whitelistPiiProperties: [],
+    blacklistPiiProperties: []
   };
 
   beforeEach(function() {
@@ -250,6 +251,160 @@ describe('Facebook Pixel', function() {
             {
               team: 'Warriors',
               country: 'USA'
+            },
+            { eventID: undefined }
+          );
+        });
+
+        it('should blacklist properties defined in the blacklistPiiProperties setting', function() {
+          facebookPixel.options.blacklistPiiProperties = [
+            { propertyName: 'team', hashPropery: false }
+          ];
+          analytics.track('event', {
+            // PII
+            email: 'steph@warriors.com',
+            firstName: 'Steph',
+            lastName: 'Curry',
+            gender: 'male',
+            city: 'Oakland',
+            country: 'USA',
+            phone: '12345534534',
+            state: 'CA',
+            zip: '12345',
+            birthday: 'i dunno?',
+
+            // Non PII
+            position: 'point guard',
+
+            // Not default PII but included in blacklist setting
+            team: 'Warriors'
+          });
+
+          analytics.called(
+            window.fbq,
+            'trackSingleCustom',
+            options.pixelId,
+            'event',
+            {
+              position: 'point guard'
+            },
+            { eventID: undefined }
+          );
+        });
+
+        it('should hash and send blacklisted properties if the hashProperty flag is true', function() {
+          facebookPixel.options.blacklistPiiProperties = [
+            {
+              propertyName: 'email',
+              hashProperty: true
+            },
+            {
+              propertyName: 'team',
+              hashProperty: true
+            }
+          ];
+          analytics.track('event', {
+            // PII
+            email: 'steph@warriors.com',
+            firstName: 'Steph',
+            lastName: 'Curry',
+            gender: 'male',
+            city: 'Oakland',
+            country: 'USA',
+            phone: '12345534534',
+            state: 'CA',
+            zip: '12345',
+            birthday: 'i dunno?',
+
+            // Non PII
+            position: 'point guard',
+
+            // Not default PII but included in blacklist setting
+            team: 'Warriors'
+          });
+
+          analytics.called(
+            window.fbq,
+            'trackSingleCustom',
+            options.pixelId,
+            'event',
+            {
+              team:
+                '3fae3f8daeddc90e04e7502be791c0d149cbc8f0886d68037ad81b8bd61d029d',
+              email:
+                '6dd27a21704a843224245b20369e216eecd3a599b78c4489e5f6cabb5aeca24a',
+              position: 'point guard'
+            },
+            { eventID: undefined }
+          );
+        });
+
+        it('should only attempt to hash string values', function() {
+          facebookPixel.options.blacklistPiiProperties = [
+            {
+              propertyName: 'email',
+              hashProperty: true
+            },
+            {
+              propertyName: 'number',
+              hashProperty: true
+            }
+          ];
+          analytics.track('event', {
+            // PII
+            email: 'steph@warriors.com',
+            firstName: 'Steph',
+            lastName: 'Curry',
+            gender: 'male',
+            city: 'Oakland',
+            country: 'USA',
+            phone: '12345534534',
+            state: 'CA',
+            zip: '12345',
+            birthday: 'i dunno?',
+            number: 30
+          });
+
+          analytics.called(
+            window.fbq,
+            'trackSingleCustom',
+            options.pixelId,
+            'event',
+            {
+              email:
+                '6dd27a21704a843224245b20369e216eecd3a599b78c4489e5f6cabb5aeca24a'
+            },
+            { eventID: undefined }
+          );
+        });
+
+        it('should fallback to an empty array when blacklistPiiProperties is falsy', function() {
+          facebookPixel.options.blacklistPiiProperties = null;
+
+          analytics.track('event', {
+            // PII
+            email: 'steph@warriors.com',
+            firstName: 'Steph',
+            lastName: 'Curry',
+            gender: 'male',
+            city: 'Oakland',
+            country: 'USA',
+            phone: '12345534534',
+            state: 'CA',
+            zip: '12345',
+            birthday: 'i dunno?',
+
+            // Non PII
+            team: 'Warriors'
+          });
+
+          analytics.called(
+            window.fbq,
+            'trackSingleCustom',
+            options.pixelId,
+            'event',
+            {
+              team: 'Warriors'
             },
             { eventID: undefined }
           );

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "istanbul": "^0.4.3",
     "karma": "1.3.0",
     "karma-browserify": "^5.0.4",
-    "karma-chrome-launcher": "^1.0.1",
+    "karma-chrome-launcher": "^2.2.0",
     "karma-coverage": "^1.0.0",
     "karma-junit-reporter": "^1.0.0",
     "karma-mocha": "1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1019,6 +1019,7 @@
     "@segment/analytics.js-integration" "^3.1.0"
     dateformat "^1.0.12"
     is "^3.2.1"
+    js-sha256 "^0.9.0"
     reject "0.0.1"
     segmentio-facade "^3.1.0"
     to-camel-case "^1.0.0"
@@ -4575,6 +4576,7 @@ from2@^2.1.0:
 fs-access@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/fs-access/-/fs-access-1.0.1.tgz#d6a87f262271cefebec30c553407fb995da8777a"
+  integrity sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=
   dependencies:
     null-check "^1.0.0"
 
@@ -5819,6 +5821,7 @@ isbinaryfile@^3.0.0:
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
+  integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
 isobject@^2.0.0:
   version "2.1.0"
@@ -5930,6 +5933,11 @@ jest-validate@^23.5.0:
 jkroso-type@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/jkroso-type/-/jkroso-type-1.1.0.tgz#d2f5600a6d9c82595edd862c3e9f9f7c1529bddb"
+
+js-sha256@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/js-sha256/-/js-sha256-0.9.0.tgz#0b89ac166583e91ef9123644bd3c5334ce9d0966"
+  integrity sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==
 
 js-string-escape@^1.0.0:
   version "1.0.1"
@@ -6061,10 +6069,10 @@ karma-browserify@^5.0.4:
     minimatch "^3.0.0"
     os-shim "^0.1.3"
 
-karma-chrome-launcher@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/karma-chrome-launcher/-/karma-chrome-launcher-1.0.1.tgz#be5ae7c4264f9a0a2e22e3d984beb325ad92c8cb"
-  integrity sha1-vlrnxCZPmgouIuPZhL6zJa2SyMs=
+karma-chrome-launcher@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/karma-chrome-launcher/-/karma-chrome-launcher-2.2.0.tgz#cf1b9d07136cc18fe239327d24654c3dbc368acf"
+  integrity sha512-uf/ZVpAabDBPvdPdveyk1EPgbnloPvFFGgmRhYLTDH7gEB4nZdSBk8yTU47w1g/drLSx5uMOkjKk7IWKfWg/+w==
   dependencies:
     fs-access "^1.0.0"
     which "^1.2.1"
@@ -7309,6 +7317,7 @@ npm-which@^3.0.1:
 null-check@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/null-check/-/null-check-1.0.0.tgz#977dffd7176012b9ec30d2a39db5cf72a0439edd"
+  integrity sha1-l33/1xdgErnsMNKjnbXPcqBDnt0=
 
 number-is-nan@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
**What does this PR do?**
Supports a user defined property blacklist setting. This change is a result of user's requesting that they define which of their event properties contain PII as our default list is too narrow.


**Are there breaking changes in this PR?**
No

**Has this been tested end-to-end? Please provide screenshots on how the fix now populates in the end tool. If not, what was done to test?**
Yes

**Any background context you want to provide?**


**Is there parity with the server-side/android/iOS integration (if applicable)?**
N/A

**Does this require a metadata change? If so, please link the PR from https://github.com/segmentio/destination-scripts.**


**What are the relevant tickets?**
https://segment.atlassian.net/browse/DEST-555

**Link to CC ticket**
https://segment.atlassian.net/browse/CC-4778

**List all the tests accounts you have used to make sure this change works**


**Helpful Docs**

