### PR TITLE
[DEST-1127] [CC-5207] Default to "linear" `loadType` (rather than "dynamic")

### DIFF
--- a/integrations/nielsen-dcr/lib/index.js
+++ b/integrations/nielsen-dcr/lib/index.js
@@ -531,6 +531,6 @@ function formatAirdate(airdate) {
 function formatLoadType(integrationOpts, loadTypeProperty) {
   var loadType = find(integrationOpts, 'ad_load_type') || loadTypeProperty;
   // or dynamic. linear means original ads that were broadcasted with tv airing. much less common use case
-  loadType = loadType === 'linear' ? '1' : '2';
+  loadType = loadType === 'dynamic' ? '2' : '1';
   return loadType;
 }

--- a/integrations/nielsen-dcr/package.json
+++ b/integrations/nielsen-dcr/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-nielsen-dcr",
   "description": "The Nielsen DCR analytics.js integration.",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/nielsen-dcr/test/index.test.js
+++ b/integrations/nielsen-dcr/test/index.test.js
@@ -629,7 +629,7 @@ describe('NielsenDCR', function() {
               isfullepisode: 'y',
               mediaURL: 'segment.com',
               airdate: '19910813 12:00:00',
-              adloadtype: '2',
+              adloadtype: '1',
               hasAds: '0'
             }
           ]);
@@ -687,7 +687,7 @@ describe('NielsenDCR', function() {
               isfullepisode: 'y',
               mediaURL: 'segment.com',
               airdate: '19910813 12:00:00',
-              adloadtype: '2',
+              adloadtype: '1',
               hasAds: '0'
             }
           ]);
@@ -747,7 +747,7 @@ describe('NielsenDCR', function() {
               isfullepisode: 'y',
               mediaURL: 'segment.com',
               airdate: '19910813 12:00:00',
-              adloadtype: '2',
+              adloadtype: '1',
               hasAds: '0',
               clientid: props.content.nielsen_client_id,
               subbrand: props.content.nielsen_subbrand


### PR DESCRIPTION
https://segment.atlassian.net/browse/CC-5207

**What does this PR do?**
- This PR changes the default value of `adLoadType` from 2 ("dynamic") to 1 ("linear"). **This ensures parity with our treatment of `adLoadType` on Android and iOS.**
- This is not an urgent/blocking update, so I will deploy this with the next A.js release train.

**Are there breaking changes in this PR?**
- No.

**Any background context you want to provide?**
- n/a

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
Yes - there is now! :)

**Does this require a new integration setting? If so, please explain how the new setting works**
- No.

**Links to helpful docs and other external resources**
- n/a
