### PR TITLE
[STRATCONN-77] Add Custom Context Data Variable to Heartbeat

### DIFF
--- a/integrations/adobe-analytics/HISTORY.md
+++ b/integrations/adobe-analytics/HISTORY.md
@@ -1,3 +1,7 @@
+1.15.1 / 2020-02-12
+===================
+
+  * Support sending custom Context Data Variables on `Video Playback Started`, `Video Playback Resumed`, and `Video Content Started` when using Adobe Heartbeat Tracking URL
 
 1.14.3 / 2018-06-25
 ===================

--- a/integrations/adobe-analytics/lib/index.js
+++ b/integrations/adobe-analytics/lib/index.js
@@ -843,8 +843,9 @@ function heartbeatSessionStart(track) {
     props.total_length || 0,
     streamType
   );
-  var contextData = {}; // This might be a custom object for the user.
 
+  // Assign custom context data using the Context Data Variables settings and properties in payload.
+  var contextData = createCustomVideoMetadataContext(track, this.options); // This might be a custom object for the user.
   createStandardVideoMetadata(track, mediaObj);
 
   this.mediaHeartbeats[
@@ -860,6 +861,11 @@ function heartbeatVideoStart(track) {
   var props = track.properties();
 
   this.mediaHeartbeats[props.session_id || 'default'].heartbeat.trackPlay();
+  // Assign custom metadata using the Context Data Variables settings and properties in payload.
+  var chapterCustomMetadata = createCustomVideoMetadataContext(
+    track,
+    this.options
+  );
 
   if (!this.mediaHeartbeats[props.session_id || 'default'].chapterInProgress) {
     var chapterObj = videoAnalytics.MediaHeartbeat.createChapterObject(
@@ -880,7 +886,7 @@ function heartbeatVideoStart(track) {
     this.mediaHeartbeats[props.session_id || 'default'].heartbeat.trackEvent(
       videoAnalytics.MediaHeartbeat.Event.ChapterStart,
       chapterObj,
-      {}
+      chapterCustomMetadata
     );
     this.mediaHeartbeats[
       props.session_id || 'default'
@@ -1066,6 +1072,19 @@ function createStandardVideoMetadata(track, mediaObj) {
     videoAnalytics.MediaHeartbeat.MediaObjectKey.StandardVideoMetadata,
     stdVidMeta
   );
+}
+
+function createCustomVideoMetadataContext(track, options) {
+  var contextData = {};
+
+  var properties = extractProperties(trample(track.properties()), options);
+  each(function(value, key) {
+    if (!key || value === undefined || value === null || value === '') {
+      return;
+    }
+    contextData[key] = value;
+  }, properties);
+  return contextData;
 }
 
 function createStandardAdMetadata(track, adObj) {

--- a/integrations/adobe-analytics/lib/index.js
+++ b/integrations/adobe-analytics/lib/index.js
@@ -50,14 +50,14 @@ AdobeAnalytics.sOption = function(field, value) {
   var s = window.s;
   var isValid = s && has.call(s, field) && !isEmptyString(field);
 
-  value = isValid ? s[field] : value;
+  var newValue = isValid ? s[field] : value;
 
   // TODO: Consider removing this. Not sure why we are doing this since it has no future reference
   this.prototype.sOptions = this.prototype.sOptions || {};
-  this.prototype.sOptions[field] = value;
+  this.prototype.sOptions[field] = newValue;
 
   // Set field and value to this.options
-  return this.option(field, value);
+  return this.option(field, newValue);
 };
 
 /**
@@ -435,9 +435,10 @@ AdobeAnalytics.prototype.processEvent = function(msg, adobeEvent) {
   var eVarEvent = dot(this.options.eVars, msg.event());
   update(msg.event(), eVarEvent);
 
-  if (productVariables) update(productVariables, 'products');
+  if (productVariables) update(productVariables, 'products'); //eslint-disable-line
 
   updateEvents(msg.event(), this.options.events, adobeEvent);
+
   updateCommonVariables(msg, this.options);
 
   calculateTimestamp(msg, this.options);
@@ -654,7 +655,7 @@ function clearKeys(keys) {
     delete window.s[linkVar];
   }, keys);
   // Clears the array passed in
-  keys.length = 0;
+  keys.length = 0; //eslint-disable-line
 }
 
 /**
@@ -735,6 +736,7 @@ function isFunction(fn) {
  * @return {Object}
  */
 
+/* eslint-disable */
 function lowercaseKeys(obj) {
   obj = obj || {};
   each(function(value, key) {
@@ -743,6 +745,7 @@ function lowercaseKeys(obj) {
   }, obj);
   return obj;
 }
+/* eslint-disable */
 
 /**
  * Return whether `str` is an empty string.
@@ -933,9 +936,11 @@ function heartbeatAdStarted(track) {
   var props = track.properties();
   var adSessionCount = this.adBreakCounts[props.session_id || 'default'];
 
+  /* eslint-disable */
   adSessionCount
     ? (adSessionCount = ++this.adBreakCounts[props.session_id || 'default'])
     : (adSessionCount = this.adBreakCounts[props.session_id || 'default'] = 1);
+  /* eslint-disable */
 
   var adBreakObj = videoAnalytics.MediaHeartbeat.createAdBreakObject(
     props.type || 'unknown',

--- a/integrations/adobe-analytics/package.json
+++ b/integrations/adobe-analytics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-adobe-analytics",
   "description": "The Adobe Analytics analytics.js integration.",
-  "version": "1.14.3",
+  "version": "1.15.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/adobe-analytics/test/index.test.js
+++ b/integrations/adobe-analytics/test/index.test.js
@@ -44,7 +44,11 @@ describe('Adobe Analytics', function() {
     lVars: {
       names: 'list1'
     },
-    contextValues: {},
+    contextValues: {
+      video_genre: 'video_genre',
+      video_asset_title: 'video_asset_title',
+      video_series_name: 'video_series_name'
+    },
     customDataPrefix: '',
     timestampOption: 'enabled',
     enableTrackPageName: true,
@@ -1173,6 +1177,29 @@ describe('Adobe Analytics', function() {
 
         analytics.called(
           adobeAnalytics.mediaHeartbeats[sessionId].heartbeat.trackPlay
+        );
+      });
+
+      it('should allow for custom metdata to sent on Video Playbak S', function() {
+        analytics.track('Video Playback Started', {
+          session_id: sessionId,
+          video_genre: 'Reality, Game Show, Music',
+          video_asset_title: 'Some Kind of Title',
+          video_series_name: 'The Masked Singer'
+        });
+
+        analytics.assert(adobeAnalytics.mediaHeartbeats[sessionId]);
+        analytics.assert(
+          adobeAnalytics.mediaHeartbeats[sessionId].heartbeat._aaPlugin
+            ._videoMetadata.video_genre === 'Reality, Game Show, Music'
+        );
+        analytics.assert(
+          adobeAnalytics.mediaHeartbeats[sessionId].heartbeat._aaPlugin
+            ._videoMetadata.video_asset_title === 'Some Kind of Title'
+        );
+        analytics.assert(
+          adobeAnalytics.mediaHeartbeats[sessionId].heartbeat._aaPlugin
+            ._videoMetadata.video_series_name === 'The Masked Singer'
         );
       });
 


### PR DESCRIPTION
**What does this PR do?**
REDEPLOY FROM THIS PR: https://github.com/segmentio/analytics.js-integrations/pull/423
JIRA: https://segment.atlassian.net/browse/STRATCONN-77
Add support to send Custom Metadata (Context Data) to Adobe Analytics for Heartbeat events. Per Adobe Analytics documentation we can send addtional custom data in these scenarios: 

1. `trackSessionStart(mediaObj, contextData);` for Video Playback Started and Video Playback Resumed events. 
2. `trackEvent(chapterStart, chapterObj, contextData)` for Video Content Started events.  

We will leverage our existing setting Context Data Variables to map properties to custom content to send to AA. 

Deployment plan is to deploy to Fox test source for validation tomorrow (2/12/20) : https://app.segment.com/foxdcg/sources/web_staging/overview

**Are there breaking changes in this PR?**
No. This was tested locally using the Golden Compiler. Validation results were shared with Fox to ensure expected Query Parameter outcomes matched expectations. 

Outbound request: 
```
{
  "anonymousId": "a3219017-b2ae-4f10-a625-6957b022660d",
  "context": {
  ......
 },
  "event": "Video Playback Started",
  "properties": {
    "video_asset_title": "The Llama's First Interview Without The Mask",
    "video_genre": "Reality, Game Show, Music",
    "video_primary_business_unit": "fng",
    "video_series_name": "The Masked Singer",
  },
  "receivedAt": "2020-02-12T18:55:58.100Z",
  "sentAt": "2020-02-12T18:55:57.955Z",
  "timestamp": "2020-02-12T18:55:58.091Z",
  "type": "track",
  "userId": null
}
```
Network Request to Heartbeat Tracking URL:

![Screen Shot 2020-02-12 at 2 34 39 PM](https://user-images.githubusercontent.com/31782219/74391342-cbfe8e00-4db8-11ea-9ee8-87eea4cc925a.png)

Network Request to Server URL:
![Screen Shot 2020-02-12 at 2 36 38 PM](https://user-images.githubusercontent.com/31782219/74391395-fa7c6900-4db8-11ea-8037-fdf1c7d0c953.png)


**Any background context you want to provide?**
N/A 

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
N/A at this time. 

**Does this require a new integration setting? If so, please explain how the new setting works**
No. 

**Links to helpful docs and other external resources**
Additional Background and Context Doc: https://paper.dropbox.com/doc/Adobe-Analytics-A.js-Heartbeat--AuOKIvh6w8PCLv5MiXNp7AJVAg-FAcr9dX5rqZ9RLTg46Bvk
