### PR TITLE
[WIP] [DEST-1141] Send Segment anonymousId as Monetate deviceId

### DIFF
--- a/integrations/monetate/HISTORY.md
+++ b/integrations/monetate/HISTORY.md
@@ -1,4 +1,9 @@
 
+3.0.1 / 2019-10-31
+==================
+
+  * Send Segment `anonymousId` as Monetate `deviceId`.
+
 3.0.0 / 2019-06-24
 ==================
 

--- a/integrations/monetate/lib/index.js
+++ b/integrations/monetate/lib/index.js
@@ -41,7 +41,8 @@ Monetate.prototype.initialize = function() {
     this.options.events = {
       orderCompleted: 'addPurchaseRows',
       productViewed: 'addProductDetails',
-      productListViewed: 'addProducts'
+      productListViewed: 'addProducts',
+      productAdded: 'addCartRows'
     };
   }
   window.monetateQ = window.monetateQ || [];

--- a/integrations/monetate/lib/index.js
+++ b/integrations/monetate/lib/index.js
@@ -42,7 +42,6 @@ Monetate.prototype.initialize = function() {
       orderCompleted: 'addPurchaseRows',
       productViewed: 'addProductDetails',
       productListViewed: 'addProducts'
-      // productAdded: 'addCartRows'
     };
   }
   window.monetateQ = window.monetateQ || [];

--- a/integrations/monetate/lib/index.js
+++ b/integrations/monetate/lib/index.js
@@ -181,7 +181,9 @@ function push() {
   if (push.tid) return;
   push.tid = setTimeout(function() {
     clearTimeout(push.tid);
-    window.monetateQ.push(['deviceId', this.analytics.user().anonymousId()]);
+    if (window.monetateQ) {
+      window.monetateQ.push(['deviceId', this.analytics.user().anonymousId()]);
+    }
     mq('trackData');
     push.tid = null;
   });

--- a/integrations/monetate/lib/index.js
+++ b/integrations/monetate/lib/index.js
@@ -41,8 +41,8 @@ Monetate.prototype.initialize = function() {
     this.options.events = {
       orderCompleted: 'addPurchaseRows',
       productViewed: 'addProductDetails',
-      productListViewed: 'addProducts',
-      productAdded: 'addCartRows'
+      productListViewed: 'addProducts'
+      // productAdded: 'addCartRows'
     };
   }
   window.monetateQ = window.monetateQ || [];
@@ -181,6 +181,7 @@ function push() {
   if (push.tid) return;
   push.tid = setTimeout(function() {
     clearTimeout(push.tid);
+    window.monetateQ.push(['deviceId', this.analytics.user().anonymousId()]);
     mq('trackData');
     push.tid = null;
   });

--- a/integrations/monetate/package.json
+++ b/integrations/monetate/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-monetate",
   "description": "The Monetate analytics.js integration.",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/monetate/test/index.test.js
+++ b/integrations/monetate/test/index.test.js
@@ -148,27 +148,6 @@ describe('Monetate', function() {
         analytics.called(window.monetateQ.push, expected);
       });
 
-      it('should track product added', function() {
-        analytics.track('product added', {
-          product_id: 'bb161be4',
-          sku: 'fc0b3bb',
-          name: 'sony pulse',
-          price: 299,
-          quantity: 8
-        });
-        analytics.called(window.monetateQ.push, [
-          'addCartRows',
-          [
-            {
-              itemId: 'bb161be4',
-              sku: 'fc0b3bb',
-              quantity: 8,
-              unitPrice: '299.00'
-            }
-          ]
-        ]);
-      });
-
       it('should track order completed', function() {
         analytics.track('order completed', {
           orderId: 'e493a192',

--- a/integrations/monetate/test/index.test.js
+++ b/integrations/monetate/test/index.test.js
@@ -148,6 +148,27 @@ describe('Monetate', function() {
         analytics.called(window.monetateQ.push, expected);
       });
 
+      it('should track product added', function() {
+        analytics.track('product added', {
+          product_id: 'bb161be4',
+          sku: 'fc0b3bb',
+          name: 'sony pulse',
+          price: 299,
+          quantity: 8
+        });
+        analytics.called(window.monetateQ.push, [
+          'addCartRows',
+          [
+            {
+              itemId: 'bb161be4',
+              sku: 'fc0b3bb',
+              quantity: 8,
+              unitPrice: '299.00'
+            }
+          ]
+        ]);
+      });
+
       it('should track order completed', function() {
         analytics.track('order completed', {
           orderId: 'e493a192',

--- a/integrations/monetate/test/index.test.js
+++ b/integrations/monetate/test/index.test.js
@@ -10,7 +10,8 @@ describe('Monetate', function() {
   var monetate;
   var options = {
     domain: 'stage.segment.io',
-    siteId: 'a-63d5abf3'
+    siteId: 'a-63d5abf3',
+    sendDeviceId: false
   };
 
   beforeEach(function() {


### PR DESCRIPTION
**What does this PR do?**
- This PR is based on the existing PR: https://github.com/segmentio/analytics.js-integrations/pull/206. Here, I have changed the package name and updated the Readme to remove customer-specific info.
- I have verified with a local build of A.js that the latest code works as expected, pushing `deviceId` into `window.monetateQ` with each Segment event.

**Are there breaking changes in this PR?**
- No.

**Any background context you want to provide?**
- Yes, this PR incorporates a request made by Monetate that has been echoed by a customer. https://segment.atlassian.net/browse/DEST-1141

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
- n/a

**Does this require a new integration setting? If so, please explain how the new setting works**
- Verifying now whether functionality should be gated behind a setting. For now, though, I see no reason why it should be.

**Links to helpful docs and other external resources**
- n/a