### PR TITLE
[DEST-937] Update Fullstory crossorigin flag and add `fs.log`

### DIFF
--- a/integrations/fullstory/HISTORY.md
+++ b/integrations/fullstory/HISTORY.md
@@ -1,4 +1,9 @@
 
+2.2.1 / 2019-07-31
+==================
+
+  * Update recording snippet
+
 2.1.4 / 2018-05-01
 ==================
 
@@ -15,12 +20,12 @@
 2.1.2 / 2017-01-24
 ==================
 
-  * Fix error when null is passed as a trait value 
+  * Fix error when null is passed as a trait value
 
 2.1.1 / 2017-01-03
 ==================
 
-  * Remove option to override default namespace 
+  * Remove option to override default namespace
 
 2.1.0 / 2017-01-03
 ==================

--- a/integrations/fullstory/lib/index.js
+++ b/integrations/fullstory/lib/index.js
@@ -37,11 +37,10 @@ FullStory.prototype.initialize = function() {
 
   /* eslint-disable */
   /* istanbul ignore next */
+  /* The snippet below differs slightly from the snippet available on fullstory.com because fs.js is already loaded above*/
   (function(m,n,e,t,l,o,g,y){
     if (e in m) {if(m.console && m.console.log) { m.console.log('FullStory namespace conflict. Please set window["_fs_namespace"].');} return;}
     g=m[e]=function(a,b,s){g.q?g.q.push([a,b,s]):g._api(a,b,s);};g.q=[];
-    o=n.createElement(t);o.async=1;o.crossOrigin='anonymous';o.src='https://'+_fs_host+'/s/fs.js';
-    y=n.getElementsByTagName(t)[0];y.parentNode.insertBefore(o,y);
     g.identify=function(i,v,s){g(l,{uid:i},s);if(v)g(l,v,s)};g.setUserVars=function(v,s){g(l,v,s)};g.event=function(i,v,s){g('event',{n:i,p:v},s)};
     g.shutdown=function(){g("rec",!1)};g.restart=function(){g("rec",!0)};
     g.log = function(a,b) { g("log", [a,b]) };

--- a/integrations/fullstory/lib/index.js
+++ b/integrations/fullstory/lib/index.js
@@ -40,8 +40,11 @@ FullStory.prototype.initialize = function() {
   (function(m,n,e,t,l,o,g,y){
     if (e in m) {if(m.console && m.console.log) { m.console.log('FullStory namespace conflict. Please set window["_fs_namespace"].');} return;}
     g=m[e]=function(a,b,s){g.q?g.q.push([a,b,s]):g._api(a,b,s);};g.q=[];
+    o=n.createElement(t);o.async=1;o.crossOrigin='anonymous';o.src='https://'+_fs_host+'/s/fs.js';
+    y=n.getElementsByTagName(t)[0];y.parentNode.insertBefore(o,y);
     g.identify=function(i,v,s){g(l,{uid:i},s);if(v)g(l,v,s)};g.setUserVars=function(v,s){g(l,v,s)};g.event=function(i,v,s){g('event',{n:i,p:v},s)};
     g.shutdown=function(){g("rec",!1)};g.restart=function(){g("rec",!0)};
+    g.log = function(a,b) { g("log", [a,b]) };
     g.consent=function(a){g("consent",!arguments.length||a)};
     g.identifyAccount=function(i,v){o='account';v=v||{};v.acctId=i;g(o,v)};
     g.clearUserCookie=function(){};
@@ -73,12 +76,13 @@ FullStory.prototype.identify = function(identify) {
 
   var newTraits = foldl(
     function(results, value, key) {
+      var rs = results;
       if (key !== 'id') {
-        results[
+        rs[
           key === 'displayName' || key === 'email' ? key : camelCaseField(key)
         ] = value;
       }
-      return results;
+      return rs;
     },
     {},
     traits

--- a/integrations/fullstory/lib/index.js
+++ b/integrations/fullstory/lib/index.js
@@ -17,7 +17,9 @@ var integration = require('@segment/analytics.js-integration');
 var FullStory = (module.exports = integration('FullStory')
   .option('org', '')
   .option('debug', false)
-  .tag('<script src="https://www.fullstory.com/s/fs.js"></script>'));
+  .tag(
+    '<script async src="https://www.fullstory.com/s/fs.js" crossorigin="anonymous"></script>'
+  ));
 
 /**
  * The ApiSource string.

--- a/integrations/fullstory/package.json
+++ b/integrations/fullstory/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-fullstory",
   "description": "The Fullstory analytics.js integration.",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",


### PR DESCRIPTION
**What does this PR do?**
This PR updates the FS snippet to its current version. 

**Are there breaking changes in this PR?**
No

**Any background context you want to provide?**
Changes included in this version:
1. Enable cross-origin access to errors from fs.js
2. Make FS.log not throw an exception if it is called before FS is ready.

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
Not applicable

**Does this require a new integration setting? If so, please explain how the new setting works**
No

**Links to helpful docs and other external resources**
