### PR TITLE
[LIB-1546] populate locale in segmentio integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,10 +45,17 @@ jobs:
               exit 2
             fi
 
+
             mkdir -p /home/circleci/project
             cd /home/circleci/project
             git clone "$CIRCLE_REPOSITORY_URL" .
-            git checkout $CIRCLE_BRANCH
+
+            if [ -n "$CIRCLE_BRANCH" ]
+            then
+              git reset --hard "$CIRCLE_SHA1"
+              git checkout -q -B "$CIRCLE_BRANCH"
+            fi
+
             git reset --hard "$CIRCLE_SHA1"
       - run:
           name: Determine which projects have changed and trigger the builds

--- a/integrations/segmentio/lib/index.js
+++ b/integrations/segmentio/lib/index.js
@@ -283,8 +283,8 @@ Segment.prototype.normalize = function(message) {
   delete msg.options;
   msg.writeKey = this.options.apiKey;
   ctx.userAgent = navigator.userAgent;
-  const locale = navigator.userLanguage || navigator.language
-  if (locale != undefined) {
+  var locale = navigator.userLanguage || navigator.language
+  if (!ctx.locale && locale != undefined) {
     ctx.locale = locale
   }
   if (!ctx.library)

--- a/integrations/segmentio/lib/index.js
+++ b/integrations/segmentio/lib/index.js
@@ -283,9 +283,9 @@ Segment.prototype.normalize = function(message) {
   delete msg.options;
   msg.writeKey = this.options.apiKey;
   ctx.userAgent = navigator.userAgent;
-  var locale = navigator.userLanguage || navigator.language
-  if (!ctx.locale && locale != undefined) {
-    ctx.locale = locale
+  var locale = navigator.userLanguage || navigator.language;
+  if (!ctx.locale && locale !== undefined) {
+    ctx.locale = locale;
   }
   if (!ctx.library)
     ctx.library = { name: 'analytics.js', version: this.analytics.VERSION };

--- a/integrations/segmentio/lib/index.js
+++ b/integrations/segmentio/lib/index.js
@@ -283,6 +283,10 @@ Segment.prototype.normalize = function(message) {
   delete msg.options;
   msg.writeKey = this.options.apiKey;
   ctx.userAgent = navigator.userAgent;
+  const locale = navigator.userLanguage || navigator.language
+  if (locale != undefined) {
+    ctx.locale = locale
+  }
   if (!ctx.library)
     ctx.library = { name: 'analytics.js', version: this.analytics.VERSION };
   if (this.isCrossDomainAnalyticsEnabled()) {

--- a/integrations/segmentio/lib/index.js
+++ b/integrations/segmentio/lib/index.js
@@ -284,7 +284,7 @@ Segment.prototype.normalize = function(message) {
   msg.writeKey = this.options.apiKey;
   ctx.userAgent = navigator.userAgent;
   var locale = navigator.userLanguage || navigator.language;
-  if (!ctx.locale && locale !== undefined) {
+  if (typeof ctx.locale === 'undefined' && typeof locale !== 'undefined') {
     ctx.locale = locale;
   }
   if (!ctx.library)

--- a/integrations/segmentio/package.json
+++ b/integrations/segmentio/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-segmentio",
   "description": "The Segmentio analytics.js integration.",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/segmentio/test/index.test.js
+++ b/integrations/segmentio/test/index.test.js
@@ -210,6 +210,11 @@ describe('Segment.io', function() {
         analytics.assert(object.context.userAgent === navigator.userAgent);
       });
 
+      it('should add .locale', function() {
+        segment.normalize(object);
+        analytics.assert(object.context.locale === navigator.language);
+      });
+
       it('should add .campaign', function() {
         Segment.global = { navigator: {}, location: {} };
         Segment.global.location.search =

--- a/integrations/segmentio/test/index.test.js
+++ b/integrations/segmentio/test/index.test.js
@@ -215,6 +215,15 @@ describe('Segment.io', function() {
         analytics.assert(object.context.locale === navigator.language);
       });
 
+      it('should not replace .locale if provided', function() {
+        var ctx = {
+          locale: 'foobar'
+        };
+        var object = { context: ctx };
+        segment.normalize(object);
+        analytics.assert(object.context.locale === 'foobar');
+      });
+
       it('should add .campaign', function() {
         Segment.global = { navigator: {}, location: {} };
         Segment.global.location.search =


### PR DESCRIPTION
**What does this PR do?**

This PR populates "locale" in the context with the language of the web browser.

**Are there breaking changes in this PR?**

No

**Any background context you want to provide?**

This is for https://segment.atlassian.net/browse/LIB-1546

**Is there parity with the server-side/android/iOS integration components (if applicable)?**


**Does this require a new integration setting? If so, please explain how the new setting works**


**Links to helpful docs and other external resources**
