### PR TITLE
[DEST-1645] [Comscore] Push params to existing comscore array on init.

### DIFF
--- a/integrations/comscore/lib/index.js
+++ b/integrations/comscore/lib/index.js
@@ -65,7 +65,12 @@ Comscore.prototype.page = function(page) {
 };
 
 Comscore.prototype._initialize = function() {
-  window._comscore = window._comscore || [this.comScoreParams];
+  window._comscore = window._comscore || [];
+
+  if (Object.keys(this.comScoreParams).length > 0) {
+    window._comscore.push(this.comScoreParams);
+  }
+
   var tagName = useHttps() ? 'https' : 'http';
   this.load(tagName, this.ready);
 };

--- a/integrations/comscore/package.json
+++ b/integrations/comscore/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-comscore",
   "description": "The Comscore analytics.js integration.",
-  "version": "2.0.5",
+  "version": "2.1.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/comscore/package.json
+++ b/integrations/comscore/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-comscore",
   "description": "The Comscore analytics.js integration.",
-  "version": "2.1.0",
+  "version": "2.1.0-beta",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/comscore/test/index.test.js
+++ b/integrations/comscore/test/index.test.js
@@ -58,7 +58,7 @@ describe('comScore', function() {
         analytics.assert(window._comscore instanceof Array);
       });
 
-      it.only('should push values if window._comscore already exists', function() {
+      it('should push values if window._comscore already exists', function() {
         window._comscore = ['test value'];
         analytics.initialize();
         analytics.page('testing', { exampleParam: 'testing' });

--- a/integrations/comscore/test/index.test.js
+++ b/integrations/comscore/test/index.test.js
@@ -57,6 +57,17 @@ describe('comScore', function() {
         analytics.page();
         analytics.assert(window._comscore instanceof Array);
       });
+
+      it.only('should push values if window._comscore already exists', function() {
+        window._comscore = ['test value'];
+        analytics.initialize();
+        analytics.page('testing', { exampleParam: 'testing' });
+        analytics.assert(window._comscore instanceof Array);
+        analytics.assert(window._comscore, [
+          'test value',
+          { c5: 'testing', c1: '2', c2: 'x', comscorekw: 'test' }
+        ]);
+      });
     });
   });
 


### PR DESCRIPTION
https://segment.atlassian.net/browse/DEST-1645

**What does this PR do?**
- This PR updates how Segment initializes the `_comscore` array. Instead of overwriting the contents of the array with Segment values, Segment "pushes" data into the array.

**Are there breaking changes in this PR?**
- Yes, this PR changes default behavior of Comscore. However, it is unlikely the change will negatively impact customers, as this change reflects how Segment and Comscore probably _should_ work together, as it allows customers to push values into Segment by calling native Comscore methods.

**Any background context you want to provide?**
- Request from Fox.

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
- n/a

**Does this require a new integration setting? If so, please explain how the new setting works**
- Possibly? Instead of changing the default behavior, we *could* add a setting that allows customers to either overwrite the `_comscore` array, or push data into the existing `_comscore` array. However, I don't know why anyone would want to do the former intentionally. In addition, adding a setting would add more customer-facing clutter to settings.

**Links to helpful docs and other external resources**
- n/a