### PR TITLE
[DEST-1646][Nielsen DCR] Fix how we persist content asset id and bump to 1.4.0.

### DIFF
--- a/integrations/nielsen-dcr/lib/index.js
+++ b/integrations/nielsen-dcr/lib/index.js
@@ -322,11 +322,7 @@ NielsenDCR.prototype.videoAdStarted = function(track) {
   // because nielsen ties ad attribution to the content not playback session
   if (type === 'preroll') {
     contentMetadata = this.getContentMetadata(track, 'contentEvent');
-
-    this._client.ggPM(
-      'loadMetadata',
-      this.getContentMetadata(track, 'contentEvent')
-    );
+    this._client.ggPM('loadMetadata', contentMetadata);
   }
 
   var adMetadata = {
@@ -335,7 +331,7 @@ NielsenDCR.prototype.videoAdStarted = function(track) {
   };
 
   this._client.ggPM('loadMetadata', adMetadata);
-  // contentMetadata may be an empty object here, but that's ok
+  // contentMetadata may be an empty object below, but that's ok
   // in this case, the assetId will be passed as `undefined` to the `heartbeat` method, b/c we only
   // need an assetid if a content assetid is set in properties or content.properties
   this.heartbeat(contentMetadata.assetid, position);

--- a/integrations/nielsen-dcr/lib/index.js
+++ b/integrations/nielsen-dcr/lib/index.js
@@ -134,7 +134,7 @@ NielsenDCR.prototype.heartbeat = function(assetId, position, livestream) {
   if (livestream) {
     // for livestream events, we calculate a unix timestamp based on the current time an offset value, which should be passed in properties.position
     this.currentPosition = getOffsetTime(position);
-  } else if (position) {
+  } else if (position >= 0) {
     // this.currentPosition defaults to 0 upon initialization
     this.currentPosition = position;
   }
@@ -310,6 +310,7 @@ NielsenDCR.prototype.videoContentCompleted = function(track) {
 NielsenDCR.prototype.videoAdStarted = function(track) {
   clearInterval(this.heartbeatId);
 
+  var contentMetadata = {};
   var adAssetId = this.options.adAssetIdPropertyName
     ? track.proxy('properties.' + this.options.adAssetIdPropertyName)
     : track.proxy('properties.asset_id');
@@ -320,6 +321,8 @@ NielsenDCR.prototype.videoAdStarted = function(track) {
   // edge case: if pre-roll, you must load the content metadata first
   // because nielsen ties ad attribution to the content not playback session
   if (type === 'preroll') {
+    contentMetadata = this.getContentMetadata(track, 'contentEvent');
+
     this._client.ggPM(
       'loadMetadata',
       this.getContentMetadata(track, 'contentEvent')
@@ -332,7 +335,10 @@ NielsenDCR.prototype.videoAdStarted = function(track) {
   };
 
   this._client.ggPM('loadMetadata', adMetadata);
-  this.heartbeat(adAssetId, position);
+  // contentMetadata may be an empty object here, but that's ok
+  // in this case, the assetId will be passed as `undefined` to the `heartbeat` method, b/c we only
+  // need an assetid if a content assetid is set in properties or content.properties
+  this.heartbeat(contentMetadata.assetid, position);
 };
 
 /**

--- a/integrations/nielsen-dcr/package.json
+++ b/integrations/nielsen-dcr/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-nielsen-dcr",
   "description": "The Nielsen DCR analytics.js integration.",
-  "version": "1.3.5",
+  "version": "1.4.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/nielsen-dcr/test/index.test.js
+++ b/integrations/nielsen-dcr/test/index.test.js
@@ -527,11 +527,7 @@ describe('NielsenDCR', function() {
             assetid: props.asset_id,
             type: 'midroll'
           });
-          analytics.called(
-            nielsenDCR.heartbeat,
-            props.asset_id,
-            props.position
-          );
+          analytics.called(nielsenDCR.heartbeat, undefined, props.position);
         });
 
         it('video ad started with custom asset id', function() {
@@ -542,11 +538,7 @@ describe('NielsenDCR', function() {
             assetid: props.custom_asset_id_prop,
             type: 'midroll'
           });
-          analytics.called(
-            nielsenDCR.heartbeat,
-            props.custom_asset_id_prop,
-            props.position
-          );
+          analytics.called(nielsenDCR.heartbeat, undefined, props.position);
         });
 
         it('video ad started — preroll', function() {
@@ -599,7 +591,7 @@ describe('NielsenDCR', function() {
           ]);
           analytics.called(
             nielsenDCR.heartbeat,
-            props.asset_id,
+            props.content.asset_id,
             props.position
           );
         });
@@ -656,7 +648,7 @@ describe('NielsenDCR', function() {
           ]);
           analytics.called(
             nielsenDCR.heartbeat,
-            props.asset_id,
+            props.content.custom_asset_id_prop,
             props.position
           );
         });
@@ -717,7 +709,7 @@ describe('NielsenDCR', function() {
           ]);
           analytics.called(
             nielsenDCR.heartbeat,
-            props.asset_id,
+            props.content.asset_id,
             props.position
           );
         });


### PR DESCRIPTION
**What does this PR do?**
- This PR removes persistence of a pre-roll adAssetId, which was causing issues with Fox's Nielsen implementation.

**Are there breaking changes in this PR?**
No.

**Any background context you want to provide?**
- Request from Fox/Nielsen.

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
- n/a

**Does this require a new integration setting? If so, please explain how the new setting works**
- n/a

**Links to helpful docs and other external resources**
- n/a