### PR TITLE
[DEST-593] Send multiple reqs when multiple mappings

### DIFF
--- a/integrations/google-adwords-new/package.json
+++ b/integrations/google-adwords-new/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-google-adwords-new",
   "description": "The google-adwords-new analytics.js integration.",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/google-adwords-new/test/index.test.js
+++ b/integrations/google-adwords-new/test/index.test.js
@@ -23,6 +23,13 @@ describe('Google AdWords New', function() {
       },
       {
         value: {
+          event: 'Order completed',
+          id: 'ljkhsdfkjlhsdfj',
+          accountId: ''
+        }
+      },
+      {
+        value: {
           event: 'signup',
           id: 'eAZJCICuz3gQ1ta71QM',
           accountId: ''
@@ -41,6 +48,13 @@ describe('Google AdWords New', function() {
         value: {
           event: 'Landing',
           id: '80mjCKaqz3gQ1ta71QM',
+          accountId: ''
+        }
+      },
+      {
+        value: {
+          event: 'Landing',
+          id: 'kajsd98sdf098sjf',
           accountId: ''
         }
       },
@@ -163,6 +177,19 @@ describe('Google AdWords New', function() {
             url: location.href
           }
         ]);
+        analytics.deepEqual(window.gtag.args[3], [
+          'event',
+          'landing',
+          {
+            name: 'landing',
+            send_to: options.accountId + '/kajsd98sdf098sjf',
+            path: location.pathname,
+            referrer: document.referrer,
+            search: location.search,
+            title: document.title,
+            url: location.href
+          }
+        ]);
       });
 
       it('should allow overriding accountId when sending page load conversions', function() {
@@ -236,6 +263,15 @@ describe('Google AdWords New', function() {
           'order completed',
           {
             send_to: options.accountId + '/hNDoCJ6Yt3gQ1ta71QM',
+            value: 25,
+            transaction_id: 'totally-tubular'
+          }
+        ]);
+        analytics.deepEqual(window.gtag.args[3], [
+          'event',
+          'order completed',
+          {
+            send_to: options.accountId + '/ljkhsdfkjlhsdfj',
             value: 25,
             transaction_id: 'totally-tubular'
           }


### PR DESCRIPTION
**What does this PR do?**
The [old Adwords integration](https://github.com/segment-integrations/analytics.js-integration-adwords) sends multiple requests when an event is mapped to multiple account IDs while the new integration doesn't. This pull request fixes that parity issue.

When the `clickConversions` and `pageLoadConversions` settings have multiple mappings for a single event, the new Adwords integration will now send multiple events.

**Are there breaking changes in this PR?**
Nah

**Any background context you want to provide?**
Nah

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
Yes, parity with the old a.js integration.

**Does this require a new integration setting? If so, please explain how the new setting works**
Nah

**Links to helpful docs and other external resources**
