### PR TITLE
DWEB-11

### DIFF
--- a/integrations/optimizely/HISTORY.md
+++ b/integrations/optimizely/HISTORY.md
@@ -1,4 +1,9 @@
 
+3.5.0 / 2019-12-28
+==================
+
+  * Added support for setting custom props field mapping via option `customProps`. Its a mapping of key(segment property) and value(optimizely property).
+
 3.4.1 / 2018-04-05
 ==================
 
@@ -21,7 +26,7 @@
 3.3.0 / 2017-04-17
 ==================
 
-  * Adds option `onlySendRevenueOnOrderCompleted` to send revenue only on `Order Completed` events, which will default to `true` for new users  
+  * Adds option `onlySendRevenueOnOrderCompleted` to send revenue only on `Order Completed` events, which will default to `true` for new users
 
 3.2.1 / 2017-03-23
 ==================

--- a/integrations/optimizely/HISTORY.md
+++ b/integrations/optimizely/HISTORY.md
@@ -2,7 +2,7 @@
 3.5.0 / 2019-12-28
 ==================
 
-  * Added support for setting custom props field mapping via option `customProps`. Its a mapping of key(segment property) and value(optimizely property).
+  * Added support for setting custom props field mapping via option `customExperimentProperties` & `customCampaignProperties`. Its a mapping of key(segment property) and value(optimizely property).
 
 3.4.1 / 2018-04-05
 ==================

--- a/integrations/optimizely/lib/index.js
+++ b/integrations/optimizely/lib/index.js
@@ -214,6 +214,8 @@ Optimizely.prototype.sendClassicDataToSegment = function(experimentState) {
       variationName: variationNames.join(', ') // eg. 'Variation X' or 'Variation 1, Variation 2'
     };
 
+    // If customProps is provided overide the props with it.
+    // If valid customProps present it will override existing props.
     var customProps = this.options.customProps;
     var customPropsKeys = Object.keys(customProps);
     var data = window.optimizely && window.optimizely.data;

