### PR TITLE
[DEST-1289] Support keyword on Comscore

### DIFF
--- a/integrations/comscore/HISTORY.md
+++ b/integrations/comscore/HISTORY.md
@@ -1,7 +1,9 @@
-2.0.4 / 2018-01-24
+2.0.5 / 2019-11-25
 ==================
 
- * Ladan made a mistake, see 2.0.3 for changes.
+ * Adds support for `comscorekw` parameter
+ * Leverages new destination config setting `comscorekw` to assign value to `comscorekw` query parameter
+
 
 2.0.3 / 2018-01-24
 ==================

--- a/integrations/comscore/lib/index.js
+++ b/integrations/comscore/lib/index.js
@@ -16,6 +16,7 @@ var Comscore = (module.exports = integration('comScore')
   .global('COMSCORE')
   .option('c1', '2')
   .option('c2', '')
+  .option('comscorekw', '')
   .tag('http', '<script src="http://b.scorecardresearch.com/beacon.js">')
   .tag('https', '<script src="https://sb.scorecardresearch.com/beacon.js">'));
 
@@ -85,6 +86,9 @@ Comscore.prototype.mapComscoreParams = function(page) {
 
   comScoreParams.c1 = this.options.c1;
   comScoreParams.c2 = this.options.c2;
+  if (this.options.comscorekw.length) {
+    comScoreParams.comscorekw = this.options.comscorekw;
+  }
 
   return comScoreParams;
 };

--- a/integrations/comscore/package.json
+++ b/integrations/comscore/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-comscore",
   "description": "The Comscore analytics.js integration.",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/comscore/test/index.test.js
+++ b/integrations/comscore/test/index.test.js
@@ -11,6 +11,7 @@ describe('comScore', function() {
   var comscore;
   var options = {
     c2: 'x',
+    comscorekw: 'test',
     autoUpdateInterval: '',
     beaconParamMap: {
       exampleParam: 'c5',
@@ -40,6 +41,7 @@ describe('comScore', function() {
         .global('_comscore')
         .option('c1', '2')
         .option('c2', '')
+        .option('comscorekw', '')
     );
   });
 
@@ -77,19 +79,32 @@ describe('comScore', function() {
       });
 
       it('should call only on 2nd page', function() {
-        analytics.didNotCall(window.COMSCORE.beacon, { c1: '2', c2: 'x' });
+        analytics.didNotCall(window.COMSCORE.beacon, {
+          c1: '2',
+          c2: 'x',
+          comscorekw: 'test'
+        });
         analytics.page();
-        analytics.called(window.COMSCORE.beacon, { c1: '2', c2: 'x' });
+        analytics.called(window.COMSCORE.beacon, {
+          c1: '2',
+          c2: 'x',
+          comscorekw: 'test'
+        });
       });
 
       it('should map properties in beaconParamMap', function() {
-        analytics.didNotCall(window.COMSCORE.beacon, { c1: '2', c2: 'x' });
+        analytics.didNotCall(window.COMSCORE.beacon, {
+          c1: '2',
+          c2: 'x',
+          comscorekw: 'test'
+        });
         analytics.page({ exampleParam: 'foo', anotherParam: 'bar' });
         analytics.called(window.COMSCORE.beacon, {
           c1: '2',
           c2: 'x',
           c5: 'foo',
-          c6: 'bar'
+          c6: 'bar',
+          comscorekw: 'test'
         });
       });
     });


### PR DESCRIPTION
**What does this PR do?**
Adds support to add a new setting option to set the keyword. The integration will retireve teh custom keyword and send it in a query string parameter on the request to Comscore as `comscorekw=` This value is unique per customer and not at event level, so can be set on destination setting config level. 

**Are there breaking changes in this PR?**
No, this was tested with the Golden Compiler. 
Legacy Behavior with setting undefined does not add query parameter:
```
// Golden Compiler Settings 
"comScore": {
     "appName":"",
     "autoUpdate":true,
     "autoUpdateInterval":60,
     "beaconParamMap":{

     },
     "c2":"95808742",
     "foregroundOnly":true,
     "publisherSecret":"",
     "useHTTPS":true,
     "comscorekw": ""
   }
````
Network Output:

<img width="841" alt="Screen Shot 2019-11-25 at 4 00 23 PM" src="https://user-images.githubusercontent.com/31782219/69588228-d7ea6900-0f9c-11ea-8c90-6c6938de9ccf.png">

New Behavior with setting defined adds query parameter:
```
//Settings in Golden Compiler 
"comScore": {
     "appName":"",
     "autoUpdate":true,
     "autoUpdateInterval":60,
     "beaconParamMap":{

     },
     "c2":"95808742",
     "foregroundOnly":true,
     "publisherSecret":"",
     "useHTTPS":true,
     "comscorekw": "test"
   }
```
Network Output:

![Screen Shot 2019-11-25 at 4 02 29 PM](https://user-images.githubusercontent.com/31782219/69588331-1d0e9b00-0f9d-11ea-8cd5-9feb864f34b1.png)


**Any background context you want to provide?**
Fox TV Station is trying to roll out their 20 stations with Segment. They have run into issues with comScore for their AMP pages for 6 of the stations. These 6 stations are blocked from launch until this is resolved.

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
No, this will likely need to be updated for iOS and Android at a later date 

**Does this require a new integration setting? If so, please explain how the new setting works**
Yes. The new setting is called `comscorekw` ie. Comscore Keyword. A customer can indicate in their destination config in the app what keyword they want to send in their query string to Comscore. The integration will retrieve this, when a keyword is provided in the settings, and send that to Comscore. If a keyword is not provided, ie. legacy behavior, no additional query parameters will be added to the query string. 

**Links to helpful docs and other external resources**
JIRA Ticket: https://segment.atlassian.net/browse/DEST-1289
CC Ticket: https://segment.atlassian.net/browse/CC-5712

