### PR TITLE
[STRATCONN-77] Add Custom Context Data Variable to Heartbeat

### DIFF
--- a/integrations/adobe-analytics/HISTORY.md
+++ b/integrations/adobe-analytics/HISTORY.md
@@ -1,3 +1,7 @@
+1.16.0 / 2020-02-12
+===================
+
+  * Support sending custom Context Data Variables on `Video Playback Started`, `Video Playback Resumed`, and `Video Content Started` when using Adobe Heartbeat Tracking URL
 
 1.15.0 / 2019-10-21
 ===================

--- a/integrations/adobe-analytics/lib/index.js
+++ b/integrations/adobe-analytics/lib/index.js
@@ -1229,8 +1229,9 @@ function heartbeatSessionStart(track) {
     props.total_length || 0,
     streamType
   );
-  var contextData = {}; // This might be a custom object for the user.
 
+  // Assign custom context data using the Context Data Variables settings and properties in payload.
+  var contextData = createCustomVideoMetadataContext(track, this.options); // This might be a custom object for the user.
   createStandardVideoMetadata(track, mediaObj);
 
   this.mediaHeartbeats[
@@ -1246,6 +1247,11 @@ function heartbeatVideoStart(track) {
   var props = track.properties();
 
   this.mediaHeartbeats[props.session_id || 'default'].heartbeat.trackPlay();
+  // Assign custom metadata using the Context Data Variables settings and properties in payload.
+  var chapterCustomMetadata = createCustomVideoMetadataContext(
+    track,
+    this.options
+  );
 
   if (!this.mediaHeartbeats[props.session_id || 'default'].chapterInProgress) {
     var chapterObj = videoAnalytics.MediaHeartbeat.createChapterObject(
@@ -1266,7 +1272,7 @@ function heartbeatVideoStart(track) {
     this.mediaHeartbeats[props.session_id || 'default'].heartbeat.trackEvent(
       videoAnalytics.MediaHeartbeat.Event.ChapterStart,
       chapterObj,
-      {}
+      chapterCustomMetadata
     );
     this.mediaHeartbeats[
       props.session_id || 'default'
@@ -1454,6 +1460,19 @@ function createStandardVideoMetadata(track, mediaObj) {
     videoAnalytics.MediaHeartbeat.MediaObjectKey.StandardVideoMetadata,
     stdVidMeta
   );
+}
+
+function createCustomVideoMetadataContext(track, options) {
+  var contextData = {};
+
+  var properties = extractProperties(trample(track.properties()), options);
+  each(function(value, key) {
+    if (!key || value === undefined || value === null || value === '') {
+      return;
+    }
+    contextData[key] = value;
+  }, properties);
+  return contextData;
 }
 
 function createStandardAdMetadata(track, adObj) {

--- a/integrations/adobe-analytics/package.json
+++ b/integrations/adobe-analytics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-adobe-analytics",
   "description": "The Adobe Analytics analytics.js integration.",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/adobe-analytics/test/index.test.js
+++ b/integrations/adobe-analytics/test/index.test.js
@@ -45,7 +45,11 @@ describe('Adobe Analytics', function() {
     lVars: {
       names: 'list1'
     },
-    contextValues: {},
+    contextValues: {
+      video_genre: 'video_genre',
+      video_asset_title: 'video_asset_title',
+      video_series_name: 'video_series_name'
+    },
     customDataPrefix: '',
     timestampOption: 'enabled',
     enableTrackPageName: true,
@@ -1342,6 +1346,29 @@ describe('Adobe Analytics', function() {
 
         analytics.called(
           adobeAnalytics.mediaHeartbeats[sessionId].heartbeat.trackPlay
+        );
+      });
+
+      it('should allow for custom metdata to sent on Video Playbak S', function() {
+        analytics.track('Video Playback Started', {
+          session_id: sessionId,
+          video_genre: 'Reality, Game Show, Music',
+          video_asset_title: 'Some Kind of Title',
+          video_series_name: 'The Masked Singer'
+        });
+
+        analytics.assert(adobeAnalytics.mediaHeartbeats[sessionId]);
+        analytics.assert(
+          adobeAnalytics.mediaHeartbeats[sessionId].heartbeat._aaPlugin
+            ._videoMetadata.video_genre === 'Reality, Game Show, Music'
+        );
+        analytics.assert(
+          adobeAnalytics.mediaHeartbeats[sessionId].heartbeat._aaPlugin
+            ._videoMetadata.video_asset_title === 'Some Kind of Title'
+        );
+        analytics.assert(
+          adobeAnalytics.mediaHeartbeats[sessionId].heartbeat._aaPlugin
+            ._videoMetadata.video_series_name === 'The Masked Singer'
         );
       });
 


### PR DESCRIPTION
**What does this PR do?**
JIRA: https://segment.atlassian.net/browse/STRATCONN-77
Add support to send Custom Metadata (Context Data) to Adobe Analytics for Heartbeat events. Per Adobe Analytics documentation we can send addtional custom data in these scenarios: 

1. `trackSessionStart(mediaObj, contextData);` for Video Playback Started and Video Playback Resumed events. 
2. `trackEvent(chapterStart, chapterObj, contextData)` for Video Content Started events.  

We will leverage our existing setting Context Data Variables to map properties to custom content to send to AA. 

Deployment plan is to deploy to Fox test source for validation tomorrow (2/12/20) : https://app.segment.com/foxdcg/sources/web_staging/overview

**Are there breaking changes in this PR?**
No. This was tested locally using the Golden Compiler. Validation results were shared with Fox to ensure expected Query Parameter outcomes matched expectations. 

Outbound request: 
```
{
  "anonymousId": "a3219017-b2ae-4f10-a625-6957b022660d",
  "context": {
  ......
 },
  "event": "Video Playback Started",
  "properties": {
    "video_asset_title": "The Llama's First Interview Without The Mask",
    "video_genre": "Reality, Game Show, Music",
    "video_primary_business_unit": "fng",
    "video_series_name": "The Masked Singer",
  },
  "receivedAt": "2020-02-12T18:55:58.100Z",
  "sentAt": "2020-02-12T18:55:57.955Z",
  "timestamp": "2020-02-12T18:55:58.091Z",
  "type": "track",
  "userId": null
}
```
Network Request to Heartbeat Tracking URL:

![Screen Shot 2020-02-12 at 2 34 39 PM](https://user-images.githubusercontent.com/31782219/74391342-cbfe8e00-4db8-11ea-9ee8-87eea4cc925a.png)

Network Request to Server URL:
![Screen Shot 2020-02-12 at 2 36 38 PM](https://user-images.githubusercontent.com/31782219/74391395-fa7c6900-4db8-11ea-8037-fdf1c7d0c953.png)


**Any background context you want to provide?**
N/A 

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
N/A at this time. 

**Does this require a new integration setting? If so, please explain how the new setting works**
No. 

**Links to helpful docs and other external resources**
Additional Background and Context Doc: https://paper.dropbox.com/doc/Adobe-Analytics-A.js-Heartbeat--AuOKIvh6w8PCLv5MiXNp7AJVAg-FAcr9dX5rqZ9RLTg46Bvk