### PR TITLE
[CC-5017] [Nielsen DCR] Fix more position property issues.

### DIFF
--- a/integrations/nielsen-dcr/lib/index.js
+++ b/integrations/nielsen-dcr/lib/index.js
@@ -116,7 +116,7 @@ NielsenDCR.prototype.page = function(page) {
 
 NielsenDCR.prototype.heartbeat = function(assetId, position, options) {
   var self = this;
-  var newPosition;
+  var newPosition = position;
   var opts = options || {};
   // if position is not sent as a string
   try {
@@ -132,7 +132,7 @@ NielsenDCR.prototype.heartbeat = function(assetId, position, options) {
   if (!this.currentAssetId) this.currentAssetId = assetId;
 
   // if position is passed in we should override the state of the current playhead position with the explicit position given from the customer
-  this.currentPosition = newPosition || position;
+  this.currentPosition = newPosition;
 
   // Segment expects our own heartbeats every 10 seconds, so we're adding 5 seconds of potential redundancy for buffer
   // for a total of 15 heartbeats

--- a/integrations/nielsen-dcr/package.json
+++ b/integrations/nielsen-dcr/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-nielsen-dcr",
   "description": "The Nielsen DCR analytics.js integration.",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",


### PR DESCRIPTION
Sorry, team. This should be the last Nielsen DCR tweak. I tested these updates by building A.js locally using [golden-compiler](https://github.com/segmentio/golden-compiler) and the current code seems to address the `position` issues I was seeing in stage.

**What does this PR do?**
This PR ensures we properly handle the `position` property if it as passed as either a String or an Integer. Previously, the `heartbeat` method would noop when `position` was passed as an Integer. Segment's [video spec](https://segment.com/docs/spec/video/) expects that customers pass `position` as type Integer.

**Are there breaking changes in this PR?**
No.

**Any background context you want to provide?**
n/a

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
Yes.

**Does this require a new integration setting? If so, please explain how the new setting works**
No.

**Links to helpful docs and other external resources**
n/a