### PR TITLE
[DEST-931] Add support for `adAssetIdPropertyName` setting

### DIFF
--- a/integrations/nielsen-dcr/lib/index.js
+++ b/integrations/nielsen-dcr/lib/index.js
@@ -16,7 +16,8 @@ var NielsenDCR = (module.exports = integration('Nielsen DCR')
   .option('appId', '')
   .option('instanceName', '') // the snippet lets you override the instance so make sure you don't have any global window props w same value as this setting unless you are intentionally doing that.
   .option('nolDevDebug', false)
-  .option('assetIdPropertyName', '')
+  .option('assetIdPropertyName', '') // deprecated
+  .option('contentAssetIdPropertyName', '')
   .option('adAssetIdPropertyName', '')
   .option('subbrandPropertyName', '')
   .option('clientIdPropertyName', '')
@@ -169,8 +170,8 @@ NielsenDCR.prototype.getContentMetadata = function(track, type) {
   var integrationOpts = track.options(this.name);
   var contentMetadata = {
     type: 'content',
-    assetid: this.options.assetIdPropertyName
-      ? track.proxy(properties + this.options.assetIdPropertyName)
+    assetid: this.options.contentAssetIdPropertyName
+      ? track.proxy(properties + this.options.contentAssetIdPropertyName)
       : track.proxy(properties + assetIdProp),
     program: track.proxy(properties + 'program'),
     title: track.proxy(properties + 'title'),
@@ -267,8 +268,8 @@ NielsenDCR.prototype.videoContentStarted = function(track) {
 NielsenDCR.prototype.videoContentPlaying = function(track) {
   clearInterval(this.heartbeatId);
 
-  var assetId = this.options.assetIdPropertyName
-    ? track.proxy('properties.' + this.options.assetIdPropertyName)
+  var assetId = this.options.contentAssetIdPropertyName
+    ? track.proxy('properties.' + this.options.contentAssetIdPropertyName)
     : track.proxy('properties.asset_id');
   var position = track.proxy('properties.position');
   var livestream = track.proxy('properties.livestream');
@@ -392,8 +393,8 @@ NielsenDCR.prototype.videoPlaybackInterrupted = function(track) {
 NielsenDCR.prototype.videoPlaybackSeekCompleted = function(track) {
   clearInterval(this.heartbeatId);
 
-  var contentAssetId = this.options.assetIdPropertyName
-    ? track.proxy('properties.' + this.options.assetIdPropertyName)
+  var contentAssetId = this.options.contentAssetIdPropertyName
+    ? track.proxy('properties.' + this.options.contentAssetIdPropertyName)
     : track.proxy('properties.content_asset_id');
   var adAssetId = this.options.adAssetIdPropertyName
     ? track.proxy('properties.' + this.options.adAssetIdPropertyName)
@@ -444,8 +445,8 @@ NielsenDCR.prototype.videoPlaybackPaused = function(track) {
 NielsenDCR.prototype.videoPlaybackResumed = function(track) {
   clearInterval(this.heartbeatId);
 
-  var contentAssetId = this.options.assetIdPropertyName
-    ? track.proxy('properties.' + this.options.assetIdPropertyName)
+  var contentAssetId = this.options.contentAssetIdPropertyName
+    ? track.proxy('properties.' + this.options.contentAssetIdPropertyName)
     : track.proxy('properties.content_asset_id');
   var adAssetId = this.options.adAssetIdPropertyName
     ? track.proxy('properties.' + this.options.adAssetIdPropertyName)

--- a/integrations/nielsen-dcr/package.json
+++ b/integrations/nielsen-dcr/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-nielsen-dcr",
   "description": "The Nielsen DCR analytics.js integration.",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/nielsen-dcr/test/index.test.js
+++ b/integrations/nielsen-dcr/test/index.test.js
@@ -38,7 +38,13 @@ describe('NielsenDCR', function() {
       integration('Nielsen DCR')
         .option('appId', '')
         .option('instanceName', '')
-        .option('assetIdPropertyName', 'asset_id')
+        .option('nolDevDebug', false)
+        .option('assetIdPropertyName', '')
+        .option('adAssetIdPropertyName', '')
+        .option('subbrandPropertyName', '')
+        .option('clientIdPropertyName', '')
+        .option('contentLengthPropertyName', 'total_length')
+        .option('optout', false)
         .tag(
           'http',
           '<script src="http://cdn-gl.imrworldwide.com/conf/{{ appId }}.js#name={{ instanceName }}&ns=NOLBUNDLE">'

--- a/integrations/nielsen-dcr/test/index.test.js
+++ b/integrations/nielsen-dcr/test/index.test.js
@@ -39,7 +39,8 @@ describe('NielsenDCR', function() {
         .option('appId', '')
         .option('instanceName', '')
         .option('nolDevDebug', false)
-        .option('assetIdPropertyName', '')
+        .option('assetIdPropertyName', '') // deprecated
+        .option('contentAssetIdPropertyName', '')
         .option('adAssetIdPropertyName', '')
         .option('subbrandPropertyName', '')
         .option('clientIdPropertyName', '')
@@ -538,16 +539,16 @@ describe('NielsenDCR', function() {
         });
 
         it('video ad started with custom asset id', function() {
-          nielsenDCR.options.assetIdPropertyName = 'custom_asset_id_prop';
+          nielsenDCR.options.adAssetIdPropertyName = 'custom_asset_id_prop';
           analytics.track('Video Ad Started', props);
           analytics.called(window.clearInterval);
           analytics.called(nielsenDCR._client.ggPM, 'loadMetadata', {
-            assetid: props.asset_id,
+            assetid: props.custom_asset_id_prop,
             type: 'midroll'
           });
           analytics.called(
             nielsenDCR.heartbeat,
-            props.asset_id,
+            props.custom_asset_id_prop,
             props.position,
             { type: 'ad' }
           );

--- a/integrations/nielsen-dcr/test/index.test.js
+++ b/integrations/nielsen-dcr/test/index.test.js
@@ -278,7 +278,8 @@ describe('NielsenDCR', function() {
 
         it('video content started - custom asset id', function() {
           var timestamp = new Date();
-          nielsenDCR.options.assetIdPropertyName = 'custom_asset_id_prop';
+          nielsenDCR.options.contentAssetIdPropertyName =
+            'custom_asset_id_prop';
           analytics.track('Video Content Started', props, {
             page: { url: 'segment.com' },
             'Nielsen DCR': { ad_load_type: 'dynamic' },
@@ -630,7 +631,8 @@ describe('NielsenDCR', function() {
             livestream: false,
             airdate: '1991-08-13'
           };
-          nielsenDCR.options.assetIdPropertyName = 'custom_asset_id_prop';
+          nielsenDCR.options.contentAssetIdPropertyName =
+            'custom_asset_id_prop';
           analytics.track('Video Ad Started', props, {
             page: { url: 'segment.com' }
           });


### PR DESCRIPTION
**CC Ticket:** https://segment.atlassian.net/browse/CC-5017

**What does this PR do?**
This PR adds support for `adAssetIdPropertyName` setting, which allows customers to send ad asset ids to Segment using a custom property key.

**Are there breaking changes in this PR?**
Yes.

`assetIdPropertyName` now default to an empty string rather than `asset_id`. This is because an asset id can either be `content_asset_id`, `ad_asset_id`, or `asset_id` depending on the specced event.

**Any background context you want to provide?**
This PR is in response to a New Fox request to support mapping custom ad asset id properties to Nielsen.


**Is there parity with the server-side/android/iOS integration components (if applicable)?**
Yes.


**Does this require a new integration setting? If so, please explain how the new setting works**
Yes - adAssetIdPropertyName. This setting has already been added to Partner Portal.

**Links to helpful docs and other external resources**
n/a