### PR TITLE
Removed Add to Cart, added anon id

### DIFF
--- a/integrations/monetate/lib/index.js
+++ b/integrations/monetate/lib/index.js
@@ -41,8 +41,8 @@ Monetate.prototype.initialize = function() {
     this.options.events = {
       orderCompleted: 'addPurchaseRows',
       productViewed: 'addProductDetails',
-      productListViewed: 'addProducts',
-      productAdded: 'addCartRows'
+      productListViewed: 'addProducts'
+      // productAdded: 'addCartRows'
     };
   }
   window.monetateQ = window.monetateQ || [];
@@ -181,6 +181,7 @@ function push() {
   if (push.tid) return;
   push.tid = setTimeout(function() {
     clearTimeout(push.tid);
+    window.monetateQ.push(['deviceId', this.analytics.user().anonymousId()]);
     mq('trackData');
     push.tid = null;
   });


### PR DESCRIPTION
**What does this PR do?**

Removes Add to Cart event for JUUL and explicitly sends our anon ID as a user identifier to calls passed to Monetate.  These are required for JUULs further use of the Monetate product.

**Are there breaking changes in this PR?**

No

**Any background context you want to provide?**

JUUL asked for these - they will require these changes to support a new server-side event destination for Monetate

**Is there parity with the server-side/android/iOS integration components (if applicable)?**

NA

**Does this require a new integration setting? If so, please explain how the new setting works**

No

**Links to helpful docs and other external resources**


