### PR TITLE
[DEST-772][SEG-26] Facebook pixel supports snake_case properties.

### DIFF
--- a/integrations/facebook-pixel/HISTORY.md
+++ b/integrations/facebook-pixel/HISTORY.md
@@ -1,3 +1,8 @@
+2.9.0/ 2019-10-23
+==================
+
+  * Added support for user traits passed in snake case .
+
 2.8.1/ 2019-09-25
 ==================
 

--- a/integrations/facebook-pixel/lib/index.js
+++ b/integrations/facebook-pixel/lib/index.js
@@ -600,9 +600,9 @@ FacebookPixel.prototype.formatTraits = function formatTraits(analytics) {
   var lastName;
   // Check for firstName property
   // else check for name
-  if (traits.firstName) {
-    firstName = traits.firstName;
-    lastName = traits.lastName;
+  if (traits.firstName || traits.first_name) {
+    firstName = traits.firstName || traits.first_name;
+    lastName = traits.lastName || traits.last_name;
   } else {
     var nameArray = (traits.name && traits.name.toLowerCase().split(' ')) || [];
     firstName = nameArray.shift();
@@ -621,7 +621,7 @@ FacebookPixel.prototype.formatTraits = function formatTraits(analytics) {
       .join('')
       .toLowerCase();
   var state = address.state && address.state.toLowerCase();
-  var postalCode = address.postalCode;
+  var postalCode = address.postalCode || address.postal_code;
   var external_id; // eslint-disable-line
   if (this.options.keyForExternalId) {
     external_id = traits[this.options.keyForExternalId]; // eslint-disable-line

--- a/integrations/facebook-pixel/package.json
+++ b/integrations/facebook-pixel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-facebook-pixel",
   "description": "The Facebook Pixel analytics.js integration.",
-  "version": "2.8.2",
+  "version": "2.9.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/facebook-pixel/test/index.test.js
+++ b/integrations/facebook-pixel/test/index.test.js
@@ -2883,6 +2883,47 @@ describe('Facebook Pixel', function() {
 
       analytics.deepEqual(expected, actual);
     });
+
+    it('should send user traits if specified in snake case', function() {
+      analytics.identify('123', {
+        first_name: 'john',
+        last_name: 'doe',
+        address: {
+          postal_code: 123456
+        }
+      });
+      var expected = {
+        fn: 'john',
+        ln: 'doe',
+        ge: 'm',
+        db: '19910113',
+        zp: 123456
+      };
+      var actual = facebookPixel.formatTraits(analytics);
+
+      analytics.deepEqual(expected, actual);
+    });
+
+    it('should prefer camelCase traits over snake_case traits', function() {
+      analytics.identify('123', {
+        firstName: 'joe',
+        first_name: 'john',
+        last_name: 'doe',
+        address: {
+          postal_code: 123456
+        }
+      });
+      var expected = {
+        fn: 'joe',
+        ln: 'doe',
+        ge: 'm',
+        db: '19910113',
+        zp: 123456
+      };
+      var actual = facebookPixel.formatTraits(analytics);
+
+      analytics.deepEqual(expected, actual);
+    });
   });
 
   describe('#merge', function() {


### PR DESCRIPTION
**What does this PR do?**
- This PR adds support for snake_case properties. Previously, Segment only mapped camelCase properties downstream to Facebook.

**Are there breaking changes in this PR?**
- No.

**Any background context you want to provide?**
- n/a

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
- n/a

**Does this require a new integration setting? If so, please explain how the new setting works**
- No.

**Links to helpful docs and other external resources**
- https://segment.atlassian.net/browse/DEST-772
- https://webonise.atlassian.net/browse/SEG-26
