### PR TITLE
Set anonymousId as deviceId before each invocation of trackData

### DIFF
--- a/integrations/monetate/lib/index.js
+++ b/integrations/monetate/lib/index.js
@@ -181,6 +181,7 @@ function push() {
   if (push.tid) return;
   push.tid = setTimeout(function() {
     clearTimeout(push.tid);
+    window.monetateQ.push(['deviceId', this.analytics.user().anonymousId()]);
     mq('trackData');
     push.tid = null;
   });


### PR DESCRIPTION
**What does this PR do?**

Prior to each invocation of `trackData`, the Segment `anonymousId` will be set as the Monetate `deviceId`.  This allows us to consistently identify the user throughout the Segment-Monetate integration.

**Are there breaking changes in this PR?**

No.

**Any background context you want to provide?**

Monetate normally uses its own session identifier, called a `monetateId`, to track the visitor throughout their session.  But because the `monetateId` will not always be available to Monetate's destination component, we decided that we will use Segment's `anonymousId` in both the frontend (analytics.js) integration and the destination component.

**Is there parity with the server-side/android/iOS integration components (if applicable)?**

This PR allows us to use the same user identifier throughout the Monetate-Segment integration.

**Does this require a new integration setting? If so, please explain how the new setting works**

No.

**Links to helpful docs and other external resources**

N/A.