### PR TITLE
[CC-5017] [Nielsen DCR] Fix weird position property behavior.

### DIFF
--- a/integrations/nielsen-dcr/lib/index.js
+++ b/integrations/nielsen-dcr/lib/index.js
@@ -118,8 +118,11 @@ NielsenDCR.prototype.heartbeat = function(assetId, position, options) {
   var self = this;
   var newPosition;
   var opts = options || {};
+  // if position is not sent as a string
   try {
-    if (typeof position !== 'number') newPosition = parseInt(position, 10); // in case it is sent as a string
+    if (typeof position !== 'number') {
+      newPosition = parseInt(position, 10);
+    } // in case it is sent as a string
   } catch (e) {
     // if we can't parse position into an Int for some reason, early return
     // to prevent internal errors every second
@@ -129,7 +132,7 @@ NielsenDCR.prototype.heartbeat = function(assetId, position, options) {
   if (!this.currentAssetId) this.currentAssetId = assetId;
 
   // if position is passed in we should override the state of the current playhead position with the explicit position given from the customer
-  this.currentPosition = newPosition;
+  this.currentPosition = newPosition || position;
 
   // Segment expects our own heartbeats every 10 seconds, so we're adding 5 seconds of potential redundancy for buffer
   // for a total of 15 heartbeats

--- a/integrations/nielsen-dcr/package.json
+++ b/integrations/nielsen-dcr/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-nielsen-dcr",
   "description": "The Nielsen DCR analytics.js integration.",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",


### PR DESCRIPTION
**What does this PR do?**
Fixes some weird behavior when passing `position` property in Nielsen DCR.

Related to Nielsen DCR updates we're rolling out for Fox today: https://segment.atlassian.net/browse/CC-5017

**Are there breaking changes in this PR?**
No.

**Any background context you want to provide?**
n/a

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
Yes.

**Does this require a new integration setting? If so, please explain how the new setting works**
No.

**Links to helpful docs and other external resources**
n/a