### PR TITLE
DEST-876 appboy (aka braze) use serverWorkerLocation from settings if available

### DIFF
--- a/integrations/appboy/lib/index.js
+++ b/integrations/appboy/lib/index.js
@@ -203,6 +203,7 @@ Appboy.prototype.initializeV2 = function(customEndpoint) {
     openNewsFeedCardsInNewTab: options.openNewsFeedCardsInNewTab,
     requireExplicitInAppMessageDismissal:
       options.requireExplicitInAppMessageDismissal,
+    serviceWorkerLocation: options.serviceWorkerLocation,
     sessionTimeoutInSeconds: Number(options.sessionTimeoutInSeconds) || 30
   };
 


### PR DESCRIPTION
**What does this PR do?**
Use serverWorkerLocation from settings if available.

**Are there breaking changes in this PR?**
No.

**Any background context you want to provide?**
One customer has service worker in a different location, so we need to allow the customer to tell Braze about that.

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
Not applicable I believe.

**Does this require a new integration setting? If so, please explain how the new setting works**
Yes. It will be an optional integration String setting called `serviceWorkerLocation`.

**Links to helpful docs and other external resources**
Ticket: https://segment.atlassian.net/browse/DEST-876
appboy web sdk docs: https://js.appboycdn.com/web-sdk/latest/doc/module-appboy.html