### PR TITLE
Allow for custom trackerName for Google Analytics

### DIFF
--- a/integrations/google-analytics/lib/index.js
+++ b/integrations/google-analytics/lib/index.js
@@ -63,6 +63,7 @@ var GA = (exports.Integration = integration('Google Analytics')
   .option('optimize', '')
   .option('nameTracker', false)
   .option('resetCustomDimensionsOnPage', [])
+  .option('trackerName', null)
   .tag('library', '<script src="//www.google-analytics.com/analytics.js">')
   .tag('double click', '<script src="//stats.g.doubleclick.net/dc.js">')
   .tag('http', '<script src="http://www.google-analytics.com/ga.js">')
@@ -131,7 +132,11 @@ GA.prototype.initialize = function() {
   };
 
   // set tracker name to avoid collisions with unnamed third party trackers
-  if (opts.nameTracker) {
+  // trackerName is prioritized so when `nameTracker: true`, the trackerName can still be set
+  if (opts.trackerName) {
+    config.name = opts.trackerName;
+    this._trackerName = opts.trackerName; // tracker name must be prepended to all ga method calls with format [name].[method]
+  } else if (opts.nameTracker) {
     config.name = 'segmentGATracker';
     this._trackerName = 'segmentGATracker.'; // tracker name must be prepended to all ga method calls with format [name].[method]
   } else {

--- a/integrations/google-analytics/test/index.test.js
+++ b/integrations/google-analytics/test/index.test.js
@@ -186,6 +186,63 @@ describe('Google Analytics', function() {
           ]);
         });
 
+        it('should allow for custom tracker name', function() {
+          var expectedOpts = {
+            cookieDomain: 'none',
+            siteSpeedSampleRate: settings.siteSpeedSampleRate,
+            sampleRate: settings.sampleRate,
+            allowLinker: true,
+            name: 'FooTracker',
+            useGoogleAmpClientId: false
+          };
+          ga.options.trackerName = 'FooTracker';
+          analytics.initialize();
+          analytics.page();
+
+          // some workaround for useGoogleAmpClientId as the name passed to GA needed to change to useAmpClientId
+          // but the tests expect the option name to == the parameter passed
+          var expectedOptsOmitAmp = _.omit(expectedOpts, [
+            'useGoogleAmpClientId'
+          ]);
+          var gaOptsOmitAmp = _.omit(window.ga.q[0][2], 'useAmpClientId');
+          window.ga.q[0][2] = gaOptsOmitAmp;
+
+          analytics.deepEqual(toArray(window.ga.q[0]), [
+            'create',
+            settings.trackingId,
+            expectedOptsOmitAmp
+          ]);
+        });
+
+        it('prioritizes trackerName when nameTracker is also set', function() {
+          var expectedOpts = {
+            cookieDomain: 'none',
+            siteSpeedSampleRate: settings.siteSpeedSampleRate,
+            sampleRate: settings.sampleRate,
+            allowLinker: true,
+            name: 'FooTracker',
+            useGoogleAmpClientId: false
+          };
+          ga.options.nameTracker = true;
+          ga.options.trackerName = 'FooTracker';
+          analytics.initialize();
+          analytics.page();
+
+          // some workaround for useGoogleAmpClientId as the name passed to GA needed to change to useAmpClientId
+          // but the tests expect the option name to == the parameter passed
+          var expectedOptsOmitAmp = _.omit(expectedOpts, [
+            'useGoogleAmpClientId'
+          ]);
+          var gaOptsOmitAmp = _.omit(window.ga.q[0][2], 'useAmpClientId');
+          window.ga.q[0][2] = gaOptsOmitAmp;
+
+          analytics.deepEqual(toArray(window.ga.q[0]), [
+            'create',
+            settings.trackingId,
+            expectedOptsOmitAmp
+          ]);
+        });
+
         it('should use AMP Id as the Client Id if the setting is enabled', function() {
           ga.options.useAmpClientId = true;
           var expectedOpts = {


### PR DESCRIPTION
**What does this PR do?**

Allows for users to set a custom tracker name for Google Analytics (other than `segmentGATracker`).

**Are there breaking changes in this PR?**

No.

**Any background context you want to provide?**

We would like to use a different name, and this PR allows us to do so.

**Is there parity with the server-side/android/iOS integration components (if applicable)?**

n/a

**Does this require a new integration setting? If so, please explain how the new setting works**
	
Yes. Users can now set `trackerName: "MyTrackerName"` which will name the tracker in GA.

**Links to helpful docs and other external resources**

https://developers.google.com/analytics/devguides/collection/analyticsjs/creating-trackers#working_with_multiple_trackers
