### PR TITLE
DEST-797 fb-pixel Use optional `contentIdPreference` when populating `content_ids`

### DIFF
--- a/integrations/facebook-pixel/lib/index.js
+++ b/integrations/facebook-pixel/lib/index.js
@@ -76,12 +76,16 @@ var defaultPiiProperties = [
 
 /**
  * @param {Object} track
- * @returns {string[]} contentIds
+ * @returns {string} contentIds
  */
 function getContentId(track) {
-  return [track.productId() || track.id() || track.sku() || ''];
+  return track.productId() || track.id() || track.sku() || '';
 }
 
+/**
+ * @param {Object[]} products
+ * @returns {string[]} contentIds
+ */
 function getContentIds(products) {
   var contentIds = foldl(
     function(acc, product) {

--- a/integrations/facebook-pixel/lib/index.js
+++ b/integrations/facebook-pixel/lib/index.js
@@ -75,6 +75,14 @@ var defaultPiiProperties = [
 ];
 
 /**
+ * @param {Object} track
+ * @returns {string[]} contentIds
+ */
+function getContentIds(track) {
+  return [track.productId() || track.id() || track.sku() || ''];
+}
+
+/**
  * Initialize Facebook Pixel.
  *
  * @param {Facade} page
@@ -267,7 +275,7 @@ FacebookPixel.prototype.productViewed = function(track) {
     'ViewContent',
     merge(
       {
-        content_ids: [track.productId() || track.id() || track.sku() || ''],
+        content_ids: getContentIds(track),
         content_type: this.getContentType(track, ['product']),
         content_name: track.name() || '',
         content_category: track.category() || '',
@@ -304,7 +312,6 @@ FacebookPixel.prototype.productViewed = function(track) {
  * @api private
  * @param {Track} track
  */
-
 FacebookPixel.prototype.productAdded = function(track) {
   var self = this;
   var useValue = this.options.valueIdentifier === 'value';
@@ -316,7 +323,7 @@ FacebookPixel.prototype.productAdded = function(track) {
     'AddToCart',
     merge(
       {
-        content_ids: [track.productId() || track.id() || track.sku() || ''],
+        content_ids: getContentIds(track),
         content_type: this.getContentType(track, ['product']),
         content_name: track.name() || '',
         content_category: track.category() || '',

--- a/integrations/facebook-pixel/lib/index.js
+++ b/integrations/facebook-pixel/lib/index.js
@@ -92,8 +92,9 @@ function getContentId(track, contentIdPreference) {
   }
   if (!contentId) {
     // Preserve old behavior if no preference or preferred field is not set.
-    return track.productId() || track.id() || track.sku() || '';
+    contentId = track.productId() || track.id() || track.sku() || '';
   }
+  return contentId;
 }
 
 /**

--- a/integrations/facebook-pixel/lib/index.js
+++ b/integrations/facebook-pixel/lib/index.js
@@ -86,7 +86,7 @@ function getContentIds(products) {
   var contentIds = foldl(
     function(acc, product) {
       var item = new Track({ properties: product });
-      var key = item.productId() || item.id() || item.sku();
+      var key = getContentId(item);
       if (key) acc.push(key);
       return acc;
     },


### PR DESCRIPTION
This would allow customer to optionally set a contentIdPreference which would specify which field to use for contentId.

I think it would be a dropdown menu setting with options:
- `productId`
- `id`
- `sku`

TODO:
- [ ] Unit test `getContentIds`

**What does this PR do?**


**Are there breaking changes in this PR?**


**Any background context you want to provide?**


**Is there parity with the server-side/android/iOS integration components (if applicable)?**


**Does this require a new integration setting? If so, please explain how the new setting works**


**Links to helpful docs and other external resources**
