### PR TITLE
[DEST-1073] Fix Nielsen `airdate` property format

### DIFF
--- a/integrations/nielsen-dcr/lib/index.js
+++ b/integrations/nielsen-dcr/lib/index.js
@@ -180,7 +180,7 @@ NielsenDCR.prototype.getContentMetadata = function(track, type) {
     title: track.proxy(properties + 'title'),
     isfullepisode: track.proxy(properties + 'full_episode') ? 'y' : 'n',
     mediaURL: track.proxy('context.page.url'),
-    airdate: track.proxy(properties + 'airdate'),
+    airdate: formatAirdate(track.proxy(properties + 'airdate')),
     // below metadata fields must all be set in event's integrations opts object
     adloadtype: find(integrationOpts, 'ad_load_type') === 'linear' ? '1' : '2', // or dynamic. linear means original ads that were broadcasted with tv airing. much less common use case
     crossId1: find(integrationOpts, 'crossId1'),
@@ -497,3 +497,26 @@ NielsenDCR.prototype.videoPlaybackCompleted = function(track) {
   this.currentAssetId = null;
   this.heartbeatId = null;
 };
+
+/**
+ * Formats airdate property per Nielsen DCR spec.
+ *
+ * @api private
+ */
+
+function formatAirdate(airdate) {
+  if (typeof airdate !== 'object') return;
+
+  var date;
+  try {
+    date = airdate.toISOString();
+  } catch (e) {
+    return;
+  }
+  // Nielsen DCR requires dates to be in format YYYYMMDD HH:MI:SS
+  // Segment formats all timestamp-like strings as ISO date strings, e.g.
+  // 1999-08-26T07:00:00.000Z, so that's the format this function expects
+  var yearMonthDay = date.slice(0, 10).replace(/-/g, '');
+  var hoursMinutesSeconds = date.slice(11, 19);
+  return yearMonthDay + ' ' + hoursMinutesSeconds;
+}

--- a/integrations/nielsen-dcr/lib/index.js
+++ b/integrations/nielsen-dcr/lib/index.js
@@ -7,6 +7,7 @@
 var integration = require('@segment/analytics.js-integration');
 var find = require('obj-case').find;
 var reject = require('reject');
+var dateformat = require('dateformat');
 
 /**
  * Expose `NielsenDCR` integration.
@@ -500,23 +501,18 @@ NielsenDCR.prototype.videoPlaybackCompleted = function(track) {
 
 /**
  * Formats airdate property per Nielsen DCR spec.
+ * Nielsen DCR requires dates to be in format YYYYMMDD HH:MI:SS
  *
  * @api private
  */
 
 function formatAirdate(airdate) {
-  if (typeof airdate !== 'object') return;
-
   var date;
   try {
-    date = airdate.toISOString();
+    date = dateformat(airdate, 'yyyymmdd hh:MM:ss', true);
   } catch (e) {
-    return;
+    // do nothing with this error for now
   }
-  // Nielsen DCR requires dates to be in format YYYYMMDD HH:MI:SS
-  // Segment formats all timestamp-like strings as ISO date strings, e.g.
-  // 1999-08-26T07:00:00.000Z, so that's the format this function expects
-  var yearMonthDay = date.slice(0, 10).replace(/-/g, '');
-  var hoursMinutesSeconds = date.slice(11, 19);
-  return yearMonthDay + ' ' + hoursMinutesSeconds;
+
+  return date;
 }

--- a/integrations/nielsen-dcr/package.json
+++ b/integrations/nielsen-dcr/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-nielsen-dcr",
   "description": "The Nielsen DCR analytics.js integration.",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",
@@ -26,6 +26,7 @@
   "homepage": "https://github.com/segmentio/analytics.js-integrations/blob/master/integrations/nielsen-dcr#readme",
   "dependencies": {
     "@segment/analytics.js-integration": "^3.2.0",
+    "dateformat": "3.0.0",
     "do-when": "^1.0.0",
     "obj-case": "^0.2.0",
     "reject": "0.0.1"

--- a/integrations/nielsen-dcr/test/index.test.js
+++ b/integrations/nielsen-dcr/test/index.test.js
@@ -241,7 +241,7 @@ describe('NielsenDCR', function() {
             channel: 'espn',
             full_episode: true,
             livestream: false,
-            airdate: '1991-08-13'
+            airdate: new Date('1991-08-13')
           };
         });
 
@@ -261,7 +261,7 @@ describe('NielsenDCR', function() {
             length: props.total_length,
             isfullepisode: 'y',
             mediaURL: 'segment.com',
-            airdate: new Date(props.airdate),
+            airdate: '19910813 00:00:00',
             adloadtype: '2',
             hasAds: '0'
           });
@@ -295,7 +295,7 @@ describe('NielsenDCR', function() {
             length: props.total_length,
             isfullepisode: 'y',
             mediaURL: 'segment.com',
-            airdate: new Date(props.airdate),
+            airdate: '19910813 00:00:00',
             adloadtype: '2',
             hasAds: '0'
           });
@@ -329,7 +329,7 @@ describe('NielsenDCR', function() {
             length: props.total_content_length,
             isfullepisode: 'y',
             mediaURL: 'segment.com',
-            airdate: new Date(props.airdate),
+            airdate: '19910813 00:00:00',
             adloadtype: '2',
             hasAds: '0'
           });
@@ -365,7 +365,7 @@ describe('NielsenDCR', function() {
             length: props.total_length,
             isfullepisode: 'y',
             mediaURL: 'segment.com',
-            airdate: new Date(props.airdate),
+            airdate: '19910813 00:00:00',
             adloadtype: '2',
             hasAds: '0',
             clientid: props.nielsen_client_id,
@@ -402,7 +402,7 @@ describe('NielsenDCR', function() {
             length: 86400,
             isfullepisode: 'y',
             mediaURL: 'segment.com',
-            airdate: new Date(props.airdate),
+            airdate: '19910813 00:00:00',
             adloadtype: '2',
             hasAds: '0'
           });
@@ -438,7 +438,7 @@ describe('NielsenDCR', function() {
             length: props.total_length,
             isfullepisode: 'y',
             mediaURL: 'segment.com',
-            airdate: new Date(props.airdate),
+            airdate: '19910813 00:00:00',
             adloadtype: '2',
             hasAds: '0',
             segB: 'bend',
@@ -574,7 +574,7 @@ describe('NielsenDCR', function() {
             channel: 'espn',
             full_episode: true,
             livestream: false,
-            airdate: '1991-08-13'
+            airdate: new Date('1991-08-13')
           };
           analytics.track('Video Ad Started', props, {
             page: { url: 'segment.com' }
@@ -590,7 +590,7 @@ describe('NielsenDCR', function() {
               length: props.content.total_length,
               isfullepisode: 'y',
               mediaURL: 'segment.com',
-              airdate: new Date(props.content.airdate),
+              airdate: '19910813 00:00:00',
               adloadtype: '2',
               hasAds: '0'
             }
@@ -630,7 +630,7 @@ describe('NielsenDCR', function() {
             channel: 'espn',
             full_episode: true,
             livestream: false,
-            airdate: '1991-08-13'
+            airdate: new Date('1991-08-13')
           };
           nielsenDCR.options.contentAssetIdPropertyName =
             'custom_asset_id_prop';
@@ -648,7 +648,7 @@ describe('NielsenDCR', function() {
               length: props.content.total_length,
               isfullepisode: 'y',
               mediaURL: 'segment.com',
-              airdate: new Date(props.content.airdate),
+              airdate: '19910813 00:00:00',
               adloadtype: '2',
               hasAds: '0'
             }
@@ -692,7 +692,7 @@ describe('NielsenDCR', function() {
             channel: 'espn',
             full_episode: true,
             livestream: false,
-            airdate: '1991-08-13'
+            airdate: new Date('1991-08-13')
           };
           analytics.track('Video Ad Started', props, {
             page: { url: 'segment.com' }
@@ -708,7 +708,7 @@ describe('NielsenDCR', function() {
               length: props.content.total_length,
               isfullepisode: 'y',
               mediaURL: 'segment.com',
-              airdate: new Date(props.content.airdate),
+              airdate: '19910813 00:00:00',
               adloadtype: '2',
               hasAds: '0',
               clientid: props.content.nielsen_client_id,

--- a/integrations/nielsen-dcr/test/index.test.js
+++ b/integrations/nielsen-dcr/test/index.test.js
@@ -261,7 +261,7 @@ describe('NielsenDCR', function() {
             length: props.total_length,
             isfullepisode: 'y',
             mediaURL: 'segment.com',
-            airdate: '19910813 00:00:00',
+            airdate: '19910813 12:00:00',
             adloadtype: '2',
             hasAds: '0'
           });
@@ -295,7 +295,7 @@ describe('NielsenDCR', function() {
             length: props.total_length,
             isfullepisode: 'y',
             mediaURL: 'segment.com',
-            airdate: '19910813 00:00:00',
+            airdate: '19910813 12:00:00',
             adloadtype: '2',
             hasAds: '0'
           });
@@ -329,7 +329,7 @@ describe('NielsenDCR', function() {
             length: props.total_content_length,
             isfullepisode: 'y',
             mediaURL: 'segment.com',
-            airdate: '19910813 00:00:00',
+            airdate: '19910813 12:00:00',
             adloadtype: '2',
             hasAds: '0'
           });
@@ -365,7 +365,7 @@ describe('NielsenDCR', function() {
             length: props.total_length,
             isfullepisode: 'y',
             mediaURL: 'segment.com',
-            airdate: '19910813 00:00:00',
+            airdate: '19910813 12:00:00',
             adloadtype: '2',
             hasAds: '0',
             clientid: props.nielsen_client_id,
@@ -402,7 +402,7 @@ describe('NielsenDCR', function() {
             length: 86400,
             isfullepisode: 'y',
             mediaURL: 'segment.com',
-            airdate: '19910813 00:00:00',
+            airdate: '19910813 12:00:00',
             adloadtype: '2',
             hasAds: '0'
           });
@@ -438,7 +438,7 @@ describe('NielsenDCR', function() {
             length: props.total_length,
             isfullepisode: 'y',
             mediaURL: 'segment.com',
-            airdate: '19910813 00:00:00',
+            airdate: '19910813 12:00:00',
             adloadtype: '2',
             hasAds: '0',
             segB: 'bend',
@@ -590,7 +590,7 @@ describe('NielsenDCR', function() {
               length: props.content.total_length,
               isfullepisode: 'y',
               mediaURL: 'segment.com',
-              airdate: '19910813 00:00:00',
+              airdate: '19910813 12:00:00',
               adloadtype: '2',
               hasAds: '0'
             }
@@ -648,7 +648,7 @@ describe('NielsenDCR', function() {
               length: props.content.total_length,
               isfullepisode: 'y',
               mediaURL: 'segment.com',
-              airdate: '19910813 00:00:00',
+              airdate: '19910813 12:00:00',
               adloadtype: '2',
               hasAds: '0'
             }
@@ -708,7 +708,7 @@ describe('NielsenDCR', function() {
               length: props.content.total_length,
               isfullepisode: 'y',
               mediaURL: 'segment.com',
-              airdate: '19910813 00:00:00',
+              airdate: '19910813 12:00:00',
               adloadtype: '2',
               hasAds: '0',
               clientid: props.content.nielsen_client_id,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3276,6 +3276,11 @@ date-now@^0.1.4:
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
   integrity sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=
 
+dateformat@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.0.tgz#a42a1ab816ff3170e238a3d7188f9aa3d287542a"
+  integrity sha1-pCoauBb/MXDiOKPXGI+ao9KHVCo=
+
 dateformat@^1.0.12, dateformat@^1.0.6:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-1.0.12.tgz#9f124b67594c937ff706932e4a642cca8dbbfee9"


### PR DESCRIPTION
**Jira:** https://segment.atlassian.net/browse/DEST-1073

**What does this PR do?**
This PR adds a helper method to format the `airdate` property per [Nielsen's spec](https://engineeringportal.nielsen.com/docs/DCR_Video_Browser_SDK).

**Are there breaking changes in this PR?**
This PR changes default functionality, but the change is not breaking.

**Any background context you want to provide?**
Fox is unable to test Nielsen DCR until this fix is shipped, as Nielsen will not accept "airdate" properties in the incorrect format.

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
Not yet, but working on that this week.

**Does this require a new integration setting? If so, please explain how the new setting works**
No.

**Links to helpful docs and other external resources**
n/a