### PR TITLE
Update tracktor to 0.11.0

### DIFF
--- a/integrations/visual-tagger/package.json
+++ b/integrations/visual-tagger/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@segment/tracktor": "0.9.0",
+    "@segment/tracktor": "0.11.0",
     "do-when": "^1.0.0"
   }
 }

--- a/integrations/visual-tagger/package.json
+++ b/integrations/visual-tagger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/analytics.js-integration-visual-tagger",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "The Visual Tagger analyticsjs integration",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Updates the visual tagger integration to the latest from [tracktor](https://github.com/segmentio/tracktor/pull/94). 