### PR TITLE
Bump tracktor to 0.6.2

### DIFF
--- a/integrations/visual-tagger/package.json
+++ b/integrations/visual-tagger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/analytics.js-integration-visual-tagger",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "The Visual Tagger analyticsjs integration",
   "main": "lib/index.js",
   "scripts": {

--- a/integrations/visual-tagger/package.json
+++ b/integrations/visual-tagger/package.json
@@ -10,6 +10,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@segment/tracktor": "0.6.1"
+    "@segment/tracktor": "0.6.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1310,10 +1310,10 @@
     component-cookie "^1.1.2"
     component-url "^0.2.1"
 
-"@segment/tracktor@0.6.1":
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/@segment/tracktor/-/tracktor-0.6.1.tgz#34a01995220cc80a9dd62c4395ffaa4f0003a3c5"
-  integrity sha512-V0iMA072LOZ8FKGGGyFamGSs6264l2BHGild5Gz5dekPoIMrMIUiubvlMe1SG7TakmkBviiFuFlsIgmkYvnIxw==
+"@segment/tracktor@0.6.2":
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/@segment/tracktor/-/tracktor-0.6.2.tgz#88d937490d530971365da557c37fa9f961ca4cb5"
+  integrity sha512-sVgClYRZ1wfsj/8aeot6K/5EF+TBZanlMCWpg3ZW4tWyI7CbxzDXYTMMl2hy3tiN4mP2zyoO6xI7/IgcOCccWA==
 
 "@segment/trample@^0.2.0":
   version "0.2.0"


### PR DESCRIPTION
**What does this PR do?**
Bump tracktor to 0.6.2

**Are there breaking changes in this PR?**
No

**Any background context you want to provide?**
This adds CDN to tracktor and adds static binding support

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
N/A

**Does this require a new integration setting? If so, please explain how the new setting works**
N/A

**Links to helpful docs and other external resources**
https://github.com/segmentio/tracktor/pull/39