### PR TITLE
[DEST-236][DEST-682][DEST-777][CC-4860] Facebook Pixel v2.8.0

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,7 +13,8 @@
     "no-restricted-syntax": "warn",
     "no-continue": "warn",
     "consistent-return": "warn",
-    "no-shadow": "warn"
+    "no-shadow": "warn",
+    "no-plusplus": "off"
   },
   "overrides": [
     {

--- a/integrations/facebook-pixel/lib/index.js
+++ b/integrations/facebook-pixel/lib/index.js
@@ -476,6 +476,7 @@ FacebookPixel.prototype.checkoutStarted = function(track) {
     {
       content_category: contentCategory,
       content_ids: contentIds,
+      content_type: this.getContentType(track, ['product']),
       contents: contents,
       currency: track.currency(),
       num_items: contentIds.length,

--- a/integrations/facebook-pixel/package.json
+++ b/integrations/facebook-pixel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-facebook-pixel",
   "description": "The Facebook Pixel analytics.js integration.",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/facebook-pixel/test/index.test.js
+++ b/integrations/facebook-pixel/test/index.test.js
@@ -641,6 +641,54 @@ describe('Facebook Pixel', function() {
       beforeEach(function() {
         analytics.stub(window, 'fbq');
       });
+      it('Should map content_ids parameter to product_ids and content_type to the value in integrations options if possible', function() {
+        analytics.track(
+          'Product List Viewed',
+          {
+            category: 'Games',
+            products: [
+              {
+                product_id: '507f1f77bcf86cd799439011',
+                sku: '45790-32',
+                name: 'Monopoly: 3rd Edition',
+                price: 19,
+                position: 1,
+                category: 'Cars',
+                url: 'https://www.example.com/product/path',
+                image_url: 'https://www.example.com/product/path.jpg'
+              },
+              {
+                product_id: '505bd76785ebb509fc183733',
+                sku: '46493-32',
+                name: 'Uno Card Game',
+                price: 3,
+                position: 2,
+                category: 'Cars'
+              }
+            ]
+          },
+          {
+            'Facebook Pixel': {
+              contentType: 'myCustomType'
+            }
+          }
+        );
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          'ViewContent',
+          {
+            content_ids: [
+              '507f1f77bcf86cd799439011',
+              '505bd76785ebb509fc183733'
+            ],
+            content_type: ['myCustomType']
+          }
+        );
+        assertEventId(window.fbq);
+      });
+
       it('Should map content_ids parameter to product_ids and content_type to "product" if possible', function() {
         analytics.track('Product List Viewed', {
           category: 'Games',
@@ -736,6 +784,54 @@ describe('Facebook Pixel', function() {
         assertEventId(window.fbq);
       });
 
+      it('should send the custom content type in options even if mapped', function() {
+        analytics.track(
+          'Product List Viewed',
+          {
+            category: 'Cars',
+            products: [
+              {
+                product_id: '507f1f77bcf86cd799439011',
+                sku: '45790-32',
+                name: 'Monopoly: 3rd Edition',
+                price: 19,
+                position: 1,
+                category: 'Games',
+                url: 'https://www.example.com/product/path',
+                image_url: 'https://www.example.com/product/path.jpg'
+              },
+              {
+                product_id: '505bd76785ebb509fc183733',
+                sku: '46493-32',
+                name: 'Uno Card Game',
+                price: 3,
+                position: 2,
+                category: 'Games'
+              }
+            ]
+          },
+          {
+            'Facebook Pixel': {
+              contentType: 'myCustomType'
+            }
+          }
+        );
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          'ViewContent',
+          {
+            content_ids: [
+              '507f1f77bcf86cd799439011',
+              '505bd76785ebb509fc183733'
+            ],
+            content_type: ['myCustomType']
+          }
+        );
+        assertEventId(window.fbq);
+      });
+
       it('should send a legacy event', function() {
         facebookPixel.options.legacyEvents = {
           'Product List Viewed': '123456'
@@ -769,6 +865,29 @@ describe('Facebook Pixel', function() {
           {
             content_ids: [''],
             content_type: ['product_group']
+          }
+        );
+        assertEventId(window.fbq);
+      });
+
+      it('should use the contentType option', function() {
+        analytics.track(
+          'Product List Viewed',
+          { category: null },
+          {
+            'Facebook Pixel': {
+              contentType: 'myCustomType'
+            }
+          }
+        );
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          'ViewContent',
+          {
+            content_ids: [''],
+            content_type: ['myCustomType']
           }
         );
         assertEventId(window.fbq);
@@ -890,6 +1009,42 @@ describe('Facebook Pixel', function() {
           {
             content_ids: ['507f1f77bcf86cd799439011'],
             content_type: ['vehicle'],
+            content_name: 'my product',
+            content_category: 'Cars',
+            currency: 'USD',
+            value: '24.75'
+          }
+        );
+        assertEventId(window.fbq);
+      });
+
+      it('should send the custom content type if provided', function() {
+        analytics.track(
+          'Product Viewed',
+          {
+            product_id: '507f1f77bcf86cd799439011',
+            currency: 'USD',
+            quantity: 1,
+            price: 44.33,
+            name: 'my product',
+            category: 'Cars',
+            sku: 'p-298',
+            value: 24.75
+          },
+          {
+            'Facebook Pixel': {
+              contentType: 'myCustomType'
+            }
+          }
+        );
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          'ViewContent',
+          {
+            content_ids: ['507f1f77bcf86cd799439011'],
+            content_type: ['myCustomType'],
             content_name: 'my product',
             content_category: 'Cars',
             currency: 'USD',
@@ -1217,6 +1372,43 @@ describe('Facebook Pixel', function() {
         assertEventId(window.fbq);
       });
 
+      it('should send the custom content type if provided in the options', function() {
+        analytics.track(
+          'Product Added',
+          {
+            product_id: '507f1f77bcf86cd799439011',
+            currency: 'USD',
+            quantity: 1,
+            price: 44.33,
+            name: 'my product',
+            category: 'Cars',
+            sku: 'p-298',
+            value: 24.75,
+            content_type: 'stuff'
+          },
+          {
+            'Facebook Pixel': {
+              contentType: 'myCustomType'
+            }
+          }
+        );
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          'AddToCart',
+          {
+            content_ids: ['507f1f77bcf86cd799439011'],
+            content_type: ['myCustomType'],
+            content_name: 'my product',
+            content_category: 'Cars',
+            currency: 'USD',
+            value: '24.75'
+          }
+        );
+        assertEventId(window.fbq);
+      });
+
       it('should fallback to id for content_id', function() {
         analytics.track('Product Added', {
           id: '507f1f77bcf86cd799439011',
@@ -1528,6 +1720,41 @@ describe('Facebook Pixel', function() {
               '505bd76785ebb509fc183733'
             ],
             content_type: ['vehicle'],
+            currency: 'USD',
+            value: '0.50'
+          }
+        );
+        assertEventId(window.fbq);
+      });
+
+      it('should send the custom content type if provided', function() {
+        analytics.track(
+          'Order Completed',
+          {
+            products: [
+              { product_id: '507f1f77bcf86cd799439011', category: 'Cars' },
+              { product_id: '505bd76785ebb509fc183733', category: 'Cars' }
+            ],
+            currency: 'USD',
+            total: 0.5
+          },
+          {
+            'Facebook Pixel': {
+              contentType: 'myCustomType'
+            }
+          }
+        );
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          'Purchase',
+          {
+            content_ids: [
+              '507f1f77bcf86cd799439011',
+              '505bd76785ebb509fc183733'
+            ],
+            content_type: ['myCustomType'],
             currency: 'USD',
             value: '0.50'
           }

--- a/integrations/facebook-pixel/test/index.test.js
+++ b/integrations/facebook-pixel/test/index.test.js
@@ -29,7 +29,8 @@ describe('Facebook Pixel', function() {
       search: 'Search'
     },
     contentTypes: {
-      Cars: 'vehicle'
+      Cars: 'vehicle',
+      Snacks: 'food'
     },
     pixelId: '123123123',
     agent: 'test',
@@ -1840,6 +1841,7 @@ describe('Facebook Pixel', function() {
               '505bd76785ebb509fc183733'
             ],
             value: '25.00',
+            content_type: ['product'],
             contents: [
               { id: '507f1f77bcf86cd799439011', quantity: 1, item_price: 19 },
               { id: '505bd76785ebb509fc183733', quantity: 2, item_price: 3 }
@@ -1894,6 +1896,7 @@ describe('Facebook Pixel', function() {
               '507f1f77bcf86cd799439011',
               '505bd76785ebb509fc183733'
             ],
+            content_type: ['product'],
             value: '25.00',
             contents: [
               { id: '507f1f77bcf86cd799439011', quantity: 1, item_price: 19 },
@@ -1952,6 +1955,7 @@ describe('Facebook Pixel', function() {
               '507f1f77bcf86cd799439011',
               '505bd76785ebb509fc183733'
             ],
+            content_type: ['product'],
             value: '25.00',
             contents: [
               { id: '507f1f77bcf86cd799439011', quantity: 1, item_price: 19 },
@@ -2013,6 +2017,7 @@ describe('Facebook Pixel', function() {
               '505bd76785ebb509fc183733'
             ],
             value: '25.00',
+            content_type: ['product'],
             contents: [
               { id: '507f1f77bcf86cd799439011', quantity: 1, item_price: 19 },
               { id: '505bd76785ebb509fc183733', quantity: 2, item_price: 3 }
@@ -2020,6 +2025,126 @@ describe('Facebook Pixel', function() {
             num_items: 2,
             currency: 'USD',
             content_category: 'Games'
+          }
+        );
+        assertEventId(window.fbq);
+      });
+
+      it('should use custom content_type if provided', function() {
+        analytics.track(
+          'Checkout Started',
+          {
+            order_id: '50314b8e9bcf000000000000',
+            affiliation: 'Google Store',
+            value: 30,
+            revenue: 25,
+            shipping: 3,
+            tax: 2,
+            discount: 2.5,
+            coupon: 'hasbros',
+            currency: 'USD',
+            products: [
+              {
+                id: '507f1f77bcf86cd799439011',
+                sku: '45790-32',
+                name: 'Monopoly: 3rd Edition',
+                price: 19,
+                quantity: 1,
+                category: 'Games',
+                url: 'https://www.example.com/product/path',
+                image_url: 'https://www.example.com/product/path.jpg'
+              },
+              {
+                product_id: '505bd76785ebb509fc183733',
+                sku: '46493-32',
+                name: 'Uno Card Game',
+                price: 3,
+                quantity: 2,
+                category: 'Games'
+              }
+            ]
+          },
+          {
+            'Facebook Pixel': {
+              contentType: 'myCustomType'
+            }
+          }
+        );
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          'InitiateCheckout',
+          {
+            content_ids: [
+              '507f1f77bcf86cd799439011',
+              '505bd76785ebb509fc183733'
+            ],
+            value: '25.00',
+            content_type: ['myCustomType'],
+            contents: [
+              { id: '507f1f77bcf86cd799439011', quantity: 1, item_price: 19 },
+              { id: '505bd76785ebb509fc183733', quantity: 2, item_price: 3 }
+            ],
+            num_items: 2,
+            currency: 'USD',
+            content_category: 'Games'
+          }
+        );
+        assertEventId(window.fbq);
+      });
+
+      it('should use custom content_type if provided in the mappings', function() {
+        analytics.track('Checkout Started', {
+          order_id: '50314b8e9bcf000000000000',
+          affiliation: 'Google Store',
+          value: 30,
+          revenue: 25,
+          shipping: 3,
+          tax: 2,
+          discount: 2.5,
+          coupon: 'hasbros',
+          currency: 'USD',
+          products: [
+            {
+              id: '507f1f77bcf86cd799439011',
+              sku: '45790-32',
+              name: 'Almonds',
+              price: 19,
+              quantity: 1,
+              category: 'Snacks',
+              url: 'https://www.example.com/product/path',
+              image_url: 'https://www.example.com/product/path.jpg'
+            },
+            {
+              product_id: '505bd76785ebb509fc183733',
+              sku: '46493-32',
+              name: 'Doritos',
+              price: 3,
+              quantity: 2,
+              category: 'Snacks'
+            }
+          ]
+        });
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          'InitiateCheckout',
+          {
+            content_ids: [
+              '507f1f77bcf86cd799439011',
+              '505bd76785ebb509fc183733'
+            ],
+            value: '25.00',
+            content_type: ['food'],
+            contents: [
+              { id: '507f1f77bcf86cd799439011', quantity: 1, item_price: 19 },
+              { id: '505bd76785ebb509fc183733', quantity: 2, item_price: 3 }
+            ],
+            num_items: 2,
+            currency: 'USD',
+            content_category: 'Snacks'
           }
         );
         assertEventId(window.fbq);
@@ -2069,6 +2194,7 @@ describe('Facebook Pixel', function() {
               { id: '505bd76785ebb509fc183733', quantity: 2, item_price: 3 }
             ],
             num_items: 2,
+            content_type: ['product'],
             currency: 'USD',
             content_category: 'Games'
           }

--- a/integrations/facebook-pixel/test/index.test.js
+++ b/integrations/facebook-pixel/test/index.test.js
@@ -36,7 +36,8 @@ describe('Facebook Pixel', function() {
     agent: 'test',
     initWithExistingTraits: false,
     whitelistPiiProperties: [],
-    blacklistPiiProperties: []
+    blacklistPiiProperties: [],
+    standardEventsCustomProperties: []
   };
 
   beforeEach(function() {
@@ -690,6 +691,66 @@ describe('Facebook Pixel', function() {
         assertEventId(window.fbq);
       });
 
+      it('Should add custom properties if available', function() {
+        facebookPixel.options.standardEventsCustomProperties = [
+          'color',
+          'piiSecret'
+        ];
+        facebookPixel.options.blacklistPiiProperties = [
+          { propertyName: 'piiSecret', hashProperty: true }
+        ];
+        analytics.track(
+          'Product List Viewed',
+          {
+            category: 'Games',
+            products: [
+              {
+                product_id: '507f1f77bcf86cd799439011',
+                sku: '45790-32',
+                name: 'Monopoly: 3rd Edition',
+                price: 19,
+                position: 1,
+                category: 'Cars',
+                url: 'https://www.example.com/product/path',
+                image_url: 'https://www.example.com/product/path.jpg'
+              },
+              {
+                product_id: '505bd76785ebb509fc183733',
+                sku: '46493-32',
+                name: 'Uno Card Game',
+                price: 3,
+                position: 2,
+                category: 'Cars'
+              }
+            ],
+            color: 'blue',
+            piiSecret: 'piiInfo'
+          },
+          {
+            'Facebook Pixel': {
+              contentType: 'myCustomType'
+            }
+          }
+        );
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          'ViewContent',
+          {
+            content_ids: [
+              '507f1f77bcf86cd799439011',
+              '505bd76785ebb509fc183733'
+            ],
+            content_type: ['myCustomType'],
+            color: 'blue',
+            piiSecret:
+              '74c8513188dfb502e9a27efc0f3515d6b8491a3b66dff861350de168be870ce9'
+          }
+        );
+        assertEventId(window.fbq);
+      });
+
       it('Should map content_ids parameter to product_ids and content_type to "product" if possible', function() {
         analytics.track('Product List Viewed', {
           category: 'Games',
@@ -922,6 +983,46 @@ describe('Facebook Pixel', function() {
             content_category: 'cat 1',
             currency: 'USD',
             value: '24.75'
+          }
+        );
+        assertEventId(window.fbq);
+      });
+
+      it('should send custom properties', function() {
+        facebookPixel.options.standardEventsCustomProperties = [
+          'color',
+          'piiSecret'
+        ];
+        facebookPixel.options.blacklistPiiProperties = [
+          { propertyName: 'piiSecret', hashProperty: true }
+        ];
+        analytics.track('Product Viewed', {
+          product_id: '507f1f77bcf86cd799439011',
+          currency: 'USD',
+          quantity: 1,
+          price: 44.33,
+          name: 'my product',
+          category: 'cat 1',
+          sku: 'p-298',
+          value: 24.75,
+          color: 'blue',
+          piiSecret: 'piiInfo'
+        });
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          'ViewContent',
+          {
+            content_ids: ['507f1f77bcf86cd799439011'],
+            content_type: ['product'],
+            content_name: 'my product',
+            content_category: 'cat 1',
+            currency: 'USD',
+            value: '24.75',
+            color: 'blue',
+            piiSecret:
+              '74c8513188dfb502e9a27efc0f3515d6b8491a3b66dff861350de168be870ce9'
           }
         );
         assertEventId(window.fbq);
@@ -1278,6 +1379,46 @@ describe('Facebook Pixel', function() {
         assertEventId(window.fbq);
       });
 
+      it('shoud add custom properties', function() {
+        facebookPixel.options.standardEventsCustomProperties = [
+          'color',
+          'piiSecret'
+        ];
+        facebookPixel.options.blacklistPiiProperties = [
+          { propertyName: 'piiSecret', hashProperty: true }
+        ];
+        analytics.track('Product Added', {
+          product_id: '507f1f77bcf86cd799439011',
+          currency: 'USD',
+          quantity: 1,
+          price: 44.33,
+          name: 'my product',
+          category: 'cat 1',
+          sku: 'p-298',
+          value: 24.75,
+          color: 'blue',
+          piiSecret: 'piiInfo'
+        });
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          'AddToCart',
+          {
+            content_ids: ['507f1f77bcf86cd799439011'],
+            content_type: ['product'],
+            content_name: 'my product',
+            content_category: 'cat 1',
+            currency: 'USD',
+            value: '24.75',
+            color: 'blue',
+            piiSecret:
+              '74c8513188dfb502e9a27efc0f3515d6b8491a3b66dff861350de168be870ce9'
+          }
+        );
+        assertEventId(window.fbq);
+      });
+
       it('should send a legacy event for product added', function() {
         facebookPixel.options.legacyEvents = { 'Product Added': '123456' };
 
@@ -1614,6 +1755,45 @@ describe('Facebook Pixel', function() {
         assertEventId(window.fbq);
       });
 
+      it('should add custom properties', function() {
+        facebookPixel.options.standardEventsCustomProperties = [
+          'color',
+          'piiSecret'
+        ];
+        facebookPixel.options.blacklistPiiProperties = [
+          { propertyName: 'piiSecret', hashProperty: true }
+        ];
+        analytics.track('Order Completed', {
+          products: [
+            { product_id: '507f1f77bcf86cd799439011' },
+            { product_id: '505bd76785ebb509fc183733' }
+          ],
+          currency: 'USD',
+          total: 0.5,
+          color: 'blue',
+          piiSecret: 'piiInfo'
+        });
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          'Purchase',
+          {
+            content_ids: [
+              '507f1f77bcf86cd799439011',
+              '505bd76785ebb509fc183733'
+            ],
+            content_type: ['product'],
+            currency: 'USD',
+            value: '0.50',
+            color: 'blue',
+            piiSecret:
+              '74c8513188dfb502e9a27efc0f3515d6b8491a3b66dff861350de168be870ce9'
+          }
+        );
+        assertEventId(window.fbq);
+      });
+
       it('Should send both pixel and standard event if mapped', function() {
         facebookPixel.options.legacyEvents = { 'Order Completed': '123456' };
         analytics.track('Order Completed', {
@@ -1777,6 +1957,28 @@ describe('Facebook Pixel', function() {
         assertEventId(window.fbq);
       });
 
+      it('should add custom properties', function() {
+        facebookPixel.options.standardEventsCustomProperties = [
+          'color',
+          'piiSecret'
+        ];
+        facebookPixel.options.blacklistPiiProperties = [
+          { propertyName: 'piiSecret', hashProperty: true }
+        ];
+        analytics.track('Products Searched', {
+          query: 'yo',
+          color: 'blue',
+          piiSecret: 'piiInfo'
+        });
+        analytics.called(window.fbq, 'trackSingle', options.pixelId, 'Search', {
+          search_string: 'yo',
+          color: 'blue',
+          piiSecret:
+            '74c8513188dfb502e9a27efc0f3515d6b8491a3b66dff861350de168be870ce9'
+        });
+        assertEventId(window.fbq);
+      });
+
       it('should send standard and legacy events', function() {
         facebookPixel.options.legacyEvents = {
           'Products Searched': '123456'
@@ -1849,6 +2051,75 @@ describe('Facebook Pixel', function() {
             num_items: 2,
             currency: 'USD',
             content_category: 'NotGames'
+          }
+        );
+        assertEventId(window.fbq);
+      });
+
+      it('should add custom properties', function() {
+        facebookPixel.options.standardEventsCustomProperties = [
+          'color',
+          'piiSecret'
+        ];
+        facebookPixel.options.blacklistPiiProperties = [
+          { propertyName: 'piiSecret', hashProperty: true }
+        ];
+        analytics.track('Checkout Started', {
+          category: 'NotGames',
+          order_id: '50314b8e9bcf000000000000',
+          affiliation: 'Google Store',
+          value: 30,
+          revenue: 25,
+          shipping: 3,
+          tax: 2,
+          discount: 2.5,
+          coupon: 'hasbros',
+          currency: 'USD',
+          products: [
+            {
+              product_id: '507f1f77bcf86cd799439011',
+              sku: '45790-32',
+              name: 'Monopoly: 3rd Edition',
+              price: 19,
+              quantity: 1,
+              category: 'Games',
+              url: 'https://www.example.com/product/path',
+              image_url: 'https://www.example.com/product/path.jpg'
+            },
+            {
+              product_id: '505bd76785ebb509fc183733',
+              sku: '46493-32',
+              name: 'Uno Card Game',
+              price: 3,
+              quantity: 2,
+              category: 'Games'
+            }
+          ],
+          color: 'blue',
+          piiSecret: 'piiInfo'
+        });
+        analytics.called(
+          window.fbq,
+          'trackSingle',
+          options.pixelId,
+          'InitiateCheckout',
+          {
+            content_ids: [
+              '507f1f77bcf86cd799439011',
+              '505bd76785ebb509fc183733'
+            ],
+            value: '25.00',
+            content_type: ['product'],
+            contents: [
+              { id: '507f1f77bcf86cd799439011', quantity: 1, item_price: 19 },
+              { id: '505bd76785ebb509fc183733', quantity: 2, item_price: 3 }
+            ],
+            num_items: 2,
+            currency: 'USD',
+            content_category: 'NotGames',
+            color: 'blue',
+            piiSecret:
+              '74c8513188dfb502e9a27efc0f3515d6b8491a3b66dff861350de168be870ce9'
           }
         );
         assertEventId(window.fbq);
@@ -2282,6 +2553,47 @@ describe('Facebook Pixel', function() {
       var actual = facebookPixel.formatTraits(analytics);
 
       analytics.deepEqual(expected, actual);
+    });
+  });
+
+  describe('#merge', function() {
+    it('should merge 2 objects', function() {
+      var got = FacebookPixel.merge(
+        {
+          name: 'my value',
+          price: 10
+        },
+        {
+          otherField: true
+        }
+      );
+      var expected = {
+        name: 'my value',
+        price: 10,
+        otherField: true
+      };
+
+      analytics.deepEqual(got, expected);
+    });
+
+    it('should not override properties', function() {
+      var got = FacebookPixel.merge(
+        {
+          name: 'my value',
+          price: 10,
+          otherField: 'hi'
+        },
+        {
+          otherField: true
+        }
+      );
+      var expected = {
+        name: 'my value',
+        price: 10,
+        otherField: 'hi'
+      };
+
+      analytics.deepEqual(got, expected);
     });
   });
 });

--- a/integrations/facebook-pixel/test/index.test.js
+++ b/integrations/facebook-pixel/test/index.test.js
@@ -5,6 +5,16 @@ var sandbox = require('@segment/clear-env');
 var tester = require('@segment/analytics.js-integration-tester');
 var FacebookPixel = require('../lib');
 
+/**
+ * Event ID is generated automatically by Analytics.js, this function
+ * only checks that it was succesfully added as an argument to a `window.fbq` call.
+ */
+function assertEventId(spy) {
+  if (!spy.args[0][4].eventID.startsWith('ajs-')) {
+    throw new Error('Expected eventId on window.fbq.call. Not found.');
+  }
+}
+
 describe('Facebook Pixel', function() {
   var analytics;
   var facebookPixel;
@@ -219,9 +229,9 @@ describe('Facebook Pixel', function() {
             'event',
             {
               team: 'Warriors'
-            },
-            { eventID: undefined }
+            }
           );
+          assertEventId(window.fbq);
         });
 
         it('should send whitelisted PII properties', function() {
@@ -251,9 +261,9 @@ describe('Facebook Pixel', function() {
             {
               team: 'Warriors',
               country: 'USA'
-            },
-            { eventID: undefined }
+            }
           );
+          assertEventId(window.fbq);
         });
 
         it('should blacklist properties defined in the blacklistPiiProperties setting', function() {
@@ -287,9 +297,9 @@ describe('Facebook Pixel', function() {
             'event',
             {
               position: 'point guard'
-            },
-            { eventID: undefined }
+            }
           );
+          assertEventId(window.fbq);
         });
 
         it('should hash and send blacklisted properties if the hashProperty flag is true', function() {
@@ -334,9 +344,9 @@ describe('Facebook Pixel', function() {
               email:
                 '6dd27a21704a843224245b20369e216eecd3a599b78c4489e5f6cabb5aeca24a',
               position: 'point guard'
-            },
-            { eventID: undefined }
+            }
           );
+          assertEventId(window.fbq);
         });
 
         it('should only attempt to hash string values', function() {
@@ -373,9 +383,9 @@ describe('Facebook Pixel', function() {
             {
               email:
                 '6dd27a21704a843224245b20369e216eecd3a599b78c4489e5f6cabb5aeca24a'
-            },
-            { eventID: undefined }
+            }
           );
+          assertEventId(window.fbq);
         });
 
         it('should fallback to an empty array when blacklistPiiProperties is falsy', function() {
@@ -405,9 +415,9 @@ describe('Facebook Pixel', function() {
             'event',
             {
               team: 'Warriors'
-            },
-            { eventID: undefined }
+            }
           );
+          assertEventId(window.fbq);
         });
 
         it('should fallback to an empty array when whitelistPiiProperties is falsy', function() {
@@ -437,9 +447,9 @@ describe('Facebook Pixel', function() {
             'event',
             {
               team: 'Warriors'
-            },
-            { eventID: undefined }
+            }
           );
+          assertEventId(window.fbq);
         });
       });
 
@@ -451,9 +461,9 @@ describe('Facebook Pixel', function() {
             'trackSingleCustom',
             options.pixelId,
             'event',
-            {},
-            { eventID: undefined }
+            {}
           );
+          assertEventId(window.fbq);
         });
 
         it('should send a "custom" event and properties', function() {
@@ -465,9 +475,9 @@ describe('Facebook Pixel', function() {
             'event',
             {
               property: true
-            },
-            { eventID: undefined }
+            }
           );
+          assertEventId(window.fbq);
         });
 
         it('should send properties correctly', function() {
@@ -485,9 +495,9 @@ describe('Facebook Pixel', function() {
               currency: 'XXX',
               value: '13.00',
               property: true
-            },
-            { eventID: undefined }
+            }
           );
+          assertEventId(window.fbq);
         });
       });
 
@@ -502,9 +512,9 @@ describe('Facebook Pixel', function() {
             {
               currency: 'USD',
               value: '0.00'
-            },
-            { eventID: undefined }
+            }
           );
+          assertEventId(window.fbq);
         });
 
         it('should send an event and properties', function() {
@@ -517,9 +527,9 @@ describe('Facebook Pixel', function() {
             {
               currency: 'USD',
               value: '10.00'
-            },
-            { eventID: undefined }
+            }
           );
+          assertEventId(window.fbq);
         });
 
         it('should send only currency and revenue', function() {
@@ -532,27 +542,24 @@ describe('Facebook Pixel', function() {
             {
               currency: 'USD',
               value: '13.00'
-            },
-            { eventID: undefined }
+            }
           );
+          assertEventId(window.fbq);
         });
       });
 
       describe('event mapped to standard', function() {
-        it(
-          'should send a correctly mapped event — no required properties',
-          function() {
-            analytics.track('standardEvent');
-            analytics.called(
-              window.fbq,
-              'trackSingle',
-              options.pixelId,
-              'standard',
-              {}
-            );
-          },
-          { eventID: undefined }
-        );
+        it('should send a correctly mapped event — no required properties', function() {
+          analytics.track('standardEvent');
+          analytics.called(
+            window.fbq,
+            'trackSingle',
+            options.pixelId,
+            'standard',
+            {}
+          );
+          assertEventId(window.fbq);
+        });
 
         it('should send properties correctly', function() {
           analytics.track('standardEvent', {
@@ -569,9 +576,9 @@ describe('Facebook Pixel', function() {
               currency: 'XXX',
               value: '13.00',
               property: true
-            },
-            { eventID: undefined }
+            }
           );
+          assertEventId(window.fbq);
         });
 
         it('should default currency to USD if mapped to "Purchase"', function() {
@@ -588,9 +595,9 @@ describe('Facebook Pixel', function() {
               currency: 'USD',
               value: '13.00',
               property: true
-            },
-            { eventID: undefined }
+            }
           );
+          assertEventId(window.fbq);
         });
         describe('Dyanmic Ads for Travel date parsing', function() {
           it('should correctly pass in iso8601 formatted date objects', function() {
@@ -605,9 +612,9 @@ describe('Facebook Pixel', function() {
               'Search',
               {
                 checkin_date: '2017-07-01'
-              },
-              { eventID: undefined }
+              }
             );
+            assertEventId(window.fbq);
           });
 
           it('should pass through strings that we did not recognize as dates as-is', function() {
@@ -622,9 +629,9 @@ describe('Facebook Pixel', function() {
               'Search',
               {
                 checkin_date: '2017-06-23T15:30:00GMT'
-              },
-              { eventID: undefined }
+              }
             );
+            assertEventId(window.fbq);
           });
         });
       });
@@ -669,9 +676,9 @@ describe('Facebook Pixel', function() {
               '505bd76785ebb509fc183733'
             ],
             content_type: ['product']
-          },
-          { eventID: undefined }
+          }
         );
+        assertEventId(window.fbq);
       });
 
       it('Should fallback on mapping content_ids to the product category and content_type to "product_group"', function() {
@@ -684,9 +691,9 @@ describe('Facebook Pixel', function() {
           {
             content_ids: ['Games'],
             content_type: ['product_group']
-          },
-          { eventID: undefined }
+          }
         );
+        assertEventId(window.fbq);
       });
 
       it('should send the custom content type if mapped', function() {
@@ -724,9 +731,9 @@ describe('Facebook Pixel', function() {
               '505bd76785ebb509fc183733'
             ],
             content_type: ['vehicle']
-          },
-          { eventID: undefined }
+          }
         );
+        assertEventId(window.fbq);
       });
 
       it('should send a legacy event', function() {
@@ -742,20 +749,14 @@ describe('Facebook Pixel', function() {
           {
             content_ids: ['Games'],
             content_type: ['product_group']
-          },
-          { eventID: undefined }
+          }
         );
-        analytics.called(
-          window.fbq,
-          'trackSingle',
-          options.pixelId,
-          '123456',
-          {
-            currency: 'USD',
-            value: '0.00'
-          },
-          { eventID: undefined }
-        );
+        assertEventId(window.fbq);
+        analytics.called(window.fbq, 'trackSingle', options.pixelId, '123456', {
+          currency: 'USD',
+          value: '0.00'
+        });
+        assertEventId(window.fbq);
       });
 
       it('should default to an empty string for category', function() {
@@ -768,9 +769,9 @@ describe('Facebook Pixel', function() {
           {
             content_ids: [''],
             content_type: ['product_group']
-          },
-          { eventID: undefined }
+          }
         );
+        assertEventId(window.fbq);
       });
     });
 
@@ -801,9 +802,9 @@ describe('Facebook Pixel', function() {
             content_category: 'cat 1',
             currency: 'USD',
             value: '24.75'
-          },
-          { eventID: undefined }
+          }
         );
+        assertEventId(window.fbq);
       });
 
       it('should send a legacy event', function() {
@@ -831,20 +832,14 @@ describe('Facebook Pixel', function() {
             content_category: 'cat 1',
             currency: 'USD',
             value: '24.75'
-          },
-          { eventID: undefined }
+          }
         );
-        analytics.called(
-          window.fbq,
-          'trackSingle',
-          options.pixelId,
-          '123456',
-          {
-            currency: 'USD',
-            value: '24.75'
-          },
-          { eventID: undefined }
-        );
+        assertEventId(window.fbq);
+        analytics.called(window.fbq, 'trackSingle', options.pixelId, '123456', {
+          currency: 'USD',
+          value: '24.75'
+        });
+        assertEventId(window.fbq);
       });
 
       it('Should map properties.price to facebooks value if price is selected', function() {
@@ -871,9 +866,9 @@ describe('Facebook Pixel', function() {
             content_category: 'cat 1',
             currency: 'USD',
             value: '44.33'
-          },
-          { eventID: undefined }
+          }
         );
+        assertEventId(window.fbq);
       });
 
       it('should send the custom content type if mapped', function() {
@@ -899,9 +894,9 @@ describe('Facebook Pixel', function() {
             content_category: 'Cars',
             currency: 'USD',
             value: '24.75'
-          },
-          { eventID: undefined }
+          }
         );
+        assertEventId(window.fbq);
       });
 
       it('should fallback to id for content_id', function() {
@@ -927,9 +922,9 @@ describe('Facebook Pixel', function() {
             content_category: 'Cars',
             currency: 'USD',
             value: '24.75'
-          },
-          { eventID: undefined }
+          }
         );
+        assertEventId(window.fbq);
       });
 
       it('should fallback to sku for content_id', function() {
@@ -954,9 +949,9 @@ describe('Facebook Pixel', function() {
             content_category: 'Cars',
             currency: 'USD',
             value: '24.75'
-          },
-          { eventID: undefined }
+          }
         );
+        assertEventId(window.fbq);
       });
 
       it('should fallback to an empty string for content_id', function() {
@@ -980,9 +975,9 @@ describe('Facebook Pixel', function() {
             content_category: 'Cars',
             currency: 'USD',
             value: '24.75'
-          },
-          { eventID: undefined }
+          }
         );
+        assertEventId(window.fbq);
       });
 
       it('should fallback to an empty string for content_name', function() {
@@ -1007,9 +1002,9 @@ describe('Facebook Pixel', function() {
             content_category: 'Cars',
             currency: 'USD',
             value: '24.75'
-          },
-          { eventID: undefined }
+          }
         );
+        assertEventId(window.fbq);
       });
 
       it('should fallback to an empty string for content_category', function() {
@@ -1034,9 +1029,9 @@ describe('Facebook Pixel', function() {
             content_category: '',
             currency: 'USD',
             value: '24.75'
-          },
-          { eventID: undefined }
+          }
         );
+        assertEventId(window.fbq);
       });
 
       it('should use price in the legacy event', function() {
@@ -1065,20 +1060,14 @@ describe('Facebook Pixel', function() {
             content_category: 'cat 1',
             currency: 'USD',
             value: '44.33'
-          },
-          { eventID: undefined }
+          }
         );
-        analytics.called(
-          window.fbq,
-          'trackSingle',
-          options.pixelId,
-          '123456',
-          {
-            currency: 'USD',
-            value: '44.33'
-          },
-          { eventID: undefined }
-        );
+        assertEventId(window.fbq);
+        analytics.called(window.fbq, 'trackSingle', options.pixelId, '123456', {
+          currency: 'USD',
+          value: '44.33'
+        });
+        assertEventId(window.fbq);
       });
 
       it('should not map products if its falsy', function() {
@@ -1094,9 +1083,9 @@ describe('Facebook Pixel', function() {
           {
             content_ids: ['Games'],
             content_type: ['product_group']
-          },
-          { eventID: undefined }
+          }
         );
+        assertEventId(window.fbq);
       });
     });
 
