### PR TITLE
[DEST-1600][CC-5888] add support for EU endpoint

### DIFF
--- a/integrations/mixpanel/lib/index.js
+++ b/integrations/mixpanel/lib/index.js
@@ -39,6 +39,7 @@ var Mixpanel = (module.exports = integration('Mixpanel')
   .option('trackCategorizedPages', false)
   .option('groupIdentifierTraits', [])
   .option('sourceName', '')
+  .option('enableEuropeanUnionEndpoint', false)
   .tag('<script src="//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js">'));
 
 /**
@@ -69,6 +70,10 @@ for(h=0;h<k.length;h++)e(d,k[h]);a._i.push([b,c,f])};a.__SV=1.2;}})(document,win
   this.options.eventIncrements = lowercase(this.options.eventIncrements);
   this.options.propIncrements = lowercase(this.options.propIncrements);
   var options = alias(this.options, optionsAliases);
+  if (this.options.enableEuropeanUnionEndpoint) {
+    // https://developer.mixpanel.com/docs/implement-mixpanel#section-implementing-mixpanel-in-the-european-union-eu
+    options.api_host = 'api-eu.mixpanel.com';
+  }
   // tag ajs requests with Segment by request from Mixpanel team for better mutual debugging
   options.loaded = function(mixpanel) {
     mixpanel.register({ mp_lib: 'Segment: web' });

--- a/integrations/mixpanel/lib/index.js
+++ b/integrations/mixpanel/lib/index.js
@@ -72,7 +72,7 @@ for(h=0;h<k.length;h++)e(d,k[h]);a._i.push([b,c,f])};a.__SV=1.2;}})(document,win
   var options = alias(this.options, optionsAliases);
   if (this.options.enableEuropeanUnionEndpoint) {
     // https://developer.mixpanel.com/docs/implement-mixpanel#section-implementing-mixpanel-in-the-european-union-eu
-    options.api_host = 'api-eu.mixpanel.com';
+    options.api_host = 'https://api-eu.mixpanel.com';
   }
   // tag ajs requests with Segment by request from Mixpanel team for better mutual debugging
   options.loaded = function(mixpanel) {

--- a/integrations/mixpanel/package.json
+++ b/integrations/mixpanel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-mixpanel",
   "description": "The Mixpanel analytics.js integration.",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/mixpanel/test/index.test.js
+++ b/integrations/mixpanel/test/index.test.js
@@ -18,7 +18,8 @@ describe('Mixpanel', function() {
     consolidatedPageCalls: false,
     trackCategorizedPages: true,
     trackNamedPages: true,
-    groupIdentifierTraits: []
+    groupIdentifierTraits: [],
+    enableEuropeanUnionEndpoint: false
   };
 
   beforeEach(function() {
@@ -56,6 +57,7 @@ describe('Mixpanel', function() {
         .option('trackCategorizedPages', false)
         .option('groupIdentifierTraits', [])
         .option('sourceName', '')
+        .option('enableEuropeanUnionEndpoint', false)
     );
   });
 


### PR DESCRIPTION
Adds an option to send the events to Mixpanel's European datacenter.

- [DEST-1600](https://segment.atlassian.net/browse/DEST-1600)
- [CC-5888](https://segment.atlassian.net/browse/CC-5888)