### PR TITLE
Release Tracktor 0.7.1

### DIFF
--- a/integrations/visual-tagger/package.json
+++ b/integrations/visual-tagger/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@segment/tracktor": "0.6.2",
+    "@segment/tracktor": "0.7.1",
     "do-when": "^1.0.0"
   }
 }


### PR DESCRIPTION
**What does this PR do?**
Releases [this version of Tracktor](https://github.com/segmentio/tracktor/pull/40) that includes polyfills for older browser versions to address the relatively high initialization error rates


**Links to helpful docs and other external resources**
https://github.com/segmentio/tracktor/pull/40