@@ -1128,9 +1117,9 @@ describe('Facebook Pixel', function() {
             content_category: 'cat 1',
             currency: 'USD',
             value: '24.75'
-          },
-          { eventID: undefined }
+          }
         );
+        assertEventId(window.fbq);
       });
 
       it('should send a legacy event for product added', function() {
@@ -1159,21 +1148,15 @@ describe('Facebook Pixel', function() {
             content_category: 'cat 1',
             currency: 'USD',
             value: '24.75'
-          },
-          { eventID: undefined }
+          }
         );
+        assertEventId(window.fbq);
 
-        analytics.called(
-          window.fbq,
-          'trackSingle',
-          options.pixelId,
-          '123456',
-          {
-            currency: 'USD',
-            value: '24.75'
-          },
-          { eventID: undefined }
-        );
+        analytics.called(window.fbq, 'trackSingle', options.pixelId, '123456', {
+          currency: 'USD',
+          value: '24.75'
+        });
+        assertEventId(window.fbq);
       });
 
       it('Should map properties.price to facebooks value if price is selected', function() {
@@ -1200,9 +1183,9 @@ describe('Facebook Pixel', function() {
             content_category: 'cat 1',
             currency: 'USD',
             value: '44.33'
-          },
-          { eventID: undefined }
+          }
         );
+        assertEventId(window.fbq);
       });
 
       it('should send the custom content type if mapped', function() {
@@ -1229,9 +1212,9 @@ describe('Facebook Pixel', function() {
             content_category: 'Cars',
             currency: 'USD',
             value: '24.75'
-          },
-          { eventID: undefined }
+          }
         );
+        assertEventId(window.fbq);
       });
 
       it('should fallback to id for content_id', function() {
@@ -1257,9 +1240,9 @@ describe('Facebook Pixel', function() {
             content_category: 'cat 1',
             currency: 'USD',
             value: '24.75'
-          },
-          { eventID: undefined }
+          }
         );
+        assertEventId(window.fbq);
       });
 
       it('should fallback to sku for content_id', function() {
@@ -1284,9 +1267,9 @@ describe('Facebook Pixel', function() {
             content_category: 'cat 1',
             currency: 'USD',
             value: '24.75'
-          },
-          { eventID: undefined }
+          }
         );
+        assertEventId(window.fbq);
       });
 
       it('should fallback to an empty string for content_id', function() {
@@ -1310,9 +1293,9 @@ describe('Facebook Pixel', function() {
             content_category: 'cat 1',
             currency: 'USD',
             value: '24.75'
-          },
-          { eventID: undefined }
+          }
         );
+        assertEventId(window.fbq);
       });
 
       it('should fallback to an empty string for content_name', function() {
@@ -1337,9 +1320,9 @@ describe('Facebook Pixel', function() {
             content_category: 'cat 1',
             currency: 'USD',
             value: '24.75'
-          },
-          { eventID: undefined }
+          }
         );
+        assertEventId(window.fbq);
       });
 
       it('should fallback to an empty string for content_category', function() {
@@ -1364,9 +1347,9 @@ describe('Facebook Pixel', function() {
             content_category: '',
             currency: 'USD',
             value: '24.75'
-          },
-          { eventID: undefined }
+          }
         );
+        assertEventId(window.fbq);
       });
 
       it('should use price in the legacy event', function() {
@@ -1395,20 +1378,14 @@ describe('Facebook Pixel', function() {
             content_category: 'cat 1',
             currency: 'USD',
             value: '44.33'
-          },
-          { eventID: undefined }
+          }
         );
-        analytics.called(
-          window.fbq,
-          'trackSingle',
-          options.pixelId,
-          '123456',
-          {
-            currency: 'USD',
-            value: '44.33'
-          },
-          { eventID: undefined }
-        );
+        assertEventId(window.fbq);
+        analytics.called(window.fbq, 'trackSingle', options.pixelId, '123456', {
+          currency: 'USD',
+          value: '44.33'
+        });
+        assertEventId(window.fbq);
       });
     });
 
