### PR TITLE
    Allow revenue type variables to be passed when dealing with stand…

### DIFF
--- a/integrations/amplitude/lib/index.js
+++ b/integrations/amplitude/lib/index.js
@@ -434,7 +434,7 @@ function mapRevenueAttributes(track) {
     price: track.price(),
     productId: track.productId(),
     revenueType:
-      track.proxy('properties.revenueType') ||
+      track.proxy('properties.revenueType') ? track.proxy('properties.revenueType') :
       mapRevenueType[track.event().toLowerCase()],
     quantity: track.quantity(),
     eventProps: track.properties(),

--- a/integrations/amplitude/test/index.test.js
+++ b/integrations/amplitude/test/index.test.js
@@ -539,6 +539,29 @@ describe('Amplitude', function() {
         );
       });
 
+      it('should send a revenueV2 event with quantity and productId and revenueType if a standard event type is used', function() {
+        amplitude.options.useLogRevenueV2 = true;
+        var props = {
+          revenue: 20.0,
+          quantity: 2,
+          price: 10.0,
+          productId: 'AMP1',
+          revenueType: 'I am custom'
+        };
+        analytics.track('Completed Order', props);
+        var ampRevenue = new window.amplitude.Revenue()
+          .setPrice(10.0)
+          .setQuantity(2)
+          .setProductId('AMP1');
+        ampRevenue.setRevenueType(props.revenueType).setEventProperties(props);
+
+        analytics.didNotCall(window.amplitude.getInstance().logRevenue);
+        analytics.called(
+          window.amplitude.getInstance().logRevenueV2,
+          ampRevenue
+        );
+      });
+
       it('should send a revenueV2 event with revenue if missing price', function() {
         amplitude.options.useLogRevenueV2 = true;
         analytics.track('event', {


### PR DESCRIPTION
This PR addresses the following bug.  Thanks for your forbearance as we learn the integration standards.


Amplitude revenueType

Amplitude: revenueType hard-coded
Description: The documented behavior that a customer is able to pass in revenueType and explicitly set what type of revenue it is in their Order Completed events, is not currently working. This is crucial to see Amplitude LTV charts correctly.
Severity: Medium
Steps to reproduce:

1. Send an event like so: analytics.track('Order Completed', {revenue: 300, revenueType: 'Refund'}
2. )
3. Open Network Tab and see the call made to Amplitude: "event_properties": {"revenue":300,"revenueType":"refund"}
4. https://cl.ly/9641cf9a7b15
5. Send an event that isn't currently mapped within our code here https://github.com/segmentio/analytics.js-integrations/blob/master/integrations/amplitude/lib/index.js#L424-L443 such as analytics.track('Sara Event', {revenue: 300, revenueType: 'refund'}
6. );
7. Open Network Tab and see the call made to Amplitude: "$revenueType":"refund" where the property being sent has a $-sign indicating that it's mapped to a specific Amplitude property, not an event_property. https://cl.ly/bc15fb39e349
8. In Amplitude, you can see the difference in how this makes it to the UI: https://cl.ly/67395324d918 and https://cl.ly/e2e9afe30eed. In order for the Amplitude LTV charts to populate correctly, it must register under $revenueType, not revenueType.

The issue seems to be here where we use an OR operator: https://github.com/segmentio/analytics.js-integrations/blob/master/integrations/amplitude/lib/index.js#L436-L438rather than a ternary conditional. Which means that it falls back on the mapping automatically: https://github.com/segmentio/analytics.js-integrations/blob/master/integrations/amplitude/lib/index.js#L427-L431and doesn't let a customer pass this in themselves.
Expected Behavior: Customers should be able to explicitly specify the revenueType as we have documented and set within the UI: https://cl.ly/30a7cdae92c9
Actual Behavior: All revenueType events are being set to Purchase events



**What does this PR do?**

This PR allows custom revenue type values to be passed even when standard event types, such as 'Order Completed' are passed.

**Are there breaking changes in this PR?**

No.

**Any background context you want to provide?**

See the detailed production description above.

**Is there parity with the server-side/android/iOS integration components (if applicable)?**

N/A

**Does this require a new integration setting? If so, please explain how the new setting works**

N/A

**Links to helpful docs and other external resources**
