### PR TITLE
Seg 25

### DIFF
--- a/integrations/criteo/HISTORY.md
+++ b/integrations/criteo/HISTORY.md
@@ -1,3 +1,8 @@
+1.2.2 / 2019-10-17
+==================
+
+  * Added support for track "setSiteType" based on device: "m" FOR MOBILE OR "t" FOR TABLET OR "d" FOR DESKTOP".
+
 1.2.1 / 2019-09-26
 ==================
 

--- a/integrations/criteo/lib/index.js
+++ b/integrations/criteo/lib/index.js
@@ -266,7 +266,9 @@ function getProductMetadata(track) {
 function getDeviceType() {
   var ipadRegex = /iPad/;
   var mobileRegex = /Mobile|iP(hone|od)|Android|BlackBerry|IEMobile|Silk/;
-  if (ipadRegex.test(navigator.userAgent)) return 't';
+  if (ipadRegex.test(navigator.userAgent)) {
+    return 't';
+  }
   if (mobileRegex.test(navigator.userAgent)) {
     return 'm';
   }

--- a/integrations/criteo/lib/index.js
+++ b/integrations/criteo/lib/index.js
@@ -17,6 +17,12 @@ var is = require('is');
 var integration = require('@segment/analytics.js-integration');
 
 /**
+ * Regex to indentify the devices.
+ */
+var ipadRegex = /iPad/;
+var mobileRegex = /Mobile|iP(hone|od)|Android|BlackBerry|IEMobile|Silk/;
+
+/**
  * Expose Criteo integration.
  */
 
@@ -264,8 +270,9 @@ function getProductMetadata(track) {
  */
 
 function getDeviceType() {
-  var ipadRegex = /iPad/;
-  var mobileRegex = /Mobile|iP(hone|od)|Android|BlackBerry|IEMobile|Silk/;
+  if (!navigator || !navigator.userAgent) {
+    return 'd';
+  }
   if (ipadRegex.test(navigator.userAgent)) {
     return 't';
   }

--- a/integrations/criteo/lib/index.js
+++ b/integrations/criteo/lib/index.js
@@ -39,6 +39,7 @@ Criteo.prototype.initialize = function() {
 
   window.criteo_q = window.criteo_q || [];
   window.criteo_q.push({ event: 'setAccount', account: account });
+  window.criteo_q.push({ event: 'setSiteType', type: getDeviceType() });
 
   var protocol = useHttps() ? 'https' : 'http';
   this.load(protocol, this.ready);
@@ -252,4 +253,22 @@ function getProductMetadata(track) {
   });
 
   return products;
+}
+
+/**
+ * Get Device Type
+ *
+ * @api private
+ *
+ * REF: https://support.criteo.com/s/article?article=202806931-Managing-your-different-site-types&language=en_US
+ */
+
+function getDeviceType() {
+  var ipadRegex = /iPad/;
+  var mobileRegex = /Mobile|iP(hone|od)|Android|BlackBerry|IEMobile|Silk/;
+  if (ipadRegex.test(navigator.userAgent)) return 't';
+  if (mobileRegex.test(navigator.userAgent)) {
+    return 'm';
+  }
+  return 'd';
 }

--- a/integrations/criteo/package.json
+++ b/integrations/criteo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-criteo",
   "description": "The Criteo analytics.js integration.",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/criteo/test/index.test.js
+++ b/integrations/criteo/test/index.test.js
@@ -63,12 +63,38 @@ describe('Criteo', function() {
         analytics.called(criteo.load);
       });
 
-      it('should track setSiteType', function() {
+      it('should track setSiteType for desktop', function() {
         analytics.stub(window.criteo_q, 'push');
         analytics.initialize();
         analytics.called(window.criteo_q.push, {
           event: 'setSiteType',
           type: 'd'
+        });
+      });
+
+      it('should track setSiteType for mobile', function() {
+        Object.defineProperty(window.navigator, 'userAgent', {
+          value: 'Mobile',
+          writable: true // allow to modify readonly userAgent
+        });
+        analytics.stub(window.criteo_q, 'push');
+        analytics.initialize();
+        analytics.called(window.criteo_q.push, {
+          event: 'setSiteType',
+          type: 'm'
+        });
+      });
+
+      it('should track setSiteType for tablet', function() {
+        Object.defineProperty(window.navigator, 'userAgent', {
+          value: 'iPad',
+          writable: true // allow to modify readonly userAgent
+        });
+        analytics.stub(window.criteo_q, 'push');
+        analytics.initialize();
+        analytics.called(window.criteo_q.push, {
+          event: 'setSiteType',
+          type: 't'
         });
       });
     });

--- a/integrations/criteo/test/index.test.js
+++ b/integrations/criteo/test/index.test.js
@@ -97,6 +97,19 @@ describe('Criteo', function() {
           type: 't'
         });
       });
+
+      it('should track setSiteType for unexpected userAgent', function() {
+        Object.defineProperty(window.navigator, 'userAgent', {
+          value: 'unknownDevice',
+          writable: true // allow to modify readonly userAgent
+        });
+        analytics.stub(window.criteo_q, 'push');
+        analytics.initialize();
+        analytics.called(window.criteo_q.push, {
+          event: 'setSiteType',
+          type: 'd'
+        });
+      });
     });
   });
 

--- a/integrations/criteo/test/index.test.js
+++ b/integrations/criteo/test/index.test.js
@@ -62,6 +62,15 @@ describe('Criteo', function() {
         analytics.initialize();
         analytics.called(criteo.load);
       });
+
+      it('should track setSiteType', function() {
+        analytics.stub(window.criteo_q, 'push');
+        analytics.initialize();
+        analytics.called(window.criteo_q.push, {
+          event: 'setSiteType',
+          type: 'd'
+        });
+      });
     });
   });
 


### PR DESCRIPTION
**What does this PR do?**
Tracks the setSiteType event based on the device: "m FOR MOBILE OR t FOR TABLET OR d FOR DESKTOP"

**Are there breaking changes in this PR?**
No.

**Any background context you want to provide?**
Earlier initialise of criteo was not setting device type.

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
Yes, difference in device type.

**Does this require a new integration setting? If so, please explain how the new setting works**
No.

**Links to helpful docs and other external resources**
https://support.criteo.com/s/article?article=202806891-Criteo-OneTag-on-your-homepage&language=en_US

