### PR TITLE
[DEST-1242] [Nielsen DCR] Default length to when not provided.

### DIFF
--- a/integrations/nielsen-dcr/lib/index.js
+++ b/integrations/nielsen-dcr/lib/index.js
@@ -185,15 +185,14 @@ NielsenDCR.prototype.getContentMetadata = function(track, type) {
     hasAds: find(integrationOpts, 'hasAds') === true ? '1' : '0'
   };
 
-  if (track.proxy(propertiesPath + 'livestream')) {
-    // hardcode 86400 if livestream ¯\_(ツ)_/¯
-    contentMetadata.length = 86400;
-  } else if (this.options.contentLengthPropertyName !== 'total_length') {
+  if (this.options.contentLengthPropertyName !== 'total_length') {
     var contentLengthKey = this.options.contentLengthPropertyName;
     contentMetadata.length = track.proxy(propertiesPath + contentLengthKey);
   } else {
     contentMetadata.length = track.proxy(propertiesPath + 'total_length');
   }
+  // if length is any falsy value after the above checks, default to 0 length per Nielsen
+  contentMetadata.length = contentMetadata.length || 0;
 
   if (this.options.subbrandPropertyName) {
     var subbrandProp = this.options.subbrandPropertyName;

--- a/integrations/nielsen-dcr/package.json
+++ b/integrations/nielsen-dcr/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-nielsen-dcr",
   "description": "The Nielsen DCR analytics.js integration.",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/nielsen-dcr/test/index.test.js
+++ b/integrations/nielsen-dcr/test/index.test.js
@@ -387,7 +387,7 @@ describe('NielsenDCR', function() {
             assetid: props.asset_id,
             program: props.program,
             title: props.title,
-            length: 86400,
+            length: 0,
             isfullepisode: 'y',
             mediaURL: 'segment.com',
             airdate: '19910813 12:00:00',


### PR DESCRIPTION
**What does this PR do?**
- This PR defaults the `length` property to `0` when none is provided by the customer. Previously, we would default to `86400` per previous advice from Nielsen.

**Are there breaking changes in this PR?**
- No.

**Any background context you want to provide?**
- n/a

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
- n/a

**Does this require a new integration setting? If so, please explain how the new setting works**
- No.

**Links to helpful docs and other external resources**
- n/a