### PR TITLE
DWEB-3

### DIFF
--- a/integrations/fullstory/HISTORY.md
+++ b/integrations/fullstory/HISTORY.md
@@ -1,3 +1,7 @@
+2.2.2 / 2019-11-26
+==================
+
+  * Added support for page events with 3 option settings i.e. trackAllPages, trackNamedPages,trackCategorizedPages.
 
 2.2.1 / 2019-08-09
 ==================

--- a/integrations/fullstory/lib/index.js
+++ b/integrations/fullstory/lib/index.js
@@ -19,6 +19,7 @@ var FullStory = (module.exports = integration('FullStory')
   .option('debug', false)
   .option('trackAllPages', false)
   .option('trackNamedPages', true)
+  .option('trackCategorizedPages', true)
   .tag(
     '<script async src="https://www.fullstory.com/s/fs.js" crossorigin="anonymous"></script>'
   ));
@@ -106,12 +107,18 @@ FullStory.prototype.identify = function(identify) {
  */
 
 FullStory.prototype.page = function(page) {
+  var category = page.category();
   var name = page.fullName();
   var opts = this.options;
 
   // all pages
   if (opts.trackAllPages) {
     this.track(page.track());
+  }
+
+  // categorized pages
+  if (category && opts.trackCategorizedPages) {
+    this.track(page.track(category));
   }
 
   // named pages

--- a/integrations/fullstory/lib/index.js
+++ b/integrations/fullstory/lib/index.js
@@ -111,19 +111,15 @@ FullStory.prototype.page = function(page) {
   var name = page.fullName();
   var opts = this.options;
 
-  // all pages
-  if (opts.trackAllPages) {
-    this.track(page.track());
-  }
-
-  // categorized pages
-  if (category && opts.trackCategorizedPages) {
-    this.track(page.track(category));
-  }
-
-  // named pages
   if (name && opts.trackNamedPages) {
+    // named pages
     this.track(page.track(name));
+  } else if (category && opts.trackCategorizedPages) {
+    // categorized pages
+    this.track(page.track(category));
+  } else if (opts.trackAllPages) {
+    // all pages
+    this.track(page.track());
   }
 };
 

--- a/integrations/fullstory/lib/index.js
+++ b/integrations/fullstory/lib/index.js
@@ -17,6 +17,8 @@ var integration = require('@segment/analytics.js-integration');
 var FullStory = (module.exports = integration('FullStory')
   .option('org', '')
   .option('debug', false)
+  .option('trackAllPages', false)
+  .option('trackNamedPages', true)
   .tag(
     '<script async src="https://www.fullstory.com/s/fs.js" crossorigin="anonymous"></script>'
   ));
@@ -93,6 +95,28 @@ FullStory.prototype.identify = function(identify) {
   } else {
     newTraits.segmentAnonymousId_str = String(identify.anonymousId());
     window.FS.setUserVars(newTraits, apiSource);
+  }
+};
+
+/**
+ * Page.
+ *
+ * @api public
+ * @param {Page} page
+ */
+
+FullStory.prototype.page = function(page) {
+  var name = page.fullName();
+  var opts = this.options;
+
+  // all pages
+  if (opts.trackAllPages) {
+    this.track(page.track());
+  }
+
+  // named pages
+  if (name && opts.trackNamedPages) {
+    this.track(page.track(name));
   }
 };
 

--- a/integrations/fullstory/package.json
+++ b/integrations/fullstory/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-fullstory",
   "description": "The Fullstory analytics.js integration.",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/fullstory/test/index.test.js
+++ b/integrations/fullstory/test/index.test.js
@@ -13,7 +13,8 @@ describe('FullStory', function() {
     org: '1JO',
     debug: false,
     trackAllPages: false,
-    trackNamedPages: true
+    trackNamedPages: true,
+    trackCategorizedPages: true
   };
 
   beforeEach(function() {
@@ -37,6 +38,9 @@ describe('FullStory', function() {
       integration('FullStory')
         .option('org', '')
         .option('debug', false)
+        .option('trackAllPages', false)
+        .option('trackNamedPages', true)
+        .option('trackCategorizedPages', true)
     );
   });
 
@@ -208,6 +212,11 @@ describe('FullStory', function() {
         fullstory.options.trackNamedPages = false;
         analytics.page('Dashboard');
         analytics.didNotCall(window.FS.event);
+      });
+
+      it('should track categorized pages by default', function() {
+        analytics.page('Category', 'Name');
+        analytics.called(window.FS.event, 'Viewed Category Name Page');
       });
     });
   });

