### PR TITLE
Moengage -  Fixed snake_case for identify traits

### DIFF
--- a/integrations/moengage/HISTORY.md
+++ b/integrations/moengage/HISTORY.md
@@ -1,34 +1,31 @@
-1.0.6 / 2019-01-07
-==================
+# 1.0.7 / 2020-01-29
 
-  * Reset session when anonymous ID changes
+- Fixed and added support for snake_case identity traits
 
-1.0.5 / 2018-01-08
-==================
+# 1.0.6 / 2019-01-07
 
-  * Destroy session on reset
+- Reset session when anonymous ID changes
 
-1.0.4 / 2017-08-14
-==================
+# 1.0.5 / 2018-01-08
 
-  * Fix bug with sending custom user attribtues
+- Destroy session on reset
 
-1.0.3 / 2017-08-14
-==================
+# 1.0.4 / 2017-08-14
 
-  * Don't send `traits.username` as custom attribute again
+- Fix bug with sending custom user attribtues
 
-1.0.2 / 2017-08-11
-==================
+# 1.0.3 / 2017-08-14
 
-  * Map `traits.name` to `add_user_name` with fallback to `traits.username`
+- Don't send `traits.username` as custom attribute again
 
-1.0.1 / 2017-08-10
-==================
+# 1.0.2 / 2017-08-11
 
-  * Handle logout/reset automatically
+- Map `traits.name` to `add_user_name` with fallback to `traits.username`
 
-1.0.0 / 2017-08-09
-==================
+# 1.0.1 / 2017-08-10
 
-  * Initial Release :sparkles:
+- Handle logout/reset automatically
+
+# 1.0.0 / 2017-08-09
+
+- Initial Release :sparkles:

--- a/integrations/moengage/lib/index.js
+++ b/integrations/moengage/lib/index.js
@@ -111,12 +111,12 @@ MoEngage.prototype.identify = function(identify) {
   // analytics.js regenerates anonymousId if you call `.identify()` with a unique userId value different from the cache
   if (this.initializedAnonymousId !== identify.anonymousId()) this.reset();
   if (identify.userId()) this._client.add_unique_user_id(identify.userId());
+  if (identify.firstName()) this._client.add_first_name(identify.firstName());
+  if (identify.lastName()) this._client.add_last_name(identify.lastName());
 
   // send common traits
   // the partner sdk throws TypeErrors/Uncaughts if you pass `undefined`
   var traitsMethodMap = {
-    firstName: 'first_name',
-    lastName: 'last_name',
     email: 'email',
     phone: 'mobile',
     name: 'user_name',

--- a/integrations/moengage/package.json
+++ b/integrations/moengage/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-moengage",
   "description": "The MoEngage analytics.js integration.",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/moengage/test/index.test.js
+++ b/integrations/moengage/test/index.test.js
@@ -76,7 +76,7 @@ describe('MoEngage', function() {
         analytics.stub(moengage._client, 'destroy_session');
       });
 
-      it('should send identify', function() {
+      it('should send identify with camelCase', function() {
         var traits = {
           firstName: 'han',
           lastName: 'solo',
@@ -91,6 +91,33 @@ describe('MoEngage', function() {
         analytics.called(moengage._client.add_unique_user_id, 'han123');
         analytics.called(moengage._client.add_first_name, traits.firstName);
         analytics.called(moengage._client.add_last_name, traits.lastName);
+        analytics.called(moengage._client.add_email, traits.email);
+        analytics.called(moengage._client.add_mobile, traits.phone);
+        analytics.called(moengage._client.add_user_name, traits.name);
+        analytics.called(moengage._client.add_gender, traits.gender);
+        analytics.called(moengage._client.add_birthday, traits.birthday);
+        analytics.called(
+          moengage._client.add_user_attribute,
+          'customTrait',
+          traits.customTrait
+        );
+      });
+
+      it('should send identify with snake_case', function() {
+        var traits = {
+          first_name: 'han',
+          last_name: 'solo',
+          email: 'han@segment.com',
+          phone: '4012229047',
+          name: 'han solo',
+          gender: 'male',
+          birthday: '08/13/1991',
+          customTrait: true
+        };
+        analytics.identify('han123', traits);
+        analytics.called(moengage._client.add_unique_user_id, 'han123');
+        analytics.called(moengage._client.add_first_name, traits.first_name);
+        analytics.called(moengage._client.add_last_name, traits.last_name);
         analytics.called(moengage._client.add_email, traits.email);
         analytics.called(moengage._client.add_mobile, traits.phone);
         analytics.called(moengage._client.add_user_name, traits.name);
@@ -204,7 +231,7 @@ describe('MoEngage', function() {
             'MoEngange anonymous ID should be equal after an identify call'
           );
         }
-        1;
+
         analytics.called(moengage._client.destroy_session);
       });
 


### PR DESCRIPTION
**What does this PR do?**

- This PR adds support for snake_case identify traits like first_name and last_name. Previously these snake_case properties were breaking and caused js errors.

**Are there breaking changes in this PR?**

- No

**Any background context you want to provide?**
- When customers used snake_case identify traits, code was breaking.
![image](https://user-images.githubusercontent.com/55080009/73298801-06eab880-4234-11ea-9ad3-e9aadc89159a.png)



**Is there parity with the server-side/android/iOS integration components (if applicable)?**

- n/a

**Does this require a new integration setting? If so, please explain how the new setting works**

- n/a

**Links to helpful docs and other external resources**

- https://docs.moengage.com/docs/segment-websdk-integration
