### PR TITLE
Add support for moz-extension pages.

### DIFF
--- a/integrations/omniture/build.js
+++ b/integrations/omniture/build.js
@@ -9040,7 +9040,8 @@
 
           var https =
             document.location.protocol === 'https:' ||
-            document.location.protocol === 'chrome-extension:';
+            document.location.protocol === 'chrome-extension:' ||
+            document.location.protocol === 'moz-extension:';
 
           // If you use protocol relative URLs, third-party scripts like Google
           // Analytics break when testing with `file:` so this fixes that.


### PR DESCRIPTION
Loading this in a Firefox extension results in the wrong scheme being applied to injected script tags - http instead of https.  This adds the same check that already exists for chrome-extension pages, but for Firefox.


**What does this PR do?**
Adds support for "moz-extension" pages.


**Are there breaking changes in this PR?**
Unknown, but unlikely.

**Any background context you want to provide?**
See initial commit message.  

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
NA

**Does this require a new integration setting? If so, please explain how the new setting works**
NA

**Links to helpful docs and other external resources**
https://github.com/segmentio/analytics.js-integrations/issues/250