### PR TITLE
[DEST-877] [DEST-876] Braze: Remove nested objects/arrays, Add undefined trait checks, use serverWorkerLocation from settings if available

### DIFF
--- a/integrations/appboy/HISTORY.md
+++ b/integrations/appboy/HISTORY.md
@@ -1,3 +1,11 @@
+1.11.0 / 2019-08-08
+==================
+
+* Excludes nested non-null objects from customer user attributes in identify method
+* Excludes non-null objects from custom event properties in track method
+* Conditionally set user-related traits (ID, name, address, etc.)
+* Use serviceWorkerLocation from settings if it is available.
+
 1.9.0 / 2019-06-19
 ==================
 

--- a/integrations/appboy/lib/index.js
+++ b/integrations/appboy/lib/index.js
@@ -255,13 +255,31 @@ Appboy.prototype.identify = function(identify) {
   var phone = identify.phone();
   var traits = clone(identify.traits());
 
-  window.appboy.changeUser(userId);
-  window.appboy.getUser().setAvatarImageUrl(avatar);
-  window.appboy.getUser().setEmail(email);
-  window.appboy.getUser().setFirstName(firstName);
-  window.appboy.getUser().setGender(getGender(gender));
-  window.appboy.getUser().setLastName(lastName);
-  window.appboy.getUser().setPhoneNumber(phone);
+  if (userId) {
+    window.appboy.changeUser(userId);
+  }
+  if (avatar) {
+    window.appboy.getUser().setAvatarImageUrl(avatar);
+  }
+  if (email) {
+    window.appboy.getUser().setEmail(email);
+  }
+  if (firstName) {
+    window.appboy.getUser().setFirstName(firstName);
+  }
+  if (gender) {
+    window.appboy.getUser().setGender(getGender(gender));
+  }
+  if (lastName) {
+    window.appboy.getUser().setLastName(lastName);
+  }
+  if (phone) {
+    window.appboy.getUser().setPhoneNumber(phone);
+  }
+  if (address) {
+    window.appboy.getUser().setCountry(address.country);
+    window.appboy.getUser().setHomeCity(address.city);
+  }
   if (address) {
     window.appboy.getUser().setCountry(address.country);
     window.appboy.getUser().setHomeCity(address.city);
@@ -307,6 +325,14 @@ Appboy.prototype.identify = function(identify) {
     delete traits[key];
   }, reserved);
 
+  // Remove nested hash objects as Braze only supports nested array objects in identify calls
+  // https://segment.com/docs/destinations/braze/#identify
+  each(function(value, key) {
+    if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+      delete traits[key];
+    }
+  }, traits);
+
   each(function(value, key) {
     window.appboy.getUser().setCustomUserAttribute(key, value);
   }, traits);
@@ -325,7 +351,9 @@ Appboy.prototype.group = function(group) {
   var userId = group.userId();
   var groupIdKey = 'ab_segment_group_' + group.groupId();
 
-  window.appboy.changeUser(userId);
+  if (userId) {
+    window.appboy.changeUser(userId);
+  }
   window.appboy.getUser().setCustomUserAttribute(groupIdKey, true);
 };
 
@@ -356,7 +384,17 @@ Appboy.prototype.track = function(track) {
     delete properties[key];
   }, reserved);
 
-  window.appboy.changeUser(userId);
+  // Remove nested objects as Braze doesn't support objects in tracking calls
+  // https://segment.com/docs/destinations/braze/#track
+  each(function(value, key) {
+    if (value != null && typeof value === 'object') {
+      delete properties[key];
+    }
+  }, properties);
+
+  if (userId) {
+    window.appboy.changeUser(userId);
+  }
   window.appboy.logCustomEvent(eventName, properties);
 };
 
@@ -379,7 +417,9 @@ Appboy.prototype.page = function(page) {
   var eventName = pageEvent.event();
   var properties = page.properties();
 
-  window.appboy.changeUser(userId);
+  if (userId) {
+    window.appboy.changeUser(userId);
+  }
   window.appboy.logCustomEvent(eventName, properties);
 };
 
@@ -400,7 +440,9 @@ Appboy.prototype.orderCompleted = function(track) {
   var currencyCode = track.currency();
   var purchaseProperties = track.properties();
 
-  window.appboy.changeUser(userId);
+  if (userId) {
+    window.appboy.changeUser(userId);
+  }
 
   // remove reduntant properties
   del(purchaseProperties, 'products');

--- a/integrations/appboy/package.json
+++ b/integrations/appboy/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-appboy",
   "description": "The Appboy analytics.js integration.",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/appboy/test/index.test.js
+++ b/integrations/appboy/test/index.test.js
@@ -335,12 +335,13 @@ describe('Appboy', function() {
         );
       });
 
-      it('should handle custom traits of all types', function() {
+      it('should handle custom traits of valid types and exclude nested objects', function() {
         analytics.identify('userId', {
           song: "Who's That Chick?",
           artists: ['David Guetta', 'Rihanna'],
           number: 16,
-          date: 'Tue Apr 25 2017 14:22:48 GMT-0700 (PDT)'
+          date: 'Tue Apr 25 2017 14:22:48 GMT-0700 (PDT)',
+          details: { nested: 'object' }
         });
         analytics.called(window.appboy.changeUser, 'userId');
         analytics.called(
@@ -411,7 +412,10 @@ describe('Appboy', function() {
         analytics.track('event with properties', {
           nickname: 'noonz',
           spiritAnimal: 'rihanna',
-          best_friend: 'han'
+          best_friend: 'han',
+          number_of_friends: 12,
+          idols: ['beyonce', 'madonna'],
+          favoriteThings: { whiskers: 'on-kittins' }
         });
         analytics.called(
           window.appboy.logCustomEvent,
@@ -419,7 +423,8 @@ describe('Appboy', function() {
           {
             nickname: 'noonz',
             spiritAnimal: 'rihanna',
-            best_friend: 'han'
+            best_friend: 'han',
+            number_of_friends: 12
           }
         );
       });

--- a/integrations/appboy/test/index.test.js
+++ b/integrations/appboy/test/index.test.js
@@ -229,6 +229,7 @@ describe('Appboy', function() {
           openInAppMessagesInNewTab: false,
           openNewsFeedCardsInNewTab: false,
           sessionTimeoutInSeconds: 30,
+          serviceWorkerLocation: undefined,
           requireExplicitInAppMessageDismissal: false,
           enableHtmlInAppMessages: false
         };


### PR DESCRIPTION
**What does this PR do?**
- Excludes nested non-null objects from customer user attributes in `identify` method
- Excludes non-null objects from custom event properties in `track` method
- Conditionally set user-related traits (ID, name, address, etc.)
- Use serviceWorkerLocation from settings if it is available.

This is a combination of #153, #167, #170, #176 ! Three (3) changes were originally written by @NikoRoberts but had to be reverted and a bad conditional had to be fixed. One change (#176) is originally written by @mericsson.

**Are there breaking changes in this PR?**
Negative

**Any background context you want to provide?**


**Is there parity with the server-side/android/iOS integration components (if applicable)?**


**Does this require a new integration setting? If so, please explain how the new setting works**


**Links to helpful docs and other external resources**
