### PR TITLE
Removed nested objects from Braze identify and tracking calls

### DIFF
--- a/integrations/appboy/lib/index.js
+++ b/integrations/appboy/lib/index.js
@@ -312,7 +312,7 @@ Appboy.prototype.identify = function(identify) {
   each(function(value, key) {
     if (
       typeof value === 'object' &&
-      Object.prototype.toString.call(value) !== '[object Array]'
+      Array.isArray(value)
     ) {
       delete traits[key];
     }
@@ -370,7 +370,7 @@ Appboy.prototype.track = function(track) {
   // Remove nested objects as Braze doesn't support nested objects in tracking calls
   // https://segment.com/docs/destinations/braze/#track
   each(function(value, key) {
-    if (typeof value === 'object') {
+    if (val != null && typeof value === 'object') {
       delete properties[key];
     }
   }, properties);

--- a/integrations/appboy/lib/index.js
+++ b/integrations/appboy/lib/index.js
@@ -307,6 +307,17 @@ Appboy.prototype.identify = function(identify) {
     delete traits[key];
   }, reserved);
 
+  // Remove nested hash objects as Braze only supports nested array objects in identify calls
+  // https://segment.com/docs/destinations/braze/#identify
+  each(function(value, key) {
+    if (
+      typeof value === 'object' &&
+      Object.prototype.toString.call(value) !== '[object Array]'
+    ) {
+      delete traits[key];
+    }
+  }, traits);
+
   each(function(value, key) {
     window.appboy.getUser().setCustomUserAttribute(key, value);
   }, traits);
@@ -355,6 +366,14 @@ Appboy.prototype.track = function(track) {
   each(function(key) {
     delete properties[key];
   }, reserved);
+
+  // Remove nested objects as Braze doesn't support nested objects in tracking calls
+  // https://segment.com/docs/destinations/braze/#track
+  each(function(value, key) {
+    if (typeof value === 'object') {
+      delete properties[key];
+    }
+  }, properties);
 
   window.appboy.changeUser(userId);
   window.appboy.logCustomEvent(eventName, properties);

--- a/integrations/appboy/lib/index.js
+++ b/integrations/appboy/lib/index.js
@@ -370,7 +370,7 @@ Appboy.prototype.track = function(track) {
   // Remove nested objects as Braze doesn't support nested objects in tracking calls
   // https://segment.com/docs/destinations/braze/#track
   each(function(value, key) {
-    if (val != null && typeof value === 'object') {
+    if (value != null && typeof value === 'object') {
       delete properties[key];
     }
   }, properties);

--- a/integrations/appboy/package.json
+++ b/integrations/appboy/package.json
@@ -6,6 +6,7 @@
     "analytics.js",
     "analytics.js-integration",
     "segment",
+    "Braze",
     "Appboy"
   ],
   "main": "lib/index.js",

--- a/integrations/appboy/package.json
+++ b/integrations/appboy/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-appboy",
   "description": "The Appboy analytics.js integration.",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/appboy/test/index.test.js
+++ b/integrations/appboy/test/index.test.js
@@ -335,10 +335,11 @@ describe('Appboy', function() {
         );
       });
 
-      it('should handle custom traits of all types', function() {
+      it('should handle custom traits of acceptable types and excludes nested hashes', function() {
         analytics.identify('userId', {
           song: "Who's That Chick?",
           artists: ['David Guetta', 'Rihanna'],
+          details: { nested: 'object' },
           number: 16,
           date: 'Tue Apr 25 2017 14:22:48 GMT-0700 (PDT)'
         });
@@ -407,11 +408,14 @@ describe('Appboy', function() {
         analytics.called(window.appboy.logCustomEvent, 'event');
       });
 
-      it('should send all properties', function() {
+      it('should send all properties except nested arrays and hashes', function() {
         analytics.track('event with properties', {
           nickname: 'noonz',
           spiritAnimal: 'rihanna',
-          best_friend: 'han'
+          best_friend: 'han',
+          number_of_friends: 12,
+          idols: ['beyonce', 'madonna'],
+          favoriteThings: { whiskers: 'on-kittins' }
         });
         analytics.called(
           window.appboy.logCustomEvent,
@@ -419,7 +423,8 @@ describe('Appboy', function() {
           {
             nickname: 'noonz',
             spiritAnimal: 'rihanna',
-            best_friend: 'han'
+            best_friend: 'han',
+            number_of_friends: 12
           }
         );
       });


### PR DESCRIPTION
**What does this PR do?**
Stops the plugin from erroring when analytics.track or identify calls are made with incompatible nested object data for Braze.

**Are there breaking changes in this PR?**
No

**Any background context you want to provide?**
This is related to Segment tech support ticket 353525

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
Yes, at least iOS does similar sanitization before attempting to send data to Braze
https://github.com/segmentio/analytics.js-integrations/blob/master/integrations/appboy/lib/index.js#L256

**Does this require a new integration setting? If so, please explain how the new setting works**
No

**Links to helpful docs and other external resources**
Segment's own docs cover several times that nested data is not accepted by Braze in these calls.
https://segment.com/docs/destinations/braze/#identify