### PR TITLE
[Hotfix] [Compiler] Add Comscore to package.json.

### DIFF
--- a/compiler/package.json
+++ b/compiler/package.json
@@ -42,6 +42,7 @@
     "@segment/analytics.js-integration-chartbeat": "file:../integrations/chartbeat",
     "@segment/analytics.js-integration-clevertap": "file:../integrations/clevertap",
     "@segment/analytics.js-integration-clicky": "file:../integrations/clicky",
+    "@segment/analytics.js-integration-comscore": "file:../integrations/comscore",
     "@segment/analytics.js-integration-convertro": "file:../integrations/convertro",
     "@segment/analytics.js-integration-crazy-egg": "file:../integrations/crazy-egg",
     "@segment/analytics.js-integration-criteo": "file:../integrations/criteo",


### PR DESCRIPTION
**What does this PR do?**
- This PR adds `comscore` to the compiler tool's package.json to facilitate testing.

**Are there breaking changes in this PR?**
- No.

**Any background context you want to provide?**
- n/a

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
- n/a

**Does this require a new integration setting? If so, please explain how the new setting works**
- n/a

**Links to helpful docs and other external resources**
- n/a