@@ -1439,9 +1416,9 @@ describe('Facebook Pixel', function() {
             content_type: ['product'],
             currency: 'USD',
             value: '0.50'
-          },
-          { eventID: undefined }
+          }
         );
+        assertEventId(window.fbq);
       });
 
       it('Should send both pixel and standard event if mapped', function() {
@@ -1467,20 +1444,14 @@ describe('Facebook Pixel', function() {
             content_type: ['product'],
             currency: 'USD',
             value: '0.50'
-          },
-          { eventID: undefined }
+          }
         );
-        analytics.called(
-          window.fbq,
-          'trackSingle',
-          options.pixelId,
-          '123456',
-          {
-            currency: 'USD',
-            value: '0.50'
-          },
-          { eventID: undefined }
-        );
+        assertEventId(window.fbq);
+        analytics.called(window.fbq, 'trackSingle', options.pixelId, '123456', {
+          currency: 'USD',
+          value: '0.50'
+        });
+        assertEventId(window.fbq);
       });
 
       it('should default to id for content_id', function() {
@@ -1505,9 +1476,9 @@ describe('Facebook Pixel', function() {
             content_type: ['product'],
             currency: 'USD',
             value: '0.50'
-          },
-          { eventID: undefined }
+          }
         );
+        assertEventId(window.fbq);
       });
 
       it('should default to sku for content_id', function() {
@@ -1532,9 +1503,9 @@ describe('Facebook Pixel', function() {
             content_type: ['product'],
             currency: 'USD',
             value: '0.50'
-          },
-          { eventID: undefined }
+          }
         );
+        assertEventId(window.fbq);
       });
 
       it('should send the custom content type if mapped', function() {
@@ -1559,9 +1530,9 @@ describe('Facebook Pixel', function() {
             content_type: ['vehicle'],
             currency: 'USD',
             value: '0.50'
-          },
-          { eventID: undefined }
+          }
         );
+        assertEventId(window.fbq);
       });
     });
 
