### PR TITLE
[DEST-1606] Adds option to pass integration settings in a file to A.js compiler.

### DIFF
--- a/compiler/README.md
+++ b/compiler/README.md
@@ -1,14 +1,19 @@
 # Analaytics.js-Integrations Tester
 
-This is a simple command line tool that supports building and testing Analytics.js locally.
+This is a simple command line tool that supports building and testing
+Analytics.js locally.
 
-Note: The path to all directories referenced in this document are relative to the Compiler tool root folder (where this README is located).
+Note: The path to all directories referenced in this document are relative to
+the Compiler tool root folder (where this README is located).
 
 # Install
 
-Before you begin, run `yarn install --no-lockfile` to install dependencies. Be sure to include `no-lockfile` - this prevents yarn from generating a `yarn.lock` file. The lock file locks dependency versions, which prevents this CLI 
-from pulling in local changes you make to integrations in this repo. If at any point you generate a lock file in this 
-directory, delete it before continuing, or you won't be able to test any of your local integration changes.
+Before you begin, run `yarn install --no-lockfile` to install dependencies. Be
+sure to include `no-lockfile`. Doing so prevents yarn from generating a
+`yarn.lock` file. The lock file locks dependency versions, which prevents this
+CLI from pulling in local changes you make to integrations in this repo. If at
+any point you generate a lock file in this directory, delete it before
+continuing. Otherwise, you won't be able to test any of your local integration changes.
 
 To get started, simply run `./compile --writeKey=<YOUR WRITE KEY>`.
 
@@ -23,33 +28,71 @@ To get started, simply run `./compile --writeKey=<YOUR WRITE KEY>`.
 
     -w, --write-key <writeKey>  Writekey of target Segment source [Required]
     -p, --port [port]           Set a port to serve the local ajs file from (default: 3000)
+    -s, --settings <settings>   Relative path to custom integrations settings file
     -h, --help                  Output usage information
 ```
 
 # Build Process
 
- - This tool builds all A.js integration packages from the `../integrations` directory into a local version of A.js.
- - The tool retrieves integration settings from `http://cdn.segment.com/v1/projects/${writeKey}/settings`. Because we pull settings from the 
-Segment account associated with the `--writeKey` option, you must enable and set up each integration you'd like to test in your Segment dashboard 
-before building a version of A.js locally using this tool.
- - Once A.js is built, this tool saves a copy of your A.js build in the `./builds` folder. Build names follow the pattern `analytics-${date}.js`, where 
+- This tool builds all A.js integration packages from the `../integrations`
+directory into a local version of A.js.
+- The tool retrieves integration
+settings from `http://cdn.segment.com/v1/projects/${writeKey}/settings`.
+Because we pull settings from the Segment account associated with the
+`--writeKey` option, you must enable and set up each integration you'd like to
+test in your Segment dashboard before building a version of A.js locally using
+this tool.
+- If a custom settings file is specified, the tool uses only those
+integrations and settings defined in the file. An integrations whose
+settings are provided in a file need not be enabled in your production source.
+- Once A.js is built, this tool saves a copy of your A.js build in the
+`./builds` folder. Build names follow the pattern `analytics-${date}.js`, where
 `date` is the unix timestamp in seconds at which the file was generated.
- - Next, the tool launches your default browser, serving a sample `index` file from `./src/index.html`. This file includes the Segment snippet and 
-initializes the your just-generated A.js build so you can begin testing right away.
+- Finally, the tool launches your default browser, serving a sample `index` file
+from `./src/index.html`. This file includes the Segment snippet and initializes
+the your just-generated A.js build so you can begin testing right away.
 
 # Adding New Destinations
 
-Adding new destinations is easy - just add the package name and file path to the `./package.json` file in this directory. For example, to
-add a new integration with slug `google-v2`, just add the following line to the `dependencies` section of `./package.json`:
+Adding new destinations is easy: Just add the package name and file path to
+the `./package.json` file in this directory. For example, to add a new
+integration with slug `google-v2`, add the following line to the
+`dependencies` section of `./package.json`:
 
 ```
 "@segment/analytics.js-integrations-google-v2": "file:../integrations/google-v2"
 ```
 
-Note the `google-v2` destination directory must exist in `../integrations`, and the package name in that directory must match the package name
-specified in the `package.json` file in this directory.
+Note the `google-v2` destination directory must exist in `../integrations`, and
+the package name in that directory must match the package name specified in the
+`package.json` file in this directory.
+
+# Custom Settings
+
+An example settings file is included in `./src/settings_example.json`. Settings
+must be defined as JSON in this format:
+
+```json
+{
+  "integrations": {
+    "Integration Name": {
+      "settingsSlug": "value"
+    }
+  }
+}
+```
+
+Note `integrations` at the top level of the object is required for the tool to
+parse custom settings correctly.
+
+To compile a version of A.js with custom settings, simply run a command like this:
+
+```
+./compile --writeKey=<writeKey> --settings='./relative/path/to/settings.json'
+```
 
 # FAQ
 
 **Are A.js video plugins and client-side tracking plans supported?**
