### PR TITLE
[DEST-1157] sync node version with ajs-privatee

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,4 +1,4 @@
-FROM circleci/node:8-browsers
+FROM circleci/node:10-browsers
 
 RUN sudo apt-get install cmake libhttp-parser-dev openssl inotify-tools
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,9 +4,7 @@ jobs:
     docker:
       - image: circleci/node:10-browsers
     steps:
-      - run:
-          name: Checkout code
-          command: checkout
+      - checkout
       - restore_cache:
           key: deps-{{ checksum "yarn.lock" }}
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   setup:
     docker:
-      - image: ${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com/analytics.js-integrations-ci
+      - image: circleci/node:10-browsers
     steps:
       - run:
           name: Checkout code
@@ -25,7 +25,7 @@ jobs:
 
   lint:
     docker:
-        - image: ${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com/analytics.js-integrations-ci
+        - image: circleci/node:10-browsers
     steps:
       - attach_workspace: { at: . }
       - restore_cache:
@@ -36,7 +36,7 @@ jobs:
 
   test:
     docker:
-        - image: ${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com/analytics.js-integrations-ci
+        - image: circleci/node:10-browsers
     steps:
       - attach_workspace: { at: . }
       - restore_cache:
@@ -47,7 +47,7 @@ jobs:
 
   test_saucelabs:
     docker:
-      - image: ${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com/analytics.js-integrations-ci
+      - image: circleci/node:10-browsers
     steps:
       - attach_workspace: { at: . }
       - restore_cache:
@@ -58,7 +58,7 @@ jobs:
 
   test_snyk:
     docker:
-      - image: ${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com/analytics.js-integrations-ci
+      - image: circleci/node:10-browsers
     steps:
       - attach_workspace: { at: . }
       - restore_cache:
@@ -69,7 +69,7 @@ jobs:
 
   publish:
     docker:
-      - image: ${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com/analytics.js-integrations-ci
+      - image: circleci/node:10-browsers
     steps:
       - attach_workspace: { at: . }
       - restore_cache:

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "author": "Segment",
   "license": "See LICENSE",
   "private": true,
+  "engines": {
+    "node": "^10"
+  },
   "workspaces": [
     "integrations/*"
   ],


### PR DESCRIPTION
**What does this PR do?**
Enforces a specific node version range when any dependencies are installed. Also updates the circleci image we use to align with what's used in analytics.js-private. This is where the production artifacts are generated so maintaining parity with that is critical.