### PR TITLE
Brie/nielsen dcr asset

### DIFF
--- a/integrations/nielsen-dcr/lib/index.js
+++ b/integrations/nielsen-dcr/lib/index.js
@@ -16,6 +16,7 @@ var NielsenDCR = (module.exports = integration('Nielsen DCR')
   .option('appId', '')
   .option('instanceName', '') // the snippet lets you override the instance so make sure you don't have any global window props w same value as this setting unless you are intentionally doing that.
   .option('nolDevDebug', false)
+  .option('assetIdPropertyName', 'asset_id')
   .option('optout', false)
   .tag(
     'http',
@@ -160,7 +161,7 @@ NielsenDCR.prototype.getContentMetadata = function(track, type) {
   var integrationOpts = track.options(this.name);
   var contentMetadata = {
     type: 'content',
-    assetid: track.proxy(properties + 'asset_id'),
+    assetid: getAssetId(track, this.options.assetIdPropertyName, type),
     program: track.proxy(properties + 'program'),
     title: track.proxy(properties + 'title'),
     // hardcode 86400 if livestream ¯\_(ツ)_/¯
@@ -176,6 +177,7 @@ NielsenDCR.prototype.getContentMetadata = function(track, type) {
     crossId2: find(integrationOpts, 'crossId2'),
     hasAds: find(integrationOpts, 'hasAds') === true ? '1' : '0'
   };
+
   // optional: used for grouping data into different buckets
   var segB = find(integrationOpts, 'segB');
   var segC = find(integrationOpts, 'segC');
@@ -194,10 +196,12 @@ NielsenDCR.prototype.getContentMetadata = function(track, type) {
 NielsenDCR.prototype.getAdMetadata = function(track) {
   var type = track.proxy('properties.type');
   var adMetadata;
+  var assetId = getAssetId(track, this.options.assetIdPropertyName);
 
   if (typeof type === 'string') type = type.replace('-', '');
+
   adMetadata = {
-    assetid: track.proxy('ad_asset_id') || track.proxy('asset_id'),
+    assetid: track.proxy('ad_asset_id') || assetId,
     type: type
   };
   return adMetadata;
@@ -237,7 +241,7 @@ NielsenDCR.prototype.videoContentStarted = function(track) {
 NielsenDCR.prototype.videoContentPlaying = function(track) {
   clearInterval(this.heartbeatId);
 
-  var assetId = track.proxy('properties.asset_id');
+  var assetId = getAssetId(track, this.options.assetIdPropertyName);
   var position = track.proxy('properties.position');
   var livestream = track.proxy('properties.livestream');
 
@@ -277,7 +281,7 @@ NielsenDCR.prototype.videoContentCompleted = function(track) {
 NielsenDCR.prototype.videoAdStarted = function(track) {
   clearInterval(this.heartbeatId);
 
-  var adAssetId = track.proxy('properties.asset_id');
+  var adAssetId = getAssetId(track, this.options.assetIdPropertyName);
   var position = track.proxy('properties.position');
   var type = track.proxy('properties.type');
   if (typeof type === 'string') type = type.replace('-', '');
@@ -305,7 +309,7 @@ NielsenDCR.prototype.videoAdStarted = function(track) {
 NielsenDCR.prototype.videoAdPlaying = function(track) {
   clearInterval(this.heartbeatId);
 
-  var assetId = track.proxy('properties.asset_id');
+  var assetId = getAssetId(track, this.options.assetIdPropertyName);
   var position = track.proxy('properties.position');
   this.heartbeat(assetId, position, { type: 'ad' });
 };
@@ -441,3 +445,25 @@ NielsenDCR.prototype.videoPlaybackCompleted = function(track) {
   this.currentAssetId = null;
   this.heartbeatId = null;
 };
+
+/**
+ * Get Asset ID
+ *
+ * @param {Track} track
+ * @return {string}
+ * @api private
+ */
+
+function getAssetId(track, customAssetId, type) {
+  var assetIdValue;
+  var properties = 'properties.';
+  if (customAssetId !== 'asset_id') {
+    assetIdValue = track.proxy(properties + customAssetId);
+  } else if (type === 'preroll') {
+    properties = 'properties.content.';
+    assetIdValue = track.proxy(properties + 'asset_id');
+  } else {
+    assetIdValue = track.proxy(properties + 'asset_id');
+  }
+  return assetIdValue;
+}

--- a/integrations/nielsen-dcr/package.json
+++ b/integrations/nielsen-dcr/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-nielsen-dcr",
   "description": "The Nielsen DCR analytics.js integration.",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/nielsen-dcr/test/index.test.js
+++ b/integrations/nielsen-dcr/test/index.test.js
@@ -223,9 +223,9 @@ describe('NielsenDCR', function() {
             title: 'Interview with Tony Robbins',
             description: 'short description',
             keywords: ['entrepreneurship', 'motivation'],
-            tms_video_id: '12345',
             season: '2',
             episode: '177',
+            custom_asset_id_prop: '12345',
             genre: 'entrepreneurship',
             program: 'Tim Ferris Show',
             publisher: 'Tim Ferris',
@@ -270,14 +270,50 @@ describe('NielsenDCR', function() {
           );
         });
 
-        it('video content started with custom assetId', function() {
+        it('video content started with custom asset id', function() {
           var timestamp = new Date();
+          nielsenDCR.options.assetIdPropertyName = 'custom_asset_id_prop';
           analytics.track('Video Content Started', props, {
             page: { url: 'segment.com' },
             'Nielsen DCR': { ad_load_type: 'dynamic' },
             timestamp: timestamp
           });
-          nielsenDCR.options.assetIdPropertyName = 'tms_video_id';
+          analytics.called(window.clearInterval);
+          analytics.called(nielsenDCR._client.ggPM, 'loadMetadata', {
+            type: 'content',
+            assetid: props.custom_asset_id_prop,
+            program: props.program,
+            title: props.title,
+            length: props.total_length,
+            isfullepisode: 'y',
+            mediaURL: 'segment.com',
+            airdate: new Date(props.airdate),
+            adloadtype: '2',
+            hasAds: '0'
+          });
+          analytics.called(
+            nielsenDCR.heartbeat,
+            props.custom_asset_id_prop,
+            props.position,
+            {
+              livestream: props.livestream,
+              type: 'content',
+              timestamp: timestamp
+            }
+          );
+        });
+
+        it('video content started with cid/vcid override', function() {
+          var timestamp = new Date();
+          nielsenDCR.options.clientIdPropertyName = 'nielsen_client_id';
+          nielsenDCR.options.subbrandPropertyName = 'nielsen_subbrand';
+          props.nielsen_subbrand = 'test network name';
+          props.nielsen_client_id = 'test client id';
+          analytics.track('Video Content Started', props, {
+            page: { url: 'segment.com' },
+            'Nielsen DCR': { ad_load_type: 'dynamic' },
+            timestamp: timestamp
+          });
           analytics.called(window.clearInterval);
           analytics.called(nielsenDCR._client.ggPM, 'loadMetadata', {
             type: 'content',
@@ -289,7 +325,9 @@ describe('NielsenDCR', function() {
             mediaURL: 'segment.com',
             airdate: new Date(props.airdate),
             adloadtype: '2',
-            hasAds: '0'
+            hasAds: '0',
+            clientid: props.nielsen_client_id,
+            subbrand: props.nielsen_subbrand
           });
           analytics.called(
             nielsenDCR.heartbeat,
@@ -432,6 +470,7 @@ describe('NielsenDCR', function() {
           props = {
             session_id: '12345',
             asset_id: 'ad123',
+            custom_asset_id_prop: 'abcdef12345',
             pod_id: 'adSegA',
             type: 'mid-roll',
             title: 'Segment Connection Modes',
@@ -457,11 +496,28 @@ describe('NielsenDCR', function() {
           );
         });
 
+        it('video ad started with custom asset id', function() {
+          nielsenDCR.options.assetIdPropertyName = 'custom_asset_id_prop';
+          analytics.track('Video Ad Started', props);
+          analytics.called(window.clearInterval);
+          analytics.called(nielsenDCR._client.ggPM, 'loadMetadata', {
+            assetid: props.asset_id,
+            type: 'midroll'
+          });
+          analytics.called(
+            nielsenDCR.heartbeat,
+            props.asset_id,
+            props.position,
+            { type: 'ad' }
+          );
+        });
+
         it('video ad started — preroll', function() {
           props.type = 'pre-roll';
           props.content = {
             session_id: '12345',
             asset_id: '0129370',
+            custom_asset_id_prop: 'abcdef12345',
             pod_id: 'segA',
             title: 'Interview with Tony Robbins',
             description: 'short description',
@@ -512,6 +568,125 @@ describe('NielsenDCR', function() {
           );
         });
 
+        it('video ad started — preroll with custom asset id', function() {
+          props.type = 'pre-roll';
+          props.content = {
+            session_id: '12345',
+            asset_id: '0129370',
+            custom_asset_id_prop: 'abcdef12345',
+            pod_id: 'segA',
+            title: 'Interview with Tony Robbins',
+            description: 'short description',
+            keywords: ['entrepreneurship', 'motivation'],
+            season: '2',
+            episode: '177',
+            genre: 'entrepreneurship',
+            program: 'Tim Ferris Show',
+            publisher: 'Tim Ferris',
+            position: 0,
+            total_length: 360,
+            channel: 'espn',
+            full_episode: true,
+            livestream: false,
+            airdate: '1991-08-13'
+          };
+          nielsenDCR.options.assetIdPropertyName = 'custom_asset_id_prop';
+          analytics.track('Video Ad Started', props, {
+            page: { url: 'segment.com' }
+          });
+          analytics.called(window.clearInterval);
+          analytics.assert.deepEqual(nielsenDCR._client.ggPM.args[0], [
+            'loadMetadata',
+            {
+              type: 'content',
+              assetid: props.content.custom_asset_id_prop,
+              program: props.content.program,
+              title: props.content.title,
+              length: props.content.total_length,
+              isfullepisode: 'y',
+              mediaURL: 'segment.com',
+              airdate: new Date(props.content.airdate),
+              adloadtype: '2',
+              hasAds: '0'
+            }
+          ]);
+          analytics.assert.deepEqual(nielsenDCR._client.ggPM.args[1], [
+            'loadMetadata',
+            {
+              assetid: props.asset_id,
+              type: 'preroll'
+            }
+          ]);
+          analytics.called(
+            nielsenDCR.heartbeat,
+            props.asset_id,
+            props.position,
+            { type: 'ad' }
+          );
+        });
+
+        it('video ad started — preroll with cid/vcid override', function() {
+          nielsenDCR.options.clientIdPropertyName = 'nielsen_client_id';
+          nielsenDCR.options.subbrandPropertyName = 'nielsen_subbrand';
+          props.type = 'pre-roll';
+          props.content = {
+            session_id: '12345',
+            asset_id: '0129370',
+            custom_asset_id_prop: 'abcdef12345',
+            nielsen_subbrand: 'test network name',
+            nielsen_client_id: 'test client id',
+            pod_id: 'segA',
+            title: 'Interview with Tony Robbins',
+            description: 'short description',
+            keywords: ['entrepreneurship', 'motivation'],
+            season: '2',
+            episode: '177',
+            genre: 'entrepreneurship',
+            program: 'Tim Ferris Show',
+            publisher: 'Tim Ferris',
+            position: 0,
+            total_length: 360,
+            channel: 'espn',
+            full_episode: true,
+            livestream: false,
+            airdate: '1991-08-13'
+          };
+          analytics.track('Video Ad Started', props, {
+            page: { url: 'segment.com' }
+          });
+          analytics.called(window.clearInterval);
+          analytics.assert.deepEqual(nielsenDCR._client.ggPM.args[0], [
+            'loadMetadata',
+            {
+              type: 'content',
+              assetid: props.content.asset_id,
+              program: props.content.program,
+              title: props.content.title,
+              length: props.content.total_length,
+              isfullepisode: 'y',
+              mediaURL: 'segment.com',
+              airdate: new Date(props.content.airdate),
+              adloadtype: '2',
+              hasAds: '0',
+              clientid: props.content.nielsen_client_id,
+              subbrand: props.content.nielsen_subbrand
+            }
+          ]);
+          analytics.assert.deepEqual(nielsenDCR._client.ggPM.args[1], [
+            'loadMetadata',
+            {
+              assetid: props.asset_id,
+              type: 'preroll'
+            }
+          ]);
+          analytics.called(
+            nielsenDCR.heartbeat,
+            props.asset_id,
+            props.position,
+            { type: 'ad' }
+          );
+        });
+
         // heartbeats
         it('video ad playing', function() {
           analytics.track('Video Ad Playing', props);
@@ -533,98 +708,6 @@ describe('NielsenDCR', function() {
             props.position
           );
           analytics.called(nielsenDCR._client.ggPM, 'stop', props.position);
-        });
-      });
-
-      describe('#custom setting events', function() {
-        var props;
-        beforeEach(function() {
-          props = {
-            session_id: '12345',
-            asset_id: '0129370',
-            pod_id: 'segA',
-            title: 'Interview with Tony Robbins',
-            description: 'short description',
-            keywords: ['entrepreneurship', 'motivation'],
-            custom_asset_id_prop: '12345',
-            season: '2',
-            episode: '177',
-            genre: 'entrepreneurship',
-            program: 'Tim Ferris Show',
-            publisher: 'Tim Ferris',
-            position: 0,
-            total_length: 360,
-            channel: 'espn',
-            full_episode: true,
-            livestream: false,
-            airdate: '1991-08-13'
-          };
-          // nielsenDCR.options.assetIdPropertyName = 'custom_asset_id_prop'
-        });
-
-        it('video content started with custom asset id setting and prop in payload', function() {
-          var timestamp = new Date();
-          nielsenDCR.options.assetIdPropertyName = 'custom_asset_id_prop';
-          analytics.track('Video Content Started', props, {
-            page: { url: 'segment.com' },
-            'Nielsen DCR': { ad_load_type: 'dynamic' },
-            timestamp: timestamp
-          });
-          analytics.called(window.clearInterval);
-          analytics.called(nielsenDCR._client.ggPM, 'loadMetadata', {
-            type: 'content',
-            assetid: props.custom_asset_id_prop,
-            program: props.program,
-            title: props.title,
-            length: props.total_length,
-            isfullepisode: 'y',
-            mediaURL: 'segment.com',
-            airdate: new Date(props.airdate),
-            adloadtype: '2',
-            hasAds: '0'
-          });
-          analytics.called(
-            nielsenDCR.heartbeat,
-            props.custom_asset_id_prop,
-            props.position,
-            {
-              livestream: props.livestream,
-              type: 'content',
-              timestamp: timestamp
-            }
-          );
-        });
-
-        it('video content started sends default with asset_id with not custom asset id setting', function() {
-          var timestamp = new Date();
-          analytics.track('Video Content Started', props, {
-            page: { url: 'segment.com' },
-            'Nielsen DCR': { ad_load_type: 'dynamic' },
-            timestamp: timestamp
-          });
-          analytics.called(window.clearInterval);
-          analytics.called(nielsenDCR._client.ggPM, 'loadMetadata', {
-            type: 'content',
-            assetid: props.asset_id,
-            program: props.program,
-            title: props.title,
-            length: props.total_length,
-            isfullepisode: 'y',
-            mediaURL: 'segment.com',
-            airdate: new Date(props.airdate),
-            adloadtype: '2',
-            hasAds: '0'
-          });
-          analytics.called(
-            nielsenDCR.heartbeat,
-            props.asset_id,
-            props.position,
-            {
-              livestream: props.livestream,
-              type: 'content',
-              timestamp: timestamp
-            }
-          );
         });
       });
     });

--- a/integrations/nielsen-dcr/test/index.test.js
+++ b/integrations/nielsen-dcr/test/index.test.js
@@ -38,6 +38,7 @@ describe('NielsenDCR', function() {
       integration('Nielsen DCR')
         .option('appId', '')
         .option('instanceName', '')
+        .option('assetIdPropertyName', 'asset_id')
         .tag(
           'http',
           '<script src="http://cdn-gl.imrworldwide.com/conf/{{ appId }}.js#name={{ instanceName }}&ns=NOLBUNDLE">'
@@ -222,6 +223,7 @@ describe('NielsenDCR', function() {
             title: 'Interview with Tony Robbins',
             description: 'short description',
             keywords: ['entrepreneurship', 'motivation'],
+            tms_video_id: '12345',
             season: '2',
             episode: '177',
             genre: 'entrepreneurship',
@@ -243,6 +245,39 @@ describe('NielsenDCR', function() {
             'Nielsen DCR': { ad_load_type: 'dynamic' },
             timestamp: timestamp
           });
+          analytics.called(window.clearInterval);
+          analytics.called(nielsenDCR._client.ggPM, 'loadMetadata', {
+            type: 'content',
+            assetid: props.asset_id,
+            program: props.program,
+            title: props.title,
+            length: props.total_length,
+            isfullepisode: 'y',
+            mediaURL: 'segment.com',
+            airdate: new Date(props.airdate),
+            adloadtype: '2',
+            hasAds: '0'
+          });
+          analytics.called(
+            nielsenDCR.heartbeat,
+            props.asset_id,
+            props.position,
+            {
+              livestream: props.livestream,
+              type: 'content',
+              timestamp: timestamp
+            }
+          );
+        });
+
+        it('video content started with custom assetId', function() {
+          var timestamp = new Date();
+          analytics.track('Video Content Started', props, {
+            page: { url: 'segment.com' },
+            'Nielsen DCR': { ad_load_type: 'dynamic' },
+            timestamp: timestamp
+          });
+          nielsenDCR.options.assetIdPropertyName = 'tms_video_id';
           analytics.called(window.clearInterval);
           analytics.called(nielsenDCR._client.ggPM, 'loadMetadata', {
             type: 'content',
@@ -498,6 +533,98 @@ describe('NielsenDCR', function() {
             props.position
           );
           analytics.called(nielsenDCR._client.ggPM, 'stop', props.position);
+        });
+      });
+
+      describe('#custom setting events', function() {
+        var props;
+        beforeEach(function() {
+          props = {
+            session_id: '12345',
+            asset_id: '0129370',
+            pod_id: 'segA',
+            title: 'Interview with Tony Robbins',
+            description: 'short description',
+            keywords: ['entrepreneurship', 'motivation'],
+            custom_asset_id_prop: '12345',
+            season: '2',
+            episode: '177',
+            genre: 'entrepreneurship',
+            program: 'Tim Ferris Show',
+            publisher: 'Tim Ferris',
+            position: 0,
+            total_length: 360,
+            channel: 'espn',
+            full_episode: true,
+            livestream: false,
+            airdate: '1991-08-13'
+          };
+          // nielsenDCR.options.assetIdPropertyName = 'custom_asset_id_prop'
+        });
+
+        it('video content started with custom asset id setting and prop in payload', function() {
+          var timestamp = new Date();
+          nielsenDCR.options.assetIdPropertyName = 'custom_asset_id_prop';
+          analytics.track('Video Content Started', props, {
+            page: { url: 'segment.com' },
+            'Nielsen DCR': { ad_load_type: 'dynamic' },
+            timestamp: timestamp
+          });
+          analytics.called(window.clearInterval);
+          analytics.called(nielsenDCR._client.ggPM, 'loadMetadata', {
+            type: 'content',
+            assetid: props.custom_asset_id_prop,
+            program: props.program,
+            title: props.title,
+            length: props.total_length,
+            isfullepisode: 'y',
+            mediaURL: 'segment.com',
+            airdate: new Date(props.airdate),
+            adloadtype: '2',
+            hasAds: '0'
+          });
+          analytics.called(
+            nielsenDCR.heartbeat,
+            props.custom_asset_id_prop,
+            props.position,
+            {
+              livestream: props.livestream,
+              type: 'content',
+              timestamp: timestamp
+            }
+          );
+        });
+
+        it('video content started sends default with asset_id with not custom asset id setting', function() {
+          var timestamp = new Date();
+          analytics.track('Video Content Started', props, {
+            page: { url: 'segment.com' },
+            'Nielsen DCR': { ad_load_type: 'dynamic' },
+            timestamp: timestamp
+          });
+          analytics.called(window.clearInterval);
+          analytics.called(nielsenDCR._client.ggPM, 'loadMetadata', {
+            type: 'content',
+            assetid: props.asset_id,
+            program: props.program,
+            title: props.title,
+            length: props.total_length,
+            isfullepisode: 'y',
+            mediaURL: 'segment.com',
+            airdate: new Date(props.airdate),
+            adloadtype: '2',
+            hasAds: '0'
+          });
+          analytics.called(
+            nielsenDCR.heartbeat,
+            props.asset_id,
+            props.position,
+            {
+              livestream: props.livestream,
+              type: 'content',
+              timestamp: timestamp
+            }
+          );
         });
       });
     });


### PR DESCRIPTION
**What does this PR do?**
* Add functionality to set custom `assetId` will default to `asset_id` 
* Add functionality to override cid utilizing `clientIdPropertyName` mapped to clientid in content loadMetadata when present.
* Add functionality to override vcid utilizing `subbrandProperty` mapped to subbrand in content loadMetadata when present.

**Are there breaking changes in this PR?**
No 

**Any background context you want to provide?**


**Is there parity with the server-side/android/iOS integration components (if applicable)?**
* Parity with iOS and Android 

**Does this require a new integration setting? If so, please explain how the new setting works**
* Three new settings: 
1. `assetIdPropertyName`: string that maps to property value. That value will be assigned to Nielsen assetid value
2. `clientIdPropertyName`: string that maps to property value. That value will be assigned to Nielsen clientid value when present in content loadMetadata
2. `subbrandPropertyName`: string that maps to property value. That value will be assigned to Nielsen subbrand value when present in content loadMetadata

**Links to helpful docs and other external resources**
N/A