### PR TITLE
[CC-5185] [DEST-1113] Nielsen DCR: Update `load_type` mapping

### DIFF
--- a/integrations/nielsen-dcr/lib/index.js
+++ b/integrations/nielsen-dcr/lib/index.js
@@ -182,8 +182,12 @@ NielsenDCR.prototype.getContentMetadata = function(track, type) {
     isfullepisode: track.proxy(properties + 'full_episode') ? 'y' : 'n',
     mediaURL: track.proxy('context.page.url'),
     airdate: formatAirdate(track.proxy(properties + 'airdate')),
+    // `adLoadType` may be set in int opts, falling back to `load_type` property per our video spec
+    adloadtype: formatLoadType(
+      integrationOpts,
+      track.proxy(properties + 'load_type')
+    ),
     // below metadata fields must all be set in event's integrations opts object
-    adloadtype: find(integrationOpts, 'ad_load_type') === 'linear' ? '1' : '2', // or dynamic. linear means original ads that were broadcasted with tv airing. much less common use case
     crossId1: find(integrationOpts, 'crossId1'),
     crossId2: find(integrationOpts, 'crossId2'),
     hasAds: find(integrationOpts, 'hasAds') === true ? '1' : '0'
@@ -515,4 +519,11 @@ function formatAirdate(airdate) {
   }
 
   return date;
+}
+
+function formatLoadType(integrationOpts, loadTypeProperty) {
+  var loadType = find(integrationOpts, 'ad_load_type') || loadTypeProperty;
+  // or dynamic. linear means original ads that were broadcasted with tv airing. much less common use case
+  loadType = loadType === 'linear' ? '1' : '2';
+  return loadType;
 }

--- a/integrations/nielsen-dcr/lib/index.js
+++ b/integrations/nielsen-dcr/lib/index.js
@@ -521,6 +521,13 @@ function formatAirdate(airdate) {
   return date;
 }
 
+/**
+ * Falls back to check `properties.load_type` if
+ * `integrationsOpts.ad_load_type` is falsy
+ *
+ * @api private
+ */
+
 function formatLoadType(integrationOpts, loadTypeProperty) {
   var loadType = find(integrationOpts, 'ad_load_type') || loadTypeProperty;
   // or dynamic. linear means original ads that were broadcasted with tv airing. much less common use case

--- a/integrations/nielsen-dcr/package.json
+++ b/integrations/nielsen-dcr/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-nielsen-dcr",
   "description": "The Nielsen DCR analytics.js integration.",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/nielsen-dcr/test/index.test.js
+++ b/integrations/nielsen-dcr/test/index.test.js
@@ -456,6 +456,44 @@ describe('NielsenDCR', function() {
           );
         });
 
+        it('video content started - load_type fallback', function() {
+          var timestamp = new Date();
+          props.load_type = 'linear';
+          analytics.track('Video Content Started', props, {
+            page: { url: 'segment.com' },
+            'Nielsen DCR': {
+              segB: 'bend',
+              segC: 'the knee'
+            },
+            timestamp: timestamp
+          });
+          analytics.called(window.clearInterval);
+          analytics.called(nielsenDCR._client.ggPM, 'loadMetadata', {
+            type: 'content',
+            assetid: props.asset_id,
+            program: props.program,
+            title: props.title,
+            length: props.total_length,
+            isfullepisode: 'y',
+            mediaURL: 'segment.com',
+            airdate: '19910813 12:00:00',
+            adloadtype: '1',
+            hasAds: '0',
+            segB: 'bend',
+            segC: 'the knee'
+          });
+          analytics.called(
+            nielsenDCR.heartbeat,
+            props.asset_id,
+            props.position,
+            {
+              livestream: props.livestream,
+              type: 'content',
+              timestamp: timestamp
+            }
+          );
+        });
+
         // heartbeats
         it('video content playing', function() {
           var timestamp = new Date();


### PR DESCRIPTION
https://segment.atlassian.net/browse/DEST-1113
https://segment.atlassian.net/browse/CC-5185

**What does this PR do?**
- This PR adds a helper method to map `properties.load_type` to Nielsen's `adLoadType` field. This ensures conformity with Segment's video spec as well as parity with `load_type` mapping for Nielsen DTVR. This is a hotfix for Fox.

**Are there breaking changes in this PR?**
- No.

**Any background context you want to provide?**
- Fox request.

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
- No, but we will need to update both iOS and Android to ensure parity.

**Does this require a new integration setting? If so, please explain how the new setting works**
- No.

**Links to helpful docs and other external resources**
- n/a