### PR TITLE
[DEST-1041] Braze: stop removing keywords

### DIFF
--- a/integrations/appboy/HISTORY.md
+++ b/integrations/appboy/HISTORY.md
@@ -1,3 +1,8 @@
+1.13.0 / 2019-09-04
+===================
+
+* Stop stripping "reserved" keywords from properties sent to `logCustomEvent`.
+
 1.12.0 / 2019-08-22
 ===================
 

--- a/integrations/appboy/lib/index.js
+++ b/integrations/appboy/lib/index.js
@@ -382,18 +382,6 @@ Appboy.prototype.track = function(track) {
     // orderCompleted has same functionality of a track event with the property 'revenue'
     this.orderCompleted(track);
   } else {
-    var reserved = [
-      'time',
-      'product_id',
-      'quantity',
-      'event_name',
-      'price',
-      'currency'
-    ];
-    each(function(key) {
-      delete properties[key];
-    }, reserved);
-
     // Remove nested objects as Braze doesn't support objects in tracking calls
     // https://segment.com/docs/destinations/braze/#track
     each(function(value, key) {

--- a/integrations/appboy/package.json
+++ b/integrations/appboy/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-appboy",
   "description": "The Appboy analytics.js integration.",
-  "version": "1.13.0-beta",
+  "version": "1.13.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/appboy/package.json
+++ b/integrations/appboy/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-appboy",
   "description": "The Appboy analytics.js integration.",
-  "version": "1.12.0",
+  "version": "1.13.0-beta",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/appboy/test/index.test.js
+++ b/integrations/appboy/test/index.test.js
@@ -432,21 +432,6 @@ describe('Appboy', function() {
         );
       });
 
-      it('should remove reserved keys from custom event properties', function() {
-        analytics.track('event with properties', {
-          product_id: 'noonz',
-          event_name: 'rihanna',
-          time: 'han',
-          currency: 'usd',
-          quantity: '123'
-        });
-        analytics.called(
-          window.appboy.logCustomEvent,
-          'event with properties',
-          {}
-        );
-      });
-
       it('should call logPurchase if revenue propery is present in a Completed Order event', function(done) {
         var today = new Date();
         var orderCompleted = sinon.spy(appboy, 'orderCompleted');


### PR DESCRIPTION
**What does this PR do?**
Updates the `track` handler in the Braze integration to stop stripping "reserved" keywords from the properties passed to `logCustomEvent`. Braze has told us that these property names **are not** actually prohibited when using their web sdk.