--- a/integrations/optimizely/lib/index.js
+++ b/integrations/optimizely/lib/index.js
@@ -22,7 +22,8 @@ var Optimizely = (module.exports = integration('Optimizely')
   .option('variations', false) // send data via `.identify()`
   .option('listen', true) // send data via `.track()`
   .option('nonInteraction', false)
-  .option('sendRevenueOnlyForOrderCompleted', true));
+  .option('sendRevenueOnlyForOrderCompleted', true)
+  .option('customProps', {}));
 
 /**
  * The name and version for this integration.
@@ -212,6 +213,20 @@ Optimizely.prototype.sendClassicDataToSegment = function(experimentState) {
       variationId: variationIds.join(), // eg. '123' or '123,455'
       variationName: variationNames.join(', ') // eg. 'Variation X' or 'Variation 1, Variation 2'
     };
+
+    var customProps = this.options.customProps;
+    var customPropsKeys = Object.keys(customProps);
+    var data = window.optimizely && window.optimizely.data;
+
+    if (data && customPropsKeys.length) {
+      for (var index = 0; index < customPropsKeys.length; index++) {
+        var segmentProp = customPropsKeys[index];
+        var optimizelyProp = customProps[segmentProp];
+        if (data[optimizelyProp] !== 'undefined') {
+          props[segmentProp] = data[optimizelyProp];
+        }
+      }
+    }
 
     // If this was a redirect experiment and the effective referrer is different from document.referrer,
     // this value is made available. So if a customer came in via google.com/ad -> tb12.com -> redirect experiment -> Belichickgoat.com

--- a/integrations/optimizely/lib/index.js
+++ b/integrations/optimizely/lib/index.js
@@ -23,7 +23,7 @@ var Optimizely = (module.exports = integration('Optimizely')
   .option('listen', true) // send data via `.track()`
   .option('nonInteraction', false)
   .option('sendRevenueOnlyForOrderCompleted', true)
-  .option('customProps', {}));
+  .option('customExperimentProperties', {}));
 
 /**
  * The name and version for this integration.
@@ -214,17 +214,17 @@ Optimizely.prototype.sendClassicDataToSegment = function(experimentState) {
       variationName: variationNames.join(', ') // eg. 'Variation X' or 'Variation 1, Variation 2'
     };
 
-    // If customProps is provided overide the props with it.
-    // If valid customProps present it will override existing props.
-    var customProps = this.options.customProps;
-    var customPropsKeys = Object.keys(customProps);
+    // If customExperimentProperties is provided overide the props with it.
+    // If valid customExperimentProperties present it will override existing props.
+    var customExperimentProperties = this.options.customExperimentProperties;
+    var customPropsKeys = Object.keys(customExperimentProperties);
     var data = window.optimizely && window.optimizely.data;
 
     if (data && customPropsKeys.length) {
       for (var index = 0; index < customPropsKeys.length; index++) {
         var segmentProp = customPropsKeys[index];
-        var optimizelyProp = customProps[segmentProp];
-        if (data[optimizelyProp] !== 'undefined') {
+        var optimizelyProp = customExperimentProperties[segmentProp];
+        if (typeof data[optimizelyProp] !== 'undefined') {
           props[segmentProp] = data[optimizelyProp];
         }
       }

--- a/integrations/optimizely/lib/index.js
+++ b/integrations/optimizely/lib/index.js
@@ -23,7 +23,8 @@ var Optimizely = (module.exports = integration('Optimizely')
   .option('listen', true) // send data via `.track()`
   .option('nonInteraction', false)
   .option('sendRevenueOnlyForOrderCompleted', true)
-  .option('customExperimentProperties', {}));
+  .option('customExperimentProperties', {})
+  .option('customCampaignProperties', {}));
 
 /**
  * The name and version for this integration.
@@ -369,6 +370,21 @@ Optimizely.prototype.sendNewDataToSegment = function(campaignState) {
 
     // For Google's nonInteraction flag
     if (this.options.nonInteraction) props.nonInteraction = 1;
+
+    // If customCampaignProperties is provided overide the props with it.
+    // If valid customCampaignProperties present it will override existing props.
+    var customCampaignProperties = this.options.customCampaignProperties;
+    var customPropsKeys = Object.keys(customCampaignProperties);
+    var data = window.optimizely && window.optimizely.newMockData;
+    if (data && customPropsKeys.length) {
+      for (var index = 0; index < customPropsKeys.length; index++) {
+        var segmentProp = customPropsKeys[index];
+        var optimizelyProp = customCampaignProperties[segmentProp];
+        if (typeof data[optimizelyProp] !== 'undefined') {
+          props[segmentProp] = data[optimizelyProp];
+        }
+      }
+    }
 
     // Send to Segment
     this.analytics.track('Experiment Viewed', props, context);

--- a/integrations/optimizely/lib/index.js
+++ b/integrations/optimizely/lib/index.js
@@ -214,22 +214,6 @@ Optimizely.prototype.sendClassicDataToSegment = function(experimentState) {
       variationName: variationNames.join(', ') // eg. 'Variation X' or 'Variation 1, Variation 2'
     };
 
-    // If customExperimentProperties is provided overide the props with it.
-    // If valid customExperimentProperties present it will override existing props.
-    var customExperimentProperties = this.options.customExperimentProperties;
-    var customPropsKeys = Object.keys(customExperimentProperties);
-    var data = window.optimizely && window.optimizely.data;
-
-    if (data && customPropsKeys.length) {
-      for (var index = 0; index < customPropsKeys.length; index++) {
-        var segmentProp = customPropsKeys[index];
-        var optimizelyProp = customExperimentProperties[segmentProp];
-        if (typeof data[optimizelyProp] !== 'undefined') {
-          props[segmentProp] = data[optimizelyProp];
-        }
-      }
-    }
-
     // If this was a redirect experiment and the effective referrer is different from document.referrer,
     // this value is made available. So if a customer came in via google.com/ad -> tb12.com -> redirect experiment -> Belichickgoat.com
     // `experiment.referrer` would be google.com/ad here NOT `tb12.com`.
@@ -274,6 +258,22 @@ Optimizely.prototype.sendClassicDataToSegment = function(experimentState) {
 
     // For Google's nonInteraction flag
     if (this.options.nonInteraction) props.nonInteraction = 1;
+
+    // If customExperimentProperties is provided overide the props with it.
+    // If valid customExperimentProperties present it will override existing props.
+    var customExperimentProperties = this.options.customExperimentProperties;
+    var customPropsKeys = Object.keys(customExperimentProperties);
+    var data = window.optimizely && window.optimizely.data;
+
+    if (data && customPropsKeys.length) {
+      for (var index = 0; index < customPropsKeys.length; index++) {
+        var segmentProp = customPropsKeys[index];
+        var optimizelyProp = customExperimentProperties[segmentProp];
+        if (typeof data[optimizelyProp] !== 'undefined') {
+          props[segmentProp] = data[optimizelyProp];
+        }
+      }
+    }
 
     // Send to Segment
     this.analytics.track('Experiment Viewed', props, context);

--- a/integrations/optimizely/package.json
+++ b/integrations/optimizely/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-optimizely",
   "description": "The Optimizely analytics.js integration.",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/optimizely/test/index.test.js
+++ b/integrations/optimizely/test/index.test.js
@@ -177,7 +177,8 @@ describe('Optimizely', function() {
     listen: false,
     variations: false,
     nonInteraction: false,
-    customExperimentProperties: {}
+    customExperimentProperties: {},
+    customCampaignProperties: {}
   };
 
   beforeEach(function() {
@@ -632,7 +633,7 @@ describe('Optimizely', function() {
         });
       });
 
-      it('should map existing properties if custom properties not specified`', function(done) {
+      it('should not map existing properties if custom properties not specified`', function(done) {
         optimizely.options.customExperimentProperties = {
           variationId: 'variation_id',
           variationName: 'variation_name'
@@ -906,6 +907,74 @@ describe('Optimizely', function() {
             {
               campaignName: 'URF',
               campaignId: '7547101713',
+              experimentId: '7547682694',
+              experimentName: 'Worlds Group Stage',
+              variationId: '7557950020',
+              variationName: 'Variation #1',
+              audienceId: '7527565438',
+              audienceName: 'Trust Tree',
+              isInCampaignHoldback: true
+            },
+            { integration: optimizelyContext }
+          ]);
+        });
+      });
+
+      it('should map custom properties and send campaign data via `.track()`', function(done) {
+        optimizely.options.customCampaignProperties = {
+          campaignName: 'campaign_name',
+          campaignId: 'campaign_id',
+          experimentId: 'experiment_id',
+          experimentName: 'experiment_name'
+        };
+
+        window.optimizely.newMockData.experiment_id = '124';
+        window.optimizely.newMockData.experiment_name =
+          'custom experiment name';
+        window.optimizely.newMockData.campaign_id = '421';
+        window.optimizely.newMockData.campaign_name = 'custom campaign name';
+
+        window.optimizely.newMockData[2542102702].isActive = false;
+        analytics.initialize();
+        executeAsyncTest(done, function() {
+          analytics.deepEqual(analytics.track.args[0], [
+            'Experiment Viewed',
+            {
+              campaignName: 'custom campaign name',
+              campaignId: '421',
+              experimentId: '124',
+              experimentName: 'custom experiment name',
+              variationId: '7557950020',
+              variationName: 'Variation #1',
+              audienceId: '7527565438',
+              audienceName: 'Trust Tree',
+              isInCampaignHoldback: true
+            },
+            { integration: optimizelyContext }
+          ]);
+        });
+      });
+
+      it('should not map existing properties if custom properties not specified`', function(done) {
+        optimizely.options.customCampaignProperties = {
+          campaignName: 'campaign_name',
+          campaignId: 'campaign_id'
+        };
+
+        window.optimizely.newMockData.experiment_id = '124';
+        window.optimizely.newMockData.experiment_name =
+          'custom experiment name';
+        window.optimizely.newMockData.campaign_id = '421';
+        window.optimizely.newMockData.campaign_name = 'custom campaign name';
+
+        window.optimizely.newMockData[2542102702].isActive = false;
+        analytics.initialize();
+        executeAsyncTest(done, function() {
+          analytics.deepEqual(analytics.track.args[0], [
+            'Experiment Viewed',
+            {
+              campaignName: 'custom campaign name',
+              campaignId: '421',
               experimentId: '7547682694',
               experimentName: 'Worlds Group Stage',
               variationId: '7557950020',

--- a/integrations/optimizely/test/index.test.js
+++ b/integrations/optimizely/test/index.test.js
@@ -177,7 +177,7 @@ describe('Optimizely', function() {
     listen: false,
     variations: false,
     nonInteraction: false,
-    customProps: {}
+    customExperimentProperties: {}
   };
 
   beforeEach(function() {
@@ -604,7 +604,7 @@ describe('Optimizely', function() {
       });
 
       it('should map custom properties and send each standard active experiment data via `.track()`', function(done) {
-        optimizely.options.customProps = {
+        optimizely.options.customExperimentProperties = {
           experimentId: 'experiment_id',
           experimentName: 'experiment_name',
           variationId: 'variation_id',
@@ -633,7 +633,7 @@ describe('Optimizely', function() {
       });
 
       it('should map existing properties if custom properties not specified`', function(done) {
-        optimizely.options.customProps = {
+        optimizely.options.customExperimentProperties = {
           variationId: 'variation_id',
           variationName: 'variation_name'
         };

--- a/integrations/optimizely/test/index.test.js
+++ b/integrations/optimizely/test/index.test.js
@@ -176,7 +176,8 @@ describe('Optimizely', function() {
   var options = {
     listen: false,
     variations: false,
-    nonInteraction: false
+    nonInteraction: false,
+    customProps: {}
   };
 
   beforeEach(function() {
@@ -596,6 +597,62 @@ describe('Optimizely', function() {
               experimentName: 'Test',
               variationId: '123',
               variationName: 'Variation #123'
+            },
+            { integration: optimizelyContext }
+          ]);
+        });
+      });
+
+      it('should map custom properties and send each standard active experiment data via `.track()`', function(done) {
+        optimizely.options.customProps = {
+          experimentId: 'experiment_id',
+          experimentName: 'experiment_name',
+          variationId: 'variation_id',
+          variationName: 'variation_name'
+        };
+
+        window.optimizely.data.experiment_id = '124';
+        window.optimizely.data.experiment_name = 'custom experiment name';
+        window.optimizely.data.variation_id = '421';
+        window.optimizely.data.variation_name = 'custom variation name';
+
+        window.optimizely.data.state.activeExperiments = ['0'];
+        analytics.initialize();
+        executeAsyncTest(done, function() {
+          analytics.deepEqual(analytics.track.args[0], [
+            'Experiment Viewed',
+            {
+              experimentId: '124',
+              experimentName: 'custom experiment name',
+              variationId: '421',
+              variationName: 'custom variation name'
+            },
+            { integration: optimizelyContext }
+          ]);
+        });
+      });
+
+      it('should map existing properties if custom properties not specified`', function(done) {
+        optimizely.options.customProps = {
+          variationId: 'variation_id',
+          variationName: 'variation_name'
+        };
+
+        window.optimizely.data.experiment_id = '124';
+        window.optimizely.data.experiment_name = 'custom experiment name';
+        window.optimizely.data.variation_id = '421';
+        window.optimizely.data.variation_name = 'custom variation name';
+
+        window.optimizely.data.state.activeExperiments = ['0'];
+        analytics.initialize();
+        executeAsyncTest(done, function() {
+          analytics.deepEqual(analytics.track.args[0], [
+            'Experiment Viewed',
+            {
+              experimentId: '0',
+              experimentName: 'Test',
+              variationId: '421',
+              variationName: 'custom variation name'
             },
             { integration: optimizelyContext }
           ]);


### PR DESCRIPTION
**What does this PR do?**
Added support for setting custom props field mapping via option **customExperimentProperties** OR **customCampaignProperties**. Its a mapping of key(segment property) and value(optimizely property).

**Are there breaking changes in this PR?**
If **customExperimentProperties** OR **customCampaignProperties** are specified it will override the existing props.

**Any background context you want to provide?**
NA

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
NA

**Does this require a new integration setting? If so, please explain how the new setting works**
Yes, **customExperimentProperties** OR **customCampaignProperties** is the set of key/value pairs where **key**(segment property) and **value**(optimizely property).

**Links to helpful docs and other external resources**
NA