### PR TITLE
[DEST-806][CC-4874] Add Enhanced Matching to Pinterest

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,7 +11,7 @@
     "no-use-before-define": "warn",
     "no-loop-func": "warn",
     "no-restricted-syntax": "warn",
-    "no-continue": "warn",
+    "no-continue": "off",
     "consistent-return": "warn",
     "no-shadow": "warn",
     "no-plusplus": "off"

--- a/integrations/pinterest-tag/package.json
+++ b/integrations/pinterest-tag/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-pinterest-tag",
   "description": "The Pinterest Tag analytics.js integration.",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/pinterest-tag/test/index.test.js
+++ b/integrations/pinterest-tag/test/index.test.js
@@ -16,6 +16,7 @@ describe('Pinterest', function() {
       'Lead Generated': 'Lead',
       'User Signed Up': 'Signup'
     },
+    initWithExistingTraits: false,
     pinterestCustomProperties: ['custom_prop']
   };
 
@@ -41,6 +42,7 @@ describe('Pinterest', function() {
         .global('pintrk')
         .mapping('pinterestEventMapping')
         .option('pinterestCustomProperties', [])
+        .option('initWithExistingTraits', false)
         .option('tid', '')
     );
   });
@@ -48,6 +50,7 @@ describe('Pinterest', function() {
   describe('before loading', function() {
     beforeEach(function() {
       analytics.stub(pinterest, 'load');
+      analytics.stub(window, 'pintrk');
     });
 
     describe('#initialize', function() {
@@ -55,6 +58,45 @@ describe('Pinterest', function() {
         analytics.initialize();
         analytics.page();
         analytics.called(pinterest.load);
+        analytics.called(window.pintrk, 'load', options.tid);
+      });
+    });
+
+    describe('#initialize with traits enabled', function() {
+      before(function() {
+        options.initWithExistingTraits = true;
+      });
+
+      after(function() {
+        options.initWithExistingTraits = false;
+      });
+
+      it("should call init with the user's traits if option enabled", function() {
+        // For existing traits
+        analytics.identify('123', {
+          name: 'Ash Ketchum',
+          email: 'ash@ketchum.com',
+          gender: 'Male',
+          birthday: '01/13/1991',
+          address: {
+            city: 'Emerald',
+            state: 'Kanto',
+            postalCode: 123456
+          }
+        });
+
+        analytics.initialize();
+
+        analytics.called(window.pintrk, 'load', options.tid, {
+          em: 'ash@ketchum.com'
+        });
+      });
+
+      it("should call init with the user's traits if option enabled but no identify call was made", function() {
+        analytics.reset();
+        analytics.initialize();
+
+        analytics.called(window.pintrk, 'load', options.tid);
       });
     });
   });


### PR DESCRIPTION
Adds [Enhanced Matching](https://developers.pinterest.com/docs/ad-tools/enhanced-match/?) to Pinterest Tag integration. The customer needs to enable the new setting `initWithExistingTraits` to have this functionality on page load.

- [DEST-806](https://segment.atlassian.net/browse/DEST-806)
- [CC-4874](https://segment.atlassian.net/browse/CC-4874)

This is a follow up for #96 