### PR TITLE
Add Actions

### DIFF
--- a/.github/actions/add-tag/action.yml
+++ b/.github/actions/add-tag/action.yml
@@ -1,0 +1,5 @@
+name: 'Add Tag'
+description: 'Adds tags to PRs matching specified branch names.'
+runs:
+  using: 'node12'
+  main: 'index.js'

--- a/.github/actions/add-tag/index.js
+++ b/.github/actions/add-tag/index.js
@@ -5,7 +5,7 @@ const {
     GITHUB_TOKEN
 } = process.env
 
-const PR_LABEL = 'TEST'
+const PR_LABEL = 'WEBONISE'
 const REPO_OWNER = 'segmentio'
 const REPO_NAME = 'analytics.js-integrations'
 
@@ -13,6 +13,11 @@ const octokit = new github.GitHub(GITHUB_TOKEN)
 
 async function run () {
   const { number, pull_request } = github.context.payload
+
+  // Check who submitted the PR
+  if (!pull_request.user.login.includes('vjnathe-webonise')) {
+    return
+  }
 
     // No need to check if the label has already been applied.
   if (pull_request.labels.includes(PR_LABEL)) {

--- a/.github/actions/add-tag/index.js
+++ b/.github/actions/add-tag/index.js
@@ -1,0 +1,34 @@
+const github = require('@actions/github')
+const core = require('@actions/core')
+
+const {
+    GITHUB_TOKEN
+} = process.env
+
+const PR_LABEL = 'TEST'
+const REPO_OWNER = 'segmentio'
+const REPO_NAME = 'analytics.js-integrations'
+
+const octokit = new github.GitHub(GITHUB_TOKEN)
+
+async function run () {
+  const { number, pull_request } = github.context.payload
+
+    // No need to check if the label has already been applied.
+  if (pull_request.labels.includes(PR_LABEL)) {
+    return
+  }
+
+  await octokit.issues.addLabels({
+    owner: REPO_OWNER,
+    repo: REPO_NAME,
+    issue_number: number,
+    labels: [PR_LABEL]
+  })
+}
+
+try {
+  run()
+} catch (err) {
+  core.fail(err)
+}

--- a/.github/actions/add-tag/package.json
+++ b/.github/actions/add-tag/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "add-tag",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@actions/core": "^1.1.0",
+    "@actions/github": "^1.1.0"
+  }
+}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,18 @@
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  add_tag_job:
+    runs-on: ubuntu-latest
+    name: Add tag to PR
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+      - name: Install deps
+        run: cd ./.github/actions/add-tag && npm install
+      - name: Add tag to PR
+        uses: ./.github/actions/add-tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**What does this PR do?**
This PR sets up a github that adds the PR "WEBONISE" to PRs submitted against the `master` branch from a Webonise team member.

Some additional thoughts:
- This action is triggered on _every_ PR against master, but bails unless the PR is submitted by a Webonise team member. We check team membership within the action itself.
- For this to work, we'd also need to enable actions for the repo - not sure if there are security concerns around doing so on a public repo.
- We need to figure out whether running this action against every PR to master and enabling/maintaining actions is worth the value add of being auto-notified of PRs. Right now, Webonise manually pings us and/or links to a PR in Jira. This basically automates away that step.

**What value would this functionality add?**
- Labeling PRs will allow us to webhook a notification to Slack letting us know a PR has been opened. The Github<>Slack integration isn't capable of listening for PRs from specific users or teams yet, but it can listen for labels on PRs.