### PR TITLE
Add language_override settings properties to set it in Intercom

### DIFF
--- a/integrations/intercom/lib/index.js
+++ b/integrations/intercom/lib/index.js
@@ -121,12 +121,14 @@ Intercom.prototype.identify = function(identify) {
 
   // format nested custom traits
   traits = formatNestedCustomTraits(traits, settings);
-
   // handle options
   if (integrationSettings.userHash)
     traits.user_hash = integrationSettings.userHash;
   if (integrationSettings.user_hash)
     traits.user_hash = integrationSettings.user_hash;
+
+  if (integrationSettings.language_override)
+    traits.language_override = integrationSettings.language_override;
 
   this.bootOrUpdate(traits, integrationSettings);
 };

--- a/integrations/intercom/test/index.test.js
+++ b/integrations/intercom/test/index.test.js
@@ -494,6 +494,20 @@ describe('Intercom', function() {
         });
       });
 
+      it('identify: should set language_override if integration setting exists for it', function() {
+        var integrationSettings = {
+          Intercom: { language_override: 'EN' }
+        };
+
+        analytics.identify('id', {}, integrationSettings);
+        analytics.called(window.Intercom, 'boot', {
+          app_id: options.appId,
+          user_id: 'id',
+          id: 'id',
+          language_override: 'EN'
+        });
+      });
+
       it('group: should set hide_default_launcher if integration setting exists for it', function() {
         var integrationSettings = {
           Intercom: { hideDefaultLauncher: true }


### PR DESCRIPTION
**What does this PR do?**
Add language_override settings in Intercom integration because this property is missing.

An issue has been opened : #310

**Are there breaking changes in this PR?**
No

**Any background context you want to provide?**
language_override is a property used in Intercom widget in order to override defualt browser language tracked too.
In order to use this property inside the segment integration, we need to adjust the code.

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
No

**Does this require a new integration setting? If so, please explain how the new setting works**
language_override has been added.
You can pass a locale 'EN', 'FR', 'PL' if you want in order to override the language of your identified user.

**Links to helpful docs and other external resources**
If you want official informations about this setting please : [See Intercom Documentation](https://www.intercom.com/help/en/articles/180-localize-intercom-to-work-with-multiple-languages)