-No, currently the A.js Tester doesn't support video plugins or tracking plans; however, we will add these in the future if needed for testing.
+No, currently the A.js Tester doesn't support video plugins or tracking plans;
+however, we will add these in the future if needed for testing.

--- a/compiler/README.md
+++ b/compiler/README.md
@@ -75,8 +75,8 @@ must be defined as JSON in this format:
 ```json
 {
   "integrations": {
-    "Integration Name": {
-      "settingsSlug": "value"
+    "Google Analytics": {
+      "serversideTrackingId": "foobar"
     }
   }
 }

--- a/compiler/compile
+++ b/compiler/compile
@@ -18,6 +18,7 @@ const fileName = path.join(__dirname, 'builds', `analytics-${buildName}.js`)
 program
   .option('-w, --writeKey <writeKey>', 'Segment writeKey to for viewing events in the debugger')
   .option('-p, --port [port]', 'Set a port to serve the local ajs file from', 3000)
+  .option('-s, --settings <settings>', 'Relative path to custom integrations settings file')
   .parse(process.argv)
 
 if (!program.writeKey) {
@@ -40,6 +41,14 @@ if (diff.stdout && (diff.stdout).toString().length) {
 
 const writeKey = program.writeKey
 const port = program.port || 3000
+let customSettings
+
+if (program.settings) {
+  const settingsPath = path.join(__dirname, `${program.settings}`)
+  customSettings = JSON.parse(fs.readFileSync(settingsPath))
+} else {
+  console.info('**No custom settings file specified. Retrieving settings from Segment\'s CDN.**')
+}
 
 buildIntegrations()
 build(async (ajs, integrationVersions, coreVersion) => {
@@ -50,7 +59,8 @@ build(async (ajs, integrationVersions, coreVersion) => {
       ajs,
       integrationVersions,
       coreVersion,
-      writeKey
+      writeKey,
+      customSettings
     })
   } catch(err) {
     console.error('Error:', err)

--- a/compiler/scripts/settings.js
+++ b/compiler/scripts/settings.js
@@ -99,13 +99,13 @@ function getSlug(name) {
     .replace(/[^a-z0-9-]/g, '');
 }
 
-async function context(integrationVersions, coreVersion, writeKey) {
-  const settings = await getSourceSettings(writeKey)
+async function context(integrationVersions, coreVersion, writeKey, customSettings) {
+  const settings = customSettings || await getSourceSettings(writeKey);
   const integrations = settings.integrations;
 
   const ctx = {};
-  const availableIntegrations = readIntegrationsPackages()
-  ctx.enabled = await getEnabledIntegrations(settings, availableIntegrations)
+  const availableIntegrations = readIntegrationsPackages();
+  ctx.enabled = await getEnabledIntegrations(settings, availableIntegrations);
   ctx.integrations = pick(integrations, keys(ctx.enabled));
 
   const versions = {
@@ -121,12 +121,12 @@ async function context(integrationVersions, coreVersion, writeKey) {
   return ctx;
 }
 
-module.exports = async function ({ ajs, integrationVersions, coreVersion, writeKey }) {
+module.exports = async function ({ ajs, integrationVersions, coreVersion, writeKey, customSettings }) {
   const { version } = coreVersion
   let ctx
 
   try {
-    ctx = await context(integrationVersions, version, writeKey)
+    ctx = await context(integrationVersions, version, writeKey, customSettings)
   } catch(err) {
     console.error('Error: ', err)
     return

--- a/compiler/src/settings_example.json
+++ b/compiler/src/settings_example.json
@@ -1,7 +1,7 @@
 {
   "integrations": {
-    "Integration Name": {
-      "settingsSlug": "value"
+    "Google Analytics": {
+      "serversideTrackingId": "foobar"
     }
   }
 }

--- a/compiler/src/settings_example.json
+++ b/compiler/src/settings_example.json
@@ -1,0 +1,7 @@
+{
+  "integrations": {
+    "Integration Name": {
+      "settingsSlug": "value"
+    }
+  }
+}


### PR DESCRIPTION
JIRA ticket: https://segment.atlassian.net/browse/DEST-1606

**What does this PR do?**
(1) Adds option to specify integration settings in a json file.
(2) Reformats and adds information to compiler readme.

**Are there breaking changes in this PR?**
- No.

**Any background context you want to provide?**
- n/a

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
- n/a

**Does this require a new integration setting? If so, please explain how the new setting works**
- n/a

**Links to helpful docs and other external resources**
- n/a