### PR TITLE
[DEST-897] added check to unset params and ref on new session

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ yarn
 ```
 
 ## Contributing
-All indiviudal integrations are stored in the `integrations/` directory. We recommend navigating into the individual integration you are contributing to in your terminal rather than working from the root directory:
+All individual integrations are stored in the `integrations/` directory. We recommend navigating into the individual integration you are contributing to in your terminal rather than working from the root directory:
 
 ```bash
 cd integrations/<INTEGRATION_NAME>

--- a/integrations/amplitude/HISTORY.md
+++ b/integrations/amplitude/HISTORY.md
@@ -1,3 +1,7 @@
+# 3.2.0 / 2019-08-27
+
+- Add support for unsetParamsReferrerOnNewSession setting
+
 # 3.1.0 / 2019-08-09
 
 - Add mapping of non-property fields to event_props.

--- a/integrations/amplitude/lib/index.js
+++ b/integrations/amplitude/lib/index.js
@@ -50,6 +50,7 @@ var Amplitude = (module.exports = integration('Amplitude')
   .option('traitsToSetOnce', [])
   .option('traitsToIncrement', [])
   .option('appendFieldsToEventProps', {})
+  .option('unsetParamsReferrerOnNewSession', false)
   .tag('<script src="' + src + '">'));
 
 /**
@@ -79,6 +80,8 @@ Amplitude.prototype.initialize = function() {
     saveParamsReferrerOncePerSession: this.options
       .saveParamsReferrerOncePerSession,
     deviceIdFromUrlParam: this.options.deviceIdFromUrlParam,
+    unsetParamsReferrerOnNewSession: this.options
+      .unsetParamsReferrerOnNewSession,
     deviceId:
       this.options.preferAnonymousIdForDeviceId &&
       this.analytics &&
@@ -97,11 +100,7 @@ Amplitude.prototype.initialize = function() {
       window.amplitude = amplitude;
       when(loaded, function() {
         window.amplitude.runQueuedFunctions();
-        ready(function() {
-          if (window.amplitude.unsetParamsReferrerOnNewSession) {
-            window.amplitude.unsetParamsReferrerOnNewSession();
-          }
-        });
+        ready();
       });
     });
     return;
@@ -110,11 +109,7 @@ Amplitude.prototype.initialize = function() {
   this.load(function() {
     if (window.amplitude.runQueuedFunctions) {
       window.amplitude.runQueuedFunctions();
-      ready(function() {
-        if (window.amplitude.unsetParamsReferrerOnNewSession) {
-          window.amplitude.unsetParamsReferrerOnNewSession();
-        }
-      });
+      ready();
     }
   });
 };

--- a/integrations/amplitude/lib/index.js
+++ b/integrations/amplitude/lib/index.js
@@ -97,7 +97,11 @@ Amplitude.prototype.initialize = function() {
       window.amplitude = amplitude;
       when(loaded, function() {
         window.amplitude.runQueuedFunctions();
-        ready();
+        ready(function() {
+          if (window.amplitude.unsetParamsReferrerOnNewSession) {
+            window.amplitude.unsetParamsReferrerOnNewSession();
+          }
+        });
       });
     });
     return;
@@ -106,7 +110,11 @@ Amplitude.prototype.initialize = function() {
   this.load(function() {
     if (window.amplitude.runQueuedFunctions) {
       window.amplitude.runQueuedFunctions();
-      ready();
+      ready(function() {
+        if (window.amplitude.unsetParamsReferrerOnNewSession) {
+          window.amplitude.unsetParamsReferrerOnNewSession();
+        }
+      });
     }
   });
 };

--- a/integrations/amplitude/package.json
+++ b/integrations/amplitude/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-amplitude",
   "description": "The Amplitude analytics.js integration.",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/amplitude/test/index.test.js
+++ b/integrations/amplitude/test/index.test.js
@@ -26,7 +26,8 @@ describe('Amplitude', function() {
     mapQueryParams: {},
     traitsToIncrement: [],
     traitsToSetOnce: [],
-    preferAnonymousIdForDeviceId: true
+    preferAnonymousIdForDeviceId: true,
+    unsetParamsReferrerOnNewSession: false
   };
 
   beforeEach(function() {
@@ -65,6 +66,7 @@ describe('Amplitude', function() {
         .option('traitsToIncrement', [])
         .option('deviceIdFromUrlParam', false)
         .option('appendFieldsToEventProps', {})
+        .option('unsetParamsReferrerOnNewSession', false)
     );
   });
 
@@ -132,6 +134,10 @@ describe('Amplitude', function() {
         config.deviceIdFromUrlParam === options.deviceIdFromUrlParam
       );
       analytics.assert(config.deviceId === analytics.user().anonymousId());
+      analytics.assert(
+        config.unsetParamsReferrerOnNewSession ===
+          options.unsetParamsReferrerOnNewSession
+      );
     });
 
     it('should set api key', function() {


### PR DESCRIPTION
**What does this PR do?**
Adds check for unsetParamsReferrerOnNewSession

**Are there breaking changes in this PR?**
no

**Any background context you want to provide?**
Snippet from [amplitude docs](https://developers.amplitude.com/?javascript#platform-specific-settings):

> unsetParamsReferrerOnNewSession
> If false, the existing referrer and utm_parameter values will be carried through each new session. If set to true, the referrerand utm_parameteruser properties, which include referrer, utm_source, utm_medium, utm_campaign, utm_term, and utm_content, will be set to null upon instantiating a new session. Note: This only works if includeReferrer or includeUtm includeUtm are set to true.

--




**Is there parity with the server-side/android/iOS integration components (if applicable)?**
no

**Does this require a new integration setting? If so, please explain how the new setting works**
This PR introduces a new setting `unsetParamsReferrerOnNewSession` which tells amplitude to nullify utm/referrer params at the start of each session.

**Links to helpful docs and other external resources**
