### PR TITLE
feat(identify): use on user login instead of profile push for identify

### DIFF
--- a/integrations/clevertap/lib/index.js
+++ b/integrations/clevertap/lib/index.js
@@ -83,7 +83,7 @@ CleverTap.prototype.identify = function(identify) {
   each(function(value, key) {
     if (!is.object(value)) supportedTraits[key] = value;
   }, traits);
-  window.clevertap.profile.push({
+  window.clevertap.onUserLogin.push({
     Site: supportedTraits
   });
 };


### PR DESCRIPTION
This PR replaces the CleverTap profile push function with on user login function to better replicate Segment's  identify functionality.

No. There are no breaking changes. onUserLogin in CleverTap is same as profile push when identities don't change and for anonymous profiles.

This was reported by our client Bolt. We revisited the code and made the relevant fix.

No. This doesn't require any integration settings change.

More info: https://developer.clevertap.com/docs/concepts-user-profiles#section-maintaining-multiple-user-profiles-on-the-same-device