@@ -1572,16 +1543,10 @@ describe('Facebook Pixel', function() {
 
       it('should send pixel the search string', function() {
         analytics.track('Products Searched', { query: 'yo' });
-        analytics.called(
-          window.fbq,
-          'trackSingle',
-          options.pixelId,
-          'Search',
-          {
-            search_string: 'yo'
-          },
-          { eventID: undefined }
-        );
+        analytics.called(window.fbq, 'trackSingle', options.pixelId, 'Search', {
+          search_string: 'yo'
+        });
+        assertEventId(window.fbq);
       });
 
       it('should send standard and legacy events', function() {
@@ -1590,16 +1555,11 @@ describe('Facebook Pixel', function() {
         };
 
         analytics.track('Products Searched', { query: 'yo' });
-        analytics.called(
-          window.fbq,
-          'trackSingle',
-          options.pixelId,
-          'Search',
-          {
-            search_string: 'yo'
-          },
-          { eventID: undefined }
-        );
+        analytics.called(window.fbq, 'trackSingle', options.pixelId, 'Search', {
+          search_string: 'yo'
+        });
+        assertEventId(window.fbq);
+
         analytics.called(window.fbq, 'trackSingle', options.pixelId, '123456');
       });
     });
@@ -1660,9 +1620,9 @@ describe('Facebook Pixel', function() {
             num_items: 2,
             currency: 'USD',
             content_category: 'NotGames'
-          },
-          { eventID: undefined }
+          }
         );
+        assertEventId(window.fbq);
       });
 
       it('should call InitiateCheckout with the first product category', function() {
@@ -1715,9 +1675,9 @@ describe('Facebook Pixel', function() {
             num_items: 2,
             currency: 'USD',
             content_category: 'Games'
-          },
-          { eventID: undefined }
+          }
         );
+        assertEventId(window.fbq);
       });
 
       it('should send a standard and legacy events', function() {
@@ -1773,20 +1733,14 @@ describe('Facebook Pixel', function() {
             num_items: 2,
             currency: 'USD',
             content_category: 'Games'
-          },
-          { eventID: undefined }
+          }
         );
-        analytics.called(
-          window.fbq,
-          'trackSingle',
-          options.pixelId,
-          '123456',
-          {
-            currency: 'USD',
-            value: '25.00'
-          },
-          { eventID: undefined }
-        );
+        assertEventId(window.fbq);
+        analytics.called(window.fbq, 'trackSingle', options.pixelId, '123456', {
+          currency: 'USD',
+          value: '25.00'
+        });
+        assertEventId(window.fbq);
       });
 
       it('should default to id for content_ids', function() {
@@ -1839,9 +1793,9 @@ describe('Facebook Pixel', function() {
             num_items: 2,
             currency: 'USD',
             content_category: 'Games'
-          },
-          { eventID: undefined }
+          }
         );
+        assertEventId(window.fbq);
       });
 
       it('should default to sku for content_ids', function() {
@@ -1890,9 +1844,9 @@ describe('Facebook Pixel', function() {
             num_items: 2,
             currency: 'USD',
             content_category: 'Games'
-          },
-          { eventID: undefined }
+          }
         );
+        assertEventId(window.fbq);
       });
     });
   });


### PR DESCRIPTION
Bunch of changes all-in-one:
- [DEST-236](https://segment.atlassian.net/browse/DEST-236): Adds custom properties to standard events with a new [setting](https://app.segment.com/partner-portal/integration/facebook-pixel/settings).
- [DEST-682](https://segment.atlassian.net/browse/DEST-682): Allows to override the `content_type` field in the integrations object, as `{ integrations: { 'Facebook Pixel': { contentType: 'myType' } } }`.
- [DEST-777](https://segment.atlassian.net/browse/DEST-777): Adds `content_type` to `Checkout Started` event, as requested in #131 .

The setting and new documentation will remain hidden until this version is released to all customers.  

[CC-4860](https://segment.atlassian.net/browse/CC-4860)