--- a/integrations/fullstory/test/index.test.js
+++ b/integrations/fullstory/test/index.test.js
@@ -12,7 +12,8 @@ describe('FullStory', function() {
   var options = {
     org: '1JO',
     debug: false,
-    trackAllPages: false
+    trackAllPages: false,
+    trackNamedPages: true
   };
 
   beforeEach(function() {
@@ -192,20 +193,21 @@ describe('FullStory', function() {
         analytics.didNotCall(window.FS.event);
       });
 
-      it('should track named pages', function() {
-        analytics.page();
-        analytics.didNotCall(window.FS.event);
-      });
-
       it('should track unnamed pages if enabled', function() {
         fullstory.options.trackAllPages = true;
         analytics.page();
-        analytics.called(window.FS.event, '');
+        analytics.called(window.FS.event, 'Loaded a Page');
       });
 
       it('should track named pages by default', function() {
         analytics.page('Dashboard');
-        analytics.called(window.FS.event, 'Dashboard');
+        analytics.called(window.FS.event, 'Viewed Dashboard Page');
+      });
+
+      it('should not track name or categorized pages if disabled', function() {
+        fullstory.options.trackNamedPages = false;
+        analytics.page('Dashboard');
+        analytics.didNotCall(window.FS.event);
       });
     });
   });

--- a/integrations/fullstory/test/index.test.js
+++ b/integrations/fullstory/test/index.test.js
@@ -11,7 +11,8 @@ describe('FullStory', function() {
   var fullstory;
   var options = {
     org: '1JO',
-    debug: false
+    debug: false,
+    trackAllPages: false
   };
 
   beforeEach(function() {
@@ -62,6 +63,7 @@ describe('FullStory', function() {
     beforeEach(function(done) {
       analytics.once('ready', done);
       analytics.initialize();
+      analytics.page();
     });
 
     describe('#identify', function() {
@@ -177,6 +179,33 @@ describe('FullStory', function() {
           { some_field: 'field_value' },
           'segment'
         );
+      });
+    });
+
+    describe('#page', function() {
+      beforeEach(function() {
+        analytics.stub(window.FS, 'event');
+      });
+
+      it('should not track unnamed pages by default', function() {
+        analytics.page();
+        analytics.didNotCall(window.FS.event);
+      });
+
+      it('should track named pages', function() {
+        analytics.page();
+        analytics.didNotCall(window.FS.event);
+      });
+
+      it('should track unnamed pages if enabled', function() {
+        fullstory.options.trackAllPages = true;
+        analytics.page();
+        analytics.called(window.FS.event, '');
+      });
+
+      it('should track named pages by default', function() {
+        analytics.page('Dashboard');
+        analytics.called(window.FS.event, 'Dashboard');
       });
     });
   });


### PR DESCRIPTION
**What does this PR do?**
Added support for page events for fullstory.

**Are there breaking changes in this PR?**
No.

**Any background context you want to provide?**
Fullstory was not tracking page load events.

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
No.

**Does this require a new integration setting? If so, please explain how the new setting works**
Yes, **trackAllPages** - defaults to false , **trackNamedPages** - defaults to true, **trackCategorizedPages** - defaults to true.

**Links to helpful docs and other external resources**
NA