### PR TITLE
[DEST-294][CC-4895] Support revenueType when trackRevenuePerProduct is set

### DIFF
--- a/integrations/amplitude/package.json
+++ b/integrations/amplitude/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-amplitude",
   "description": "The Amplitude analytics.js integration.",
-  "version": "3.0.2",
+  "version": "3.0.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/amplitude/package.json
+++ b/integrations/amplitude/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-amplitude",
   "description": "The Amplitude analytics.js integration.",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/amplitude/package.json
+++ b/integrations/amplitude/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-amplitude",
   "description": "The Amplitude analytics.js integration.",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/amplitude/test/index.test.js
+++ b/integrations/amplitude/test/index.test.js
@@ -674,6 +674,43 @@ describe('Amplitude', function() {
         };
       });
 
+      it('should send a custom revenueType if trackRevenuePerProduct is set', function() {
+        amplitude.options.useLogRevenueV2 = true;
+        amplitude.options.trackRevenuePerProduct = true;
+        var props = {
+          revenue: 20.0,
+          revenueType: 'I am custom',
+          products: [
+            {
+              quantity: 2,
+              price: 10.0,
+              productId: 'AMP1'
+            }
+          ]
+        };
+
+        var setRevenue = sinon.spy(amplitude, 'setRevenue');
+
+        analytics.track('Completed Order', props);
+
+        var expected = {
+          price: 10.0,
+          productId: 'AMP1',
+          revenueType: 'I am custom',
+          quantity: 2,
+          eventProps: {
+            revenue: 20.0,
+            revenueType: 'I am custom',
+            quantity: 2,
+            price: 10.0,
+            productId: 'AMP1'
+          },
+          revenue: 20.0
+        };
+
+        analytics.assert(setRevenue.withArgs(expected).calledOnce);
+      });
+
       it('should send a logRevenueV2 event for all items in products array if trackRevenuePerProduct is true', function() {
         var spy = sinon.spy(window.amplitude.getInstance(), 'logRevenueV2');
         amplitude.options.trackRevenuePerProduct = true;


### PR DESCRIPTION
Adds `revenueType` when tracking revenue per product.

- [DEST-294](https://segment.atlassian.net/browse/DEST-294)
- [CC-4895](https://segment.atlassian.net/browse/CC-4895)