### PR TITLE
DEST-594 Category should be always be EnhancedEcommerce

### DIFF
--- a/integrations/google-analytics/lib/index.js
+++ b/integrations/google-analytics/lib/index.js
@@ -647,7 +647,7 @@ GA.prototype.pushEnhancedEcommerce = function(track, opts, trackerName) {
   var args = reject([
     self._trackerName + 'send',
     'event',
-    track.category() || 'EnhancedEcommerce',
+    'EnhancedEcommerce',
     track.event() || 'Action not defined',
     track.properties().label,
     extend(

--- a/integrations/google-analytics/lib/index.js
+++ b/integrations/google-analytics/lib/index.js
@@ -644,10 +644,16 @@ GA.prototype.pushEnhancedEcommerce = function(track, opts, trackerName) {
   var self = this;
   // Send a custom non-interaction event to ensure all EE data is pushed.
   // Without doing this we'd need to require page display after setting EE data.
+
+  var enhancedEcommerce = 'EnhancedEcommerce';
+  var category = opts.useEnhancedEcommerceCategory
+    ? enhancedEcommerce
+    : track.category() || enhancedEcommerce;
+
   var args = reject([
     self._trackerName + 'send',
     'event',
-    'EnhancedEcommerce',
+    category,
     track.event() || 'Action not defined',
     track.properties().label,
     extend(


### PR DESCRIPTION
**What does this PR do?**
Category for track enhanced ecommerce event is now always 'EnhancedEcommerce`.

**Are there breaking changes in this PR?**
Yes, if customer previously relied on being able to specify a custom category for enhanced ecommerce events those will now be `EnhancedEcommerce`.

**Any background context you want to provide?**
https://segment.atlassian.net/browse/DEST-594

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
Serverside already always uses `EnhancedEcommerce` as its category setting. https://github.com/segmentio/integrations/blob/cf87c8c01317fe7db6b6e920f57edbd20c88b983/integrations/google-analytics/lib/universal/mapper.js#L1026

**Does this require a new integration setting? If so, please explain how the new setting works**
Yes, adding a new setting `useEnhancedEcommerceCategory`

**Links to helpful docs and other external resources**
