### PR TITLE
[DEST-1605] [Nielsen DTVR] Send unix timestamp in seconds when livestreams end.

### DIFF
--- a/integrations/nielsen-dcr/package.json
+++ b/integrations/nielsen-dcr/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-nielsen-dcr",
   "description": "The Nielsen DCR analytics.js integration.",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/nielsen-dtvr/lib/index.js
+++ b/integrations/nielsen-dtvr/lib/index.js
@@ -118,7 +118,7 @@ NielsenDTVR.prototype.videoContentStarted = function(track) {
       this.previousEvent.proxy('properties.livestream') === true &&
       date instanceof Date
     ) {
-      time = Math.floor(event.timestamp().getTime() / 1000);
+      time = Math.floor(date.getTime() / 1000);
     } else if (this.previousEvent.proxy('properties.position')) {
       time = this.previousEvent.proxy('properties.position');
     }

--- a/integrations/nielsen-dtvr/lib/index.js
+++ b/integrations/nielsen-dtvr/lib/index.js
@@ -118,7 +118,7 @@ NielsenDTVR.prototype.videoContentStarted = function(track) {
       this.previousEvent.proxy('properties.livestream') === true &&
       date instanceof Date
     ) {
-      time = this.previousEvent.timestamp().getUTCDate();
+      time = Math.floor(event.timestamp().getTime() / 1000);
     } else if (this.previousEvent.proxy('properties.position')) {
       time = this.previousEvent.proxy('properties.position');
     }
@@ -282,7 +282,7 @@ NielsenDTVR.prototype.end = function(event) {
   var position = event.proxy('properties.position');
   var time;
   if (livestream) {
-    time = Date.now(event.timestamp());
+    time = Math.floor(event.timestamp().getTime() / 1000);
   } else if (position) {
     time = position;
   }

--- a/integrations/nielsen-dtvr/test/index.test.js
+++ b/integrations/nielsen-dtvr/test/index.test.js
@@ -245,6 +245,27 @@ describe('NielsenDTVR', function() {
           });
           analytics.called(nielsenDTVR.client.ggPM, 'sendID3', props.id3);
         });
+
+        it('should call end before starting a new content stream if the previous stream was not ended correctly', function() {
+          var previousEvent = {
+            asset_id: '123',
+            ad_asset_id: null,
+            channel: 'segment',
+            load_type: 'dynamic',
+            position: 1,
+            id3: '1',
+            livestream: true
+          };
+          var currentEvent = props;
+          var timestamp = new Date();
+          // when live streams end, we need to pass the Unix timestamp in seconds per Nielsen
+          var unixTime = Math.floor(timestamp.getTime() / 1000);
+          analytics.track('Video Content Started', previousEvent, {
+            timestamp: timestamp
+          });
+          analytics.track('Video Content Started', currentEvent);
+          analytics.called(nielsenDTVR.client.ggPM, 'end', unixTime);
+        });
       });
 
       describe('#persisted data', function() {

--- a/integrations/nielsen-dtvr/test/index.test.js
+++ b/integrations/nielsen-dtvr/test/index.test.js
@@ -5,7 +5,6 @@ var integrationTester = require('@segment/analytics.js-integration-tester');
 var integration = require('@segment/analytics.js-integration');
 var sandbox = require('@segment/clear-env');
 var NielsenDTVR = require('../lib/');
-var sinon = require('sinon');
 var Track = require('segmentio-facade').Track;
 var assert = require('assert');
 
@@ -205,18 +204,16 @@ describe('NielsenDTVR', function() {
         });
 
         it('should send video playback completed livestream', function() {
-          var timestamp = new Date();
-          var currentUTC = +Date.now(timestamp);
-          var newSandbox = sinon.sandbox.create();
-          newSandbox.stub(Date, 'now').returns(currentUTC);
-
           props.livestream = true;
+
+          var timestamp = new Date();
+          // when live streams end, we need to pass the Unix timestamp in seconds per Nielsen
+          var unixTime = Math.floor(timestamp.getTime() / 1000);
 
           analytics.track('Video Playback Completed', props, {
             timestamp: timestamp
           });
-          analytics.called(nielsenDTVR.client.ggPM, 'end', currentUTC);
-          newSandbox.restore();
+          analytics.called(nielsenDTVR.client.ggPM, 'end', unixTime);
         });
       });
 


### PR DESCRIPTION
Planning to deploy after holiday change freeze is lifted. Hard deadline for this change is Jan. 30 (in time for the Super Bowl).

**What does this PR do?**
- Passes unix timestamp in seconds when livestreams end, per a request from Nielsen.

**Are there breaking changes in this PR?**
- Yes, there is a "breaking" change on line 121 - but this fixes a bug that would pass an incorrect timestamp. This is an extreme edge case, and it's unlikely that it would affect anything currently in production.

**Any background context you want to provide?**
- n/a

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
- n/a

**Does this require a new integration setting? If so, please explain how the new setting works**
- n/a

**Links to helpful docs and other external resources**
- https://segment.atlassian.net/browse/DEST-1604