### PR TITLE
Add ready signalling for Visual Tagger integration

### DIFF
--- a/integrations/visual-tagger/lib/index.js
+++ b/integrations/visual-tagger/lib/index.js
@@ -3,6 +3,7 @@
  */
 var integration = require('@segment/analytics.js-integration');
 var TracktorLib = require('@segment/tracktor');
+var when = require('do-when');
 
 /**
  * Expose `Visual Tagger` integration.
@@ -26,6 +27,8 @@ Tracktor.prototype.initialize = function() {
     window.document
   );
   window.Tracktor = TracktorLib;
+
+  when(this.loaded, this.ready);
 
   tracktor.start();
 };

--- a/integrations/visual-tagger/package.json
+++ b/integrations/visual-tagger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/analytics.js-integration-visual-tagger",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "The Visual Tagger analyticsjs integration",
   "main": "lib/index.js",
   "scripts": {
@@ -10,6 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@segment/tracktor": "0.6.2"
+    "@segment/tracktor": "0.6.2",
+    "do-when": "^1.0.0"
   }
 }


### PR DESCRIPTION
`analytics.js` expects all integrations to signal when all asynchronous setup actions have completed and they are `ready`. Visual Tagger currently does not do this so any customers relying on the `ready` callback that AJS fires currently will experience problems when they flip on Visual Tagger and `ready` never happens.

For context, `mme-e2e` relies on `ready` to know when to fire its test events from AJS.

https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/#ready