### PR TITLE
Change length in content metadata to leverage new setting

### DIFF
--- a/integrations/nielsen-dcr/lib/index.js
+++ b/integrations/nielsen-dcr/lib/index.js
@@ -19,6 +19,7 @@ var NielsenDCR = (module.exports = integration('Nielsen DCR')
   .option('assetIdPropertyName', 'asset_id')
   .option('subbrandPropertyName', '')
   .option('clientIdPropertyName', '')
+  .option('contentLengthPropertyName', 'total_length')
   .option('optout', false)
   .tag(
     'http',
@@ -166,10 +167,6 @@ NielsenDCR.prototype.getContentMetadata = function(track, type) {
     assetid: getAssetId(track, this.options.assetIdPropertyName, type),
     program: track.proxy(properties + 'program'),
     title: track.proxy(properties + 'title'),
-    // hardcode 86400 if livestream ¯\_(ツ)_/¯
-    length: track.proxy(properties + 'livestream')
-      ? 86400
-      : track.proxy(properties + 'total_length'),
     isfullepisode: track.proxy(properties + 'full_episode') ? 'y' : 'n',
     mediaURL: track.proxy('context.page.url'),
     airdate: track.proxy(properties + 'airdate'),
@@ -179,6 +176,16 @@ NielsenDCR.prototype.getContentMetadata = function(track, type) {
     crossId2: find(integrationOpts, 'crossId2'),
     hasAds: find(integrationOpts, 'hasAds') === true ? '1' : '0'
   };
+
+  if (track.proxy(properties + 'livestream')) {
+    // hardcode 86400 if livestream ¯\_(ツ)_/¯
+    contentMetadata.length = 86400;
+  } else if (this.options.contentLengthPropertyName !== 'total_length') {
+    var contentLengthKey = this.options.contentLengthPropertyName;
+    contentMetadata.length = track.proxy(properties + contentLengthKey);
+  } else {
+    contentMetadata.length = track.proxy(properties + 'total_length');
+  }
 
   if (this.options.subbrandPropertyName) {
     var subbrandProp = this.options.subbrandPropertyName;

--- a/integrations/nielsen-dcr/package.json
+++ b/integrations/nielsen-dcr/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-nielsen-dcr",
   "description": "The Nielsen DCR analytics.js integration.",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/nielsen-dcr/test/index.test.js
+++ b/integrations/nielsen-dcr/test/index.test.js
@@ -270,7 +270,7 @@ describe('NielsenDCR', function() {
           );
         });
 
-        it('video content started with custom asset id', function() {
+        it('video content started - custom asset id', function() {
           var timestamp = new Date();
           nielsenDCR.options.assetIdPropertyName = 'custom_asset_id_prop';
           analytics.track('Video Content Started', props, {
@@ -294,6 +294,40 @@ describe('NielsenDCR', function() {
           analytics.called(
             nielsenDCR.heartbeat,
             props.custom_asset_id_prop,
+            props.position,
+            {
+              livestream: props.livestream,
+              type: 'content',
+              timestamp: timestamp
+            }
+          );
+        });
+
+        it('video content started - custom content length', function() {
+          var timestamp = new Date();
+          nielsenDCR.options.contentLengthPropertyName = 'total_content_length';
+          props.total_content_length = 460;
+          analytics.track('Video Content Started', props, {
+            page: { url: 'segment.com' },
+            'Nielsen DCR': { ad_load_type: 'dynamic' },
+            timestamp: timestamp
+          });
+          analytics.called(window.clearInterval);
+          analytics.called(nielsenDCR._client.ggPM, 'loadMetadata', {
+            type: 'content',
+            assetid: props.asset_id,
+            program: props.program,
+            title: props.title,
+            length: props.total_content_length,
+            isfullepisode: 'y',
+            mediaURL: 'segment.com',
+            airdate: new Date(props.airdate),
+            adloadtype: '2',
+            hasAds: '0'
+          });
+          analytics.called(
+            nielsenDCR.heartbeat,
+            props.asset_id,
             props.position,
             {
               livestream: props.livestream,


### PR DESCRIPTION
**What does this PR do?**
Change length in content metadata to leverage new setting `contentLengthPropertyName`. Still defaults to `total_length`. 

**Are there breaking changes in this PR?**
No


**Any background context you want to provide?**
N/A 

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
* Yes. 

**Does this require a new integration setting? If so, please explain how the new setting works**
New setting `contentLengthPropertyName`. If customer provides value in setting we will use that property mapping to map that value to Nielsen `length` in contentMetdata. 

**Links to helpful docs and other external resources**
