### PR TITLE
[DEST-852] Amplitude: Add mapping of non-property fields to event_props

### DIFF
--- a/integrations/amplitude/HISTORY.md
+++ b/integrations/amplitude/HISTORY.md
@@ -1,3 +1,7 @@
+# 3.1.0 / 2019-08-09
+
+- Add mapping of non-property fields to event_props.
+
 # 3.0.0 / 2019-06-10
 
 - Update Amplitude SDK to v5.2.2

--- a/integrations/amplitude/lib/index.js
+++ b/integrations/amplitude/lib/index.js
@@ -49,6 +49,7 @@ var Amplitude = (module.exports = integration('Amplitude')
   .option('preferAnonymousIdForDeviceId', false)
   .option('traitsToSetOnce', [])
   .option('traitsToIncrement', [])
+  .option('appendFieldsToEventProps', {})
   .tag('<script src="' + src + '">'));
 
 /**
@@ -252,6 +253,11 @@ function logEvent(track, dontSetRevenue) {
     if (type === 'user_properties')
       window.amplitude.getInstance().setUserProperties(params);
   }
+
+  // Append extra fields to event_props
+  each(function(prop, field) {
+    props[prop] = track.proxy(field);
+  }, this.options.appendFieldsToEventProps);
 
   // track the event
   if (options.groups) {

--- a/integrations/amplitude/package.json
+++ b/integrations/amplitude/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-amplitude",
   "description": "The Amplitude analytics.js integration.",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/amplitude/test/index.test.js
+++ b/integrations/amplitude/test/index.test.js
@@ -64,6 +64,7 @@ describe('Amplitude', function() {
         .option('traitsToSetOnce', [])
         .option('traitsToIncrement', [])
         .option('deviceIdFromUrlParam', false)
+        .option('appendFieldsToEventProps', {})
     );
   });
 
@@ -632,6 +633,18 @@ describe('Amplitude', function() {
         amplitude.options.preferAnonymousIdForDeviceId = true;
         analytics.page();
         analytics.called(window.amplitude.getInstance().setDeviceId, 'example');
+      });
+
+      it('should send an event with context properties mapped', function() {
+        amplitude.options.appendFieldsToEventProps = {
+          'context.page.path': 'pagePath'
+        };
+
+        analytics.track('event', { foo: 'bar' });
+        analytics.called(window.amplitude.getInstance().logEvent, 'event', {
+          foo: 'bar',
+          pagePath: '/context.html'
+        });
       });
     });
 


### PR DESCRIPTION
**What does this PR do?**
Implements a new "Append Fields To Event Props" setting that allows customers to map any Segment event field to Amplitude's `event_props` during a track event.

**Are there breaking changes in this PR?**
![](https://media.giphy.com/media/WS6Awhg2czs3hNoCwy/giphy.gif)

**Any background context you want to provide?**
https://segment.atlassian.net/browse/DEST-852

**Is there parity with the server-side/android/iOS integration components (if applicable)?**


**Does this require a new integration setting? If so, please explain how the new setting works**
Yes! The new setting is an object where keys are Segment field paths like `context.page.title` and its value is the `event_prop` it should be set under.

Example:
```
appendFieldsToEventProps: {
    'context.page.title': 'pageTitle'
}
```

**Links to helpful docs and other external resources**
https://segment.atlassian.net/browse/DEST-852