### PR TITLE
[Nielsen DTVR] Bumps Nielsen DTVR to 0.0.4.

### DIFF
--- a/integrations/nielsen-dtvr/package.json
+++ b/integrations/nielsen-dtvr/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-nielsen-dtvr",
   "description": "The Nielsen DTVR analytics.js integration.",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",


### PR DESCRIPTION
Note changes to DTVR were already merged to master in this PR: https://github.com/segmentio/analytics.js-integrations/pull/387/files

In that PR, I mistakenly bumped the version of DCR to 1.3.5 rather than the version of DTVR to 0.0.4 (as we're doing in this PR). Rather than revert the previous commit, I think we should just roll forward given that Version 1.3.5 of Nielsen DCR has already been auto-released. Version 1.3.4 and 1.3.5 of Nielsen DCR will be identical. 

Version 0.0.4 of Nielsen DTVR will include the changes made to how we handle unix timestamps made in PR 387.

Let me know if you're ok with this @CarlosMecha. My bad!