### PR TITLE
Fixing App Boy Braze calls when values are undefined

### DIFF
--- a/integrations/appboy/lib/index.js
+++ b/integrations/appboy/lib/index.js
@@ -255,13 +255,27 @@ Appboy.prototype.identify = function(identify) {
   var phone = identify.phone();
   var traits = clone(identify.traits());
 
-  window.appboy.changeUser(userId);
-  window.appboy.getUser().setAvatarImageUrl(avatar);
-  window.appboy.getUser().setEmail(email);
-  window.appboy.getUser().setFirstName(firstName);
-  window.appboy.getUser().setGender(getGender(gender));
-  window.appboy.getUser().setLastName(lastName);
-  window.appboy.getUser().setPhoneNumber(phone);
+  if (userId) {
+    window.appboy.changeUser(userId);
+  }
+  if (avatar) {
+    window.appboy.getUser().setAvatarImageUrl(avatar);
+  }
+  if (email) {
+    window.appboy.getUser().setEmail(email);
+  }
+  if (firstName) {
+    window.appboy.getUser().setFirstName(firstName);
+  }
+  if (gender) {
+    window.appboy.getUser().setGender(getGender(gender));
+  }
+  if (lastName) {
+    window.appboy.getUser().setLastName(lastName);
+  }
+  if (phone) {
+    window.appboy.getUser().setPhoneNumber(phone);
+  }
   if (address) {
     window.appboy.getUser().setCountry(address.country);
     window.appboy.getUser().setHomeCity(address.city);

--- a/integrations/appboy/package.json
+++ b/integrations/appboy/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-appboy",
   "description": "The Appboy analytics.js integration.",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",


### PR DESCRIPTION
**What does this PR do?**
Fix for issue #110 
Currently when injecting Braze SDK with Segment dashboard. There are non-fatal errors being reported because user data isn't in the identify or track calls.
This data is optional, so raising an error when it is not provided doesn't seem to make sense.

**Are there breaking changes in this PR?**
No

**Any background context you want to provide?**
![image](https://user-images.githubusercontent.com/697418/62418805-b8f65d00-b6b5-11e9-99c4-d7ceef6f6a63.png)

**Is there parity with the server-side/android/iOS integration components (if applicable)?**


**Does this require a new integration setting? If so, please explain how the new setting works**

**Links to helpful docs and other external resources**
