### PR TITLE
[DEST-1482] Bump Sentry to version 5.12.1

### DIFF
--- a/integrations/sentry/lib/index.js
+++ b/integrations/sentry/lib/index.js
@@ -14,6 +14,7 @@ var foldl = require('@ndhoule/foldl');
 var Sentry = (module.exports = integration('Sentry')
   .global('Sentry')
   .option('config', '')
+  .option('environment', null)
   .option('serverName', null)
   .option('release', null)
   .option('ignoreErrors', []) // deprecated
@@ -23,7 +24,6 @@ var Sentry = (module.exports = integration('Sentry')
   .option('maxMessageLength', null) // deprecated
   .option('logger', null)
   .option('customVersionProperty', null)
-  .option('level', '')
   .option('debug', false)
   .tag(
     '<script src="https://browser.sentry-cdn.com/5.11.0/bundle.min.js" integrity="sha384-jbFinqIbKkHNg+QL+yxB4VrBC0EAPTuaLGeRT0T+NfEV89YC6u1bKxHLwoo+/xxY" crossorigin="anonymous"></script>'
@@ -31,9 +31,8 @@ var Sentry = (module.exports = integration('Sentry')
 
 /**
  * Initialize.
+ * https://docs.sentry.io/error-reporting/quickstart/?platform=browser
  *
- * https://docs.sentry.io/clients/javascript/config/
- * https://github.com/getsentry/raven-js/blob/3.12.1/src/raven.js#L646-L649
  * @api public
  */
 
@@ -44,7 +43,7 @@ Sentry.prototype.initialize = function() {
 
   var options = {
     dsn: this.options.config,
-    environment: this.options.logger,
+    environment: this.options.environment,
     release: customRelease || this.options.release,
     serverName: this.options.serverName,
     whitelistUrls: this.options.whitelistUrls,
@@ -52,10 +51,15 @@ Sentry.prototype.initialize = function() {
     debug: this.options.debug
   };
 
+  var logger = this.options.logger;
   var self = this;
   this.load(function() {
     window.Sentry.onLoad(function() {
       window.Sentry.init(reject(options));
+
+      if (logger) {
+        window.Sentry.setTag('logger', logger);
+      }
     });
 
     self.ready();

--- a/integrations/sentry/lib/index.js
+++ b/integrations/sentry/lib/index.js
@@ -17,7 +17,7 @@ var Sentry = (module.exports = integration('Sentry')
   .option('environment', null)
   .option('serverName', null)
   .option('release', null)
-  .option('ignoreErrors', []) // deprecated
+  .option('ignoreErrors', []) // still exists, but not documented on Sentry's website
   .option('ignoreUrls', [])
   .option('whitelistUrls', [])
   .option('includePaths', []) // deprecated
@@ -48,6 +48,9 @@ Sentry.prototype.initialize = function() {
     serverName: this.options.serverName,
     whitelistUrls: this.options.whitelistUrls,
     blacklistUrls: this.options.ignoreUrls,
+    // ignoreErrors still exists, but is not documented on Sentry's website
+    // https://github.com/getsentry/sentry-javascript/blob/master/packages/core/src/integrations/inboundfilters.ts#L12
+    ignoreErrors: this.options.ignoreErrors,
     debug: this.options.debug
   };
 

--- a/integrations/sentry/lib/index.js
+++ b/integrations/sentry/lib/index.js
@@ -63,7 +63,18 @@ Sentry.prototype.initialize = function() {
   };
 
   var logger = this.options.logger;
-  var includePaths = this.options.includePaths;
+  var includePaths = [];
+  if (this.options.includePaths.length > 0) {
+    includePaths = this.options.includePaths.map(function(path) {
+      var regex;
+      try {
+        regex = new RegExp(path);
+      } catch (e) {
+        // do nothing
+      }
+      return regex;
+    });
+  }
 
   var self = this;
   this.load('sentry', function() {
@@ -77,7 +88,7 @@ Sentry.prototype.initialize = function() {
             iteratee: function(frame) {
               for (var i = 0; i < includePaths.length; i++) {
                 try {
-                  if (frame.filename.match(new RegExp(includePaths[i]))) {
+                  if (frame.filename.match(includePaths[i])) {
                     frame.in_app = true; // eslint-disable-line
                     return frame;
                   }

--- a/integrations/sentry/lib/index.js
+++ b/integrations/sentry/lib/index.js
@@ -12,7 +12,7 @@ var foldl = require('@ndhoule/foldl');
  */
 
 var Sentry = (module.exports = integration('Sentry')
-  .global('Sentry') // do we need a global here?
+  .global('Sentry')
   .option('config', '')
   .option('serverName', null)
   .option('release', null)
@@ -26,7 +26,7 @@ var Sentry = (module.exports = integration('Sentry')
   .option('level', '')
   .option('debug', false)
   .tag(
-    '<script src="https://browser.sentry-cdn.com/5.7.1/bundle.min.js" integrity="sha384-KMv6bBTABABhv0NI+rVWly6PIRvdippFEgjpKyxUcpEmDWZTkDOiueL5xW+cztZZ" crossorigin="anonymous"></script>'
+    '<script src="https://browser.sentry-cdn.com/5.11.0/bundle.min.js" integrity="sha384-jbFinqIbKkHNg+QL+yxB4VrBC0EAPTuaLGeRT0T+NfEV89YC6u1bKxHLwoo+/xxY" crossorigin="anonymous"></script>'
   ));
 
 /**
@@ -52,15 +52,14 @@ Sentry.prototype.initialize = function() {
     debug: this.options.debug
   };
 
-  var level = this.options.level;
-  if (level) {
-    window.Sentry.configureScope(function(scope) {
-      scope.setLevel(level);
+  var self = this;
+  this.load(function() {
+    window.Sentry.onLoad(function() {
+      window.Sentry.init(reject(options));
     });
-  }
 
-  window.Sentry.init(reject(options));
-  this.load(this.ready);
+    self.ready();
+  });
 };
 
 /**
@@ -82,9 +81,7 @@ Sentry.prototype.loaded = function() {
  */
 
 Sentry.prototype.identify = function(identify) {
-  window.Sentry.configureScope(function(scope) {
-    scope.setUser(identify.traits());
-  });
+  window.Sentry.setUser(identify.traits());
 };
 
 /**

--- a/integrations/sentry/package.json
+++ b/integrations/sentry/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-sentry",
   "description": "The Sentry analytics.js integration.",
-  "version": "2.6.2",
+  "version": "3.0.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/sentry/test/index.test.js
+++ b/integrations/sentry/test/index.test.js
@@ -15,7 +15,7 @@ var Sentry = require('../lib/');
  * customVersionProperty || release - release
  * ignoreErrors - ignoreErrors (this setting still exists, but for some reason is not included in Sentry's documentation)
  * ignoreUrls - blacklistUrls
- * ignorePaths - // now maps to Sentry.Integrations.RewriteFrames plugin
+ * ignorePaths - now maps to Sentry.Integrations.RewriteFrames plugin
  * logger - logger (type `tag`, NOT actual config option)
  * customVersionProperty - release
  *

--- a/integrations/sentry/test/index.test.js
+++ b/integrations/sentry/test/index.test.js
@@ -31,6 +31,7 @@ describe('Sentry', function() {
     release: '721e41770371db95eee98ca2707686226b993eda',
     ignoreErrors: ['fb_xd_fragment'],
     ignoreUrls: ['/graph.facebook.com/', 'http://example.com/script2.js'], // Sentry: blacklistUrls
+    includePaths: ['/https?://getsentry.com/', '/https?://cdn.getsentry.com/'], // maps to Sentry.Integrations.RewriteFrames plugin
     whitelistUrls: ['/getsentry.com/', 'segment.com'],
     logger: 'javascript', // Sentry: type `tag`, key "logger" https://docs.sentry.io/enriching-error-data/context/?platform=browser#tagging-events
     customVersionProperty: null, // Sentry: release

--- a/integrations/sentry/test/index.test.js
+++ b/integrations/sentry/test/index.test.js
@@ -6,20 +6,32 @@ var sandbox = require('@segment/clear-env');
 var tester = require('@segment/analytics.js-integration-tester');
 var Sentry = require('../lib/');
 
+/**
+ * Segment settings slugs do not always match the configuration option name
+ * in Senty. Here are the relevant mappings that may cause confusion:
+ * https://docs.sentry.io/error-reporting/configuration/?platform=browser
+ *
+ * Segment setting - Sentry config option
+ * config - dsn
+ * ignoreUrls - blacklistUrls
+ * logger - environment (if release is not specified)
+ * customVersionProperty - release (fallback if `release` is not specified)
+ */
+
 describe('Sentry', function() {
   var sentry;
   var analytics;
   var options = {
-    config: 'https://8152fdb57e8c4ec1b60d27745bda8cbd@app.getsentry.com/52723',
-    logger: 'development',
-    release: '721e41770371db95eee98ca2707686226b993eda',
+    config: 'https://8152fdb57e8c4ec1b60d27745bda8cbd@sentry.io/52723', // Sentry: dsn
     serverName: 'B5372DB0-C21E-11E4-8DFC-AA07A5B093DB',
-    whitelistUrls: ['/getsentry.com/', 'segment.com'],
+    release: '721e41770371db95eee98ca2707686226b993eda',
     ignoreErrors: ['fb_xd_fragment'],
-    ignoreUrls: ['/graph.facebook.com/', 'http://example.com/script2.js'],
-    includePaths: ['/https?://getsentry.com/', '/https?://cdn.getsentry.com/'],
-    maxMessageLength: 50,
-    customVersionProperty: null
+    ignoreUrls: ['/graph.facebook.com/', 'http://example.com/script2.js'], // Sentry: blacklistUrls
+    whitelistUrls: ['/getsentry.com/', 'segment.com'],
+    logger: 'development', // Sentry: environment
+    customVersionProperty: null, // Sentry: release
+    level: 'warning',
+    debug: false
   };
 
   beforeEach(function() {
@@ -41,8 +53,7 @@ describe('Sentry', function() {
     analytics.compare(
       Sentry,
       integration('Sentry')
-        .global('Raven')
-        .global('RavenConfig')
+        .global('Sentry')
         .option('config', '')
         .option('serverName', null)
         .option('release', null)
@@ -53,6 +64,8 @@ describe('Sentry', function() {
         .option('maxMessageLength', null)
         .option('logger', null)
         .option('customVersionProperty', null)
+        .option('level')
+        .option('debug', false)
     );
   });
 
@@ -69,20 +82,18 @@ describe('Sentry', function() {
       });
 
       it('should respect UI settings', function() {
-        // https://github.com/getsentry/raven-js/blob/3.0.2/src/raven.js#L135-L138
         var config = {
-          logger: options.logger,
+          dsn: options.config,
+          environment: options.logger,
           release: options.release,
           serverName: options.serverName,
           whitelistUrls: options.whitelistUrls,
-          ignoreErrors: options.ignoreErrors,
-          ignoreUrls: options.ignoreUrls,
-          includePaths: options.includePaths,
-          maxMessageLength: options.maxMessageLength
+          blacklistUrls: options.ignoreUrls,
+          debug: options.debug
         };
         analytics.initialize();
-        analytics.assert(window.RavenConfig.dsn === options.config);
-        analytics.assert.deepEqual(window.RavenConfig.config, config);
+        analytics.assert(window.SentryConfig.dsn === options.config);
+        analytics.assert.deepEqual(window.SentryConfig.config, config);
       });
 
       it('should allow and set custom versions', function() {
@@ -104,40 +115,40 @@ describe('Sentry', function() {
         // Need to delete before asserts to prevent leaking effects in case of failure.
         delete window.my_custom_version_property;
 
-        analytics.assert(window.RavenConfig.dsn === options.config);
-        analytics.assert.deepEqual(window.RavenConfig.config, config);
+        analytics.assert(window.SentryConfig.dsn === options.config);
+        analytics.assert.deepEqual(window.SentryConfig.config, config);
       });
 
       it('should reject null settings', function() {
         sentry.options.release = null;
         analytics.initialize();
-        analytics.assert(!window.RavenConfig.config.release);
+        analytics.assert(!window.SentryConfig.config.release);
       });
 
       it('should reject empty strings', function() {
         sentry.options.release = '';
         analytics.initialize();
-        analytics.assert(!window.RavenConfig.config.release);
+        analytics.assert(!window.SentryConfig.config.release);
       });
 
       it('should reject empty array settings', function() {
         sentry.options.ignoreUrls = [];
         analytics.initialize();
-        analytics.assert(!window.RavenConfig.config.ignoreUrls);
+        analytics.assert(!window.SentryConfig.config.ignoreUrls);
       });
 
       it('should reject arrays that have empty strings', function() {
         sentry.options.ignoreUrls = [''];
         analytics.initialize();
-        analytics.assert(!window.RavenConfig.config.ignoreUrls);
+        analytics.assert(!window.SentryConfig.config.ignoreUrls);
       });
 
       it('should clean arrays', function() {
         sentry.options.ignoreUrls = ['', 'foo'];
         sentry.options.includePaths = ['', ''];
         analytics.initialize();
-        analytics.assert(window.RavenConfig.config.ignoreUrls[0] === 'foo');
-        analytics.assert(!window.RavenConfig.config.includePaths);
+        analytics.assert(window.SentryConfig.config.ignoreUrls[0] === 'foo');
+        analytics.assert(!window.SentryConfig.config.includePaths);
       });
     });
   });
@@ -157,22 +168,22 @@ describe('Sentry', function() {
 
     describe('#identify', function() {
       beforeEach(function() {
-        analytics.stub(window.Raven, 'setUserContext');
+        analytics.stub(window.Sentry, 'setUser');
       });
 
       it('should send an id', function() {
         analytics.identify('id');
-        analytics.called(window.Raven.setUserContext, { id: 'id' });
+        analytics.called(window.Sentry.setUser, { id: 'id' });
       });
 
       it('should send traits', function() {
         analytics.identify({ trait: true });
-        analytics.called(window.Raven.setUserContext, { trait: true });
+        analytics.called(window.Sentry.setUser, { trait: true });
       });
 
       it('should send an id and traits', function() {
         analytics.identify('id', { trait: true });
-        analytics.called(window.Raven.setUserContext, {
+        analytics.called(window.Sentry.setUser, {
           id: 'id',
           trait: true
         });

--- a/integrations/sentry/test/index.test.js
+++ b/integrations/sentry/test/index.test.js
@@ -13,22 +13,24 @@ var Sentry = require('../lib/');
  *
  * Segment setting - Sentry config option
  * config - dsn
+ * customVersionProperty || release - release
  * ignoreUrls - blacklistUrls
- * logger - environment (if release is not specified)
- * customVersionProperty - release (fallback if `release` is not specified)
+ * logger - logger (type `tag`, NOT actual config option)
+ * customVersionProperty - release
  */
 
 describe('Sentry', function() {
   var sentry;
   var analytics;
   var options = {
-    config: 'https://8152fdb57e8c4ec1b60d27745bda8cbd@sentry.io/52723', // Sentry: dsn
+    config: 'https://ee3da278a59448c9866f7099b81249ac@sentry.io/1883422', // Sentry: dsn
+    environment: 'development',
     serverName: 'B5372DB0-C21E-11E4-8DFC-AA07A5B093DB',
     release: '721e41770371db95eee98ca2707686226b993eda',
     ignoreErrors: ['fb_xd_fragment'],
     ignoreUrls: ['/graph.facebook.com/', 'http://example.com/script2.js'], // Sentry: blacklistUrls
     whitelistUrls: ['/getsentry.com/', 'segment.com'],
-    logger: 'development', // Sentry: environment
+    logger: 'javascript', // Sentry: type `tag`, key "logger"
     customVersionProperty: null, // Sentry: release
     debug: false
   };
@@ -54,6 +56,7 @@ describe('Sentry', function() {
       integration('Sentry')
         .global('Sentry')
         .option('config', '')
+        .option('environment', null)
         .option('serverName', null)
         .option('release', null)
         .option('ignoreErrors', [])
@@ -99,7 +102,7 @@ describe('Sentry', function() {
 
       try {
         // eslint-disable-next-line no-undef
-        aFunctionThatMightFail();
+        myUndefinedFunction();
       } catch (err) {
         window.Sentry.captureException(err);
       }

--- a/integrations/sentry/test/index.test.js
+++ b/integrations/sentry/test/index.test.js
@@ -15,6 +15,7 @@ var Sentry = require('../lib/');
  * customVersionProperty || release - release
  * ignoreErrors - ignoreErrors (this setting still exists, but for some reason is not included in Sentry's documentation)
  * ignoreUrls - blacklistUrls
+ * ignorePaths - // now maps to Sentry.Integrations.RewriteFrames plugin
  * logger - logger (type `tag`, NOT actual config option)
  * customVersionProperty - release
  *

--- a/integrations/sentry/test/index.test.js
+++ b/integrations/sentry/test/index.test.js
@@ -13,6 +13,7 @@ var Sentry = require('../lib/');
  * Segment setting - Sentry config option
  * config - dsn
  * customVersionProperty || release - release
+ * ignoreErrors - ignoreErrors (this setting still exists, but for some reason is not included in Sentry's documentation)
  * ignoreUrls - blacklistUrls
  * logger - logger (type `tag`, NOT actual config option)
  * customVersionProperty - release
@@ -109,6 +110,8 @@ describe('Sentry', function() {
       }
       analytics.called(window.Sentry.captureException);
     });
+
+    it('should ignore errors defined in settings', function() {});
 
     describe('#identify', function() {
       beforeEach(function() {

--- a/integrations/sentry/test/index.test.js
+++ b/integrations/sentry/test/index.test.js
@@ -8,8 +8,7 @@ var Sentry = require('../lib/');
 
 /**
  * Segment settings slugs do not always match the configuration option name
- * in Senty. Here are the relevant mappings that may cause confusion:
- * https://docs.sentry.io/error-reporting/configuration/?platform=browser
+ * in Sentry. Below are the relevant mappings that may cause confusion.
  *
  * Segment setting - Sentry config option
  * config - dsn
@@ -17,6 +16,8 @@ var Sentry = require('../lib/');
  * ignoreUrls - blacklistUrls
  * logger - logger (type `tag`, NOT actual config option)
  * customVersionProperty - release
+ *
+ * Sentry configuration docs: https://docs.sentry.io/error-reporting/configuration/?platform=browser
  */
 
 describe('Sentry', function() {
@@ -30,7 +31,7 @@ describe('Sentry', function() {
     ignoreErrors: ['fb_xd_fragment'],
     ignoreUrls: ['/graph.facebook.com/', 'http://example.com/script2.js'], // Sentry: blacklistUrls
     whitelistUrls: ['/getsentry.com/', 'segment.com'],
-    logger: 'javascript', // Sentry: type `tag`, key "logger"
+    logger: 'javascript', // Sentry: type `tag`, key "logger" https://docs.sentry.io/enriching-error-data/context/?platform=browser#tagging-events
     customVersionProperty: null, // Sentry: release
     debug: false
   };
@@ -97,7 +98,7 @@ describe('Sentry', function() {
       analytics.page();
     });
 
-    it('should capture error event', function() {
+    it('should capture error events', function() {
       analytics.stub(window.Sentry, 'captureException');
 
       try {


### PR DESCRIPTION
**What does this PR do?**
This PR does two things:
- Bumps Raven to Sentry v 5.12.1
- Updates settings (deprecates old settings; adds some new ones)

The deprecated settings are:
- maxMessageLength

The new settings are:
- `environment` - String value that adds an "environment" tag to Sentry events
- `debugger` - allows customers to see debug output in their browser console to understand what Sentry is doing under the hood; enabling debug mode means events will not be sent to Sentry, just logged locally

New settings have already been added to Segment's partner portal in production and tested locally. I will unhide these settings once this PR is reviewed, merged, and released.

**Are there breaking changes in this PR?**
- No, the PR itself contains no breaking changes. In addition, this PR is designed so that users do not notice any difference in functionality after the migration from Raven to Sentry 5.12.1.

**Any background context you want to provide?**
Yes, additional potential customer side effects are described here in paper: https://paper.dropbox.com/doc/Migrate-Sentry-destination-to-latest-Sentry-SDK--AshuJuPqjWDKL7H54i96QwMmAg-DVd8BKi52gvNNpxu9HBMH#:uid=017520775066592364534602&h2=Effects-on-customers

Finally, I will update public-facing documentation after this PR is approved, but before we release the changes to all customers.

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
-n/a

**Does this require a new integration setting? If so, please explain how the new setting works**
Yes, see above.

**Links to helpful docs and other external resources**
- n/a