### PR TITLE
Fox hotfix

### DIFF
--- a/integrations/nielsen-dcr/lib/index.js
+++ b/integrations/nielsen-dcr/lib/index.js
@@ -177,10 +177,7 @@ NielsenDCR.prototype.getContentMetadata = function(track, type) {
     mediaURL: track.proxy('context.page.url'),
     airdate: formatAirdate(track.proxy(propertiesPath + 'airdate')),
     // `adLoadType` may be set in int opts, falling back to `load_type` property per our video spec
-    adloadtype: formatLoadType(
-      integrationOpts,
-      track.proxy(propertiesPath + 'load_type')
-    ),
+    adloadtype: formatLoadType(integrationOpts, track, propertiesPath),
     // below metadata fields must all be set in event's integrations opts object
     crossId1: find(integrationOpts, 'crossId1'),
     crossId2: find(integrationOpts, 'crossId2'),
@@ -487,8 +484,11 @@ function formatAirdate(airdate) {
  * @api private
  */
 
-function formatLoadType(integrationOpts, loadTypeProperty) {
-  var loadType = find(integrationOpts, 'ad_load_type') || loadTypeProperty;
+function formatLoadType(integrationOpts, track, propertiesPath) {
+  var loadType =
+    find(integrationOpts, 'ad_load_type') ||
+    track.proxy(propertiesPath + 'load_type') ||
+    track.proxy('properties.load_type');
   // linear or dynamic
   // linear means original ads that were broadcasted with tv airing. much less common use case
   loadType = loadType === 'dynamic' ? '2' : '1';

--- a/integrations/nielsen-dcr/lib/index.js
+++ b/integrations/nielsen-dcr/lib/index.js
@@ -415,9 +415,12 @@ NielsenDCR.prototype.videoPlaybackResumed = NielsenDCR.prototype.videoPlaybackSe
   // if properly implemented, the point in which the playback is resumed
   // you should _only_ be sending the asset_id of whatever you are resuming in: content or ad
   var type = contentAssetId ? 'content' : 'ad';
-  var assetId = contentAssetId;
 
-  if (this.currentAssetId && assetId && this.currentAssetId !== assetId) {
+  if (
+    this.currentAssetId &&
+    contentAssetId &&
+    this.currentAssetId !== contentAssetId
+  ) {
     // first, call `end` because we assume the user has buffered/seeked into new content if the assetId has changed
     this._client.ggPM('end', this.currentPosition);
 
@@ -431,7 +434,7 @@ NielsenDCR.prototype.videoPlaybackResumed = NielsenDCR.prototype.videoPlaybackSe
     }
   }
 
-  this.heartbeat(assetId, position, livestream);
+  this.heartbeat(contentAssetId, position, livestream);
 };
 
 /**

--- a/integrations/nielsen-dcr/package.json
+++ b/integrations/nielsen-dcr/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-nielsen-dcr",
   "description": "The Nielsen DCR analytics.js integration.",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/nielsen-dcr/test/index.test.js
+++ b/integrations/nielsen-dcr/test/index.test.js
@@ -567,6 +567,7 @@ describe('NielsenDCR', function() {
             page: { url: 'segment.com' }
           });
           analytics.called(window.clearInterval);
+
           analytics.assert.deepEqual(nielsenDCR._client.ggPM.args[0], [
             'loadMetadata',
             {
@@ -578,7 +579,7 @@ describe('NielsenDCR', function() {
               isfullepisode: 'y',
               mediaURL: 'segment.com',
               airdate: '19910813 12:00:00',
-              adloadtype: '1',
+              adloadtype: '2',
               hasAds: '0'
             }
           ]);
@@ -635,7 +636,7 @@ describe('NielsenDCR', function() {
               isfullepisode: 'y',
               mediaURL: 'segment.com',
               airdate: '19910813 12:00:00',
-              adloadtype: '1',
+              adloadtype: '2',
               hasAds: '0'
             }
           ]);
@@ -694,7 +695,7 @@ describe('NielsenDCR', function() {
               isfullepisode: 'y',
               mediaURL: 'segment.com',
               airdate: '19910813 12:00:00',
-              adloadtype: '1',
+              adloadtype: '2',
               hasAds: '0',
               clientid: props.content.nielsen_client_id,
               subbrand: props.content.nielsen_subbrand

--- a/integrations/nielsen-dcr/test/index.test.js
+++ b/integrations/nielsen-dcr/test/index.test.js
@@ -718,11 +718,7 @@ describe('NielsenDCR', function() {
         it('video ad playing', function() {
           analytics.track('Video Ad Playing', props);
           analytics.called(window.clearInterval);
-          analytics.called(
-            nielsenDCR.heartbeat,
-            props.asset_id,
-            props.position
-          );
+          analytics.called(nielsenDCR.heartbeat, null, props.position);
         });
 
         it('video ad completed', function() {


### PR DESCRIPTION
**What does this PR do?**
- This PR is a hotfix for Fox.
- In a nutshell, previously, we were keeping track of both content asset ids and ad asset ids globally in order to programmatically call Nielsen's "end" method and/or load new metadata from the Segment event if either a content asset id or an ad asset id changed mid-session. This resulted in Segment loading incorrect metadata in some cases. In this change, we are only keeping track of content asset ids globally.
- In addition, I have added a fallback to look in `properties` for "load_type" with ad events in `properties.content` is falsy.

**Are there breaking changes in this PR?**
- n/a

**Any background context you want to provide?**
- Fox request.

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
- n/a

**Does this require a new integration setting? If so, please explain how the new setting works**
- n/a

**Links to helpful docs and other external resources**
- n/a