### PR TITLE
[DEST-1068] Ability to use Advanced Matching on External ID

### DIFF
--- a/integrations/facebook-pixel/lib/index.js
+++ b/integrations/facebook-pixel/lib/index.js
@@ -28,6 +28,7 @@ var FacebookPixel = (module.exports = integration('Facebook Pixel')
   .option('whitelistPiiProperties', [])
   .option('blacklistPiiProperties', [])
   .option('standardEventsCustomProperties', [])
+  .option('keyForExternalId', '')
   .mapping('standardEvents')
   .mapping('legacyEvents')
   .mapping('contentTypes')
@@ -621,6 +622,10 @@ FacebookPixel.prototype.formatTraits = function formatTraits(analytics) {
       .toLowerCase();
   var state = address.state && address.state.toLowerCase();
   var postalCode = address.postalCode;
+  var external_id; // eslint-disable-line
+  if (this.options.keyForExternalId) {
+    external_id = traits[this.options.keyForExternalId]; // eslint-disable-line
+  }
   return reject({
     em: traits.email,
     fn: firstName,
@@ -630,7 +635,8 @@ FacebookPixel.prototype.formatTraits = function formatTraits(analytics) {
     db: birthday,
     ct: city,
     st: state,
-    zp: postalCode
+    zp: postalCode,
+    external_id: external_id  // eslint-disable-line
   });
 };
 

--- a/integrations/facebook-pixel/package.json
+++ b/integrations/facebook-pixel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-facebook-pixel",
   "description": "The Facebook Pixel analytics.js integration.",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/facebook-pixel/test/index.test.js
+++ b/integrations/facebook-pixel/test/index.test.js
@@ -2825,6 +2825,64 @@ describe('Facebook Pixel', function() {
 
       analytics.deepEqual(expected, actual);
     });
+
+    it('should add an external_id if defined in settings', function() {
+      facebookPixel.options.keyForExternalId = 'test_external_id';
+      analytics.identify('123', {
+        firstName: 'brie',
+        lastName: 'test',
+        test_external_id: '123456789', // eslint-disable-line
+        address: null
+      });
+      var expected = {
+        fn: 'brie',
+        ln: 'test',
+        ge: 'm',
+        db: '19910113',
+        external_id: '123456789' // eslint-disable-line
+      };
+      var actual = facebookPixel.formatTraits(analytics);
+
+      analytics.deepEqual(expected, actual);
+    });
+
+    it('should reject an external_id if NOT defined in settings', function() {
+      facebookPixel.options.keyForExternalId = '';
+      analytics.identify('123', {
+        firstName: 'brie',
+        lastName: 'test',
+        test_external_id: '123456789', // eslint-disable-line
+        address: null
+      });
+      var expected = {
+        fn: 'brie',
+        ln: 'test',
+        ge: 'm',
+        db: '19910113'
+      };
+      var actual = facebookPixel.formatTraits(analytics);
+
+      analytics.deepEqual(expected, actual);
+    });
+
+    it('should reject an external_id settings are all undefined', function() {
+      facebookPixel.options = {};
+      analytics.identify('123', {
+        firstName: 'brie',
+        lastName: 'test',
+        test_external_id: '123456789', // eslint-disable-line
+        address: null
+      });
+      var expected = {
+        fn: 'brie',
+        ln: 'test',
+        ge: 'm',
+        db: '19910113'
+      };
+      var actual = facebookPixel.formatTraits(analytics);
+
+      analytics.deepEqual(expected, actual);
+    });
   });
 
   describe('#merge', function() {


### PR DESCRIPTION
**What does this PR do?**
Reopens this PR: https://github.com/segmentio/analytics.js-integrations/pull/217. Had to revert post-merge because did not update the version in the package.json. 

Adds functionality to support Advanced Matching on External ID for Facebook Pixel. Since `external_id` is not part of the Segment spec I will introduce a new setting in Partner Portal marked for Client Side only called `keyForExternalId`. Customers can indicated the key in their traits which they would like to map to FB Pixel `external_id`. 

**Are there breaking changes in this PR?**
No breaking changes. This has been tested and validated with unit tests and locally using the Golden Compiler in my browser. 


**Any background context you want to provide?**
JIRA Ticket: https://segment.atlassian.net/browse/DEST-1068

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
We are not currently building support for this SS or on mobile. 

**Does this require a new integration setting? If so, please explain how the new setting works**
Yes we will be adding a new setting in PP. See the above comment in the description. 

**Links to helpful docs and other external resources**
N/A