### PR TITLE
webengage - added support for regions and SPAs

### DIFF
--- a/integrations/webengage/HISTORY.md
+++ b/integrations/webengage/HISTORY.md
@@ -1,4 +1,10 @@
 
+2.0.3 / 2020-01-22
+==================
+
+  * Added support for different regions like Global/India
+  * Added support for Single Page Applications 
+
 2.0.2 / 2016-08-18
 ==================
 

--- a/integrations/webengage/lib/index.js
+++ b/integrations/webengage/lib/index.js
@@ -16,6 +16,8 @@ var WebEngage = (module.exports = integration('WebEngage')
   .readyOnInitialize()
   .global('webengage')
   .option('licenseCode', '')
+  .option('region', 'US')
+  .option('isSpa', false)
   .tag(
     'http',
     '<script src="http://cdn.widgets.webengage.com/js/webengage-min-v-6.0.js">'
@@ -23,6 +25,14 @@ var WebEngage = (module.exports = integration('WebEngage')
   .tag(
     'https',
     '<script src="https://ssl.widgets.webengage.com/js/webengage-min-v-6.0.js">'
+  )
+  .tag(
+    'http-in',
+    '<script src="http://widgets.in.webengage.com/js/webengage-min-v-6.0.js">'
+  )
+  .tag(
+    'https-in',
+    '<script src="https://widgets.in.webengage.com/js/webengage-min-v-6.0.js">'
   ));
 
 /**
@@ -35,14 +45,22 @@ var WebEngage = (module.exports = integration('WebEngage')
 WebEngage.prototype.initialize = function() {
   /* eslint-disable */
 
-  !function(e,t,n){function o(e,t){e[t[t.length-1]]=function(){r.__queue.push([t.join("."),arguments])}}var i,s,r=e[n],g=" ",l="init options track screen onReady".split(g),a="feedback survey notification".split(g),c="options render clear abort".split(g),p="Open Close Submit Complete View Click".split(g),u="identify login logout setAttribute".split(g);if(!r||!r.__v){for(e[n]=r={__queue:[],__v:"6.0",user:{}},i=0;i<l.length;i++)o(r,[l[i]]);for(i=0;i<a.length;i++){for(r[a[i]]={},s=0;s<c.length;s++)o(r[a[i]],[a[i],c[s]]);for(s=0;s<p.length;s++)o(r[a[i]],[a[i],"on"+p[s]])}for(i=0;i<u.length;i++)o(r.user,["user",u[i]]);}}(window,document,"webengage");
+  var isSpa = this.options.isSpa ? 1 : 0,
+      name;
+
+  !function(e,t,n){function o(e,t){e[t[t.length-1]]=function(){r.__queue.push([t.join("."),arguments])}}var i,s,r=e[n],g=" ",l="init options track screen onReady".split(g),a="feedback survey notification".split(g),c="options render clear abort".split(g),p="Open Close Submit Complete View Click".split(g),u="identify login logout setAttribute".split(g);if(!r||!r.__v){for(e[n]=r={__queue:[],is_spa:isSpa,__v:"6.0",user:{}},i=0;i<l.length;i++)o(r,[l[i]]);for(i=0;i<a.length;i++){for(r[a[i]]={},s=0;s<c.length;s++)o(r[a[i]],[a[i],c[s]]);for(s=0;s<p.length;s++)o(r[a[i]],[a[i],"on"+p[s]])}for(i=0;i<u.length;i++)o(r.user,["user",u[i]]);}}(window,document,"webengage");
 
   window.webengage.ixP = 'Segment';
   /* eslint-enable */
 
   window.webengage.init(this.options.licenseCode);
 
-  var name = useHttps() ? 'https' : 'http';
+  if (!this.options.region || this.options.region === 'US') {
+    name = useHttps() ? 'https' : 'http';
+  } else if (this.options.region === 'IN') {
+    name = useHttps() ? 'https-in' : 'http-in';
+  }
+
   this.load(name, this.ready);
 };
 

--- a/integrations/webengage/package.json
+++ b/integrations/webengage/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-webengage",
   "description": "The Webengage analytics.js integration.",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/webengage/test/index.test.js
+++ b/integrations/webengage/test/index.test.js
@@ -10,7 +10,9 @@ describe('WebEngage', function() {
   var analytics;
   var webengage;
   var options = {
-    licenseCode: '~2024c003'
+    licenseCode: '~2024c003',
+    region: 'IN',
+    isSpa: true
   };
 
   beforeEach(function() {


### PR DESCRIPTION
**What does this PR do?**
Allow users to select Region and SPA site option while integrating with WebEngage.

**Are there breaking changes in this PR?**
No.

**Any background context you want to provide?**
We have multiple regions which can be handled using this change. Also the SPA option allows the segment users to take advantage of the feature.

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
No.

**Does this require a new integration setting? If so, please explain how the new setting works**
Yes. There would be two new options added, in the integration with WebEngage.
- _Single Page Application_ which would have _On_ and _Off_ selection on UI and the value would be sent as an option with key _**isSpa**_ with value _true_ or _false_ accordingly.
- _Region_ which would have _Global(default)_ and _India_ selection options on UI. And the value would be sent as an option with key _**region**_ with value **_US_** for _Global_ and **_IN_** for _India_

**Links to helpful docs and other external resources**
https://docs.webengage.com/docs/web-getting-started#section-2-integrate-the-sdk