### PR TITLE
Compiler: Enable custom cdn domain

### DIFF
--- a/compiler/compile
+++ b/compiler/compile
@@ -22,7 +22,15 @@ program
   .option('-s, --settings <settings>', 'Relative path to custom integrations settings file')
   .parse(process.argv)
 
-if (!program.writeKey) {
+// Get program parameters.
+const {
+  cdnDomain = 'http://cdn.segment.com',
+  port = 3000,
+  settings,
+  writeKey,
+} = program
+
+if (!writeKey) {
   console.error('Error: --writeKey required')
   process.exit(1)
 }
@@ -40,16 +48,10 @@ if (diff.stdout && (diff.stdout).toString().length) {
   spawnSync('yarn install --no-lockfile', opts)
 }
 
-const {
-  cdnDomain = 'http://cdn.segment.com',
-  port = 3000,
-  settings,
-  writeKey,
-} = program
 let customSettings
 
 if (settings) {
-  const settingsPath = path.join(__dirname, `${program.settings}`)
+  const settingsPath = path.join(__dirname, settings)
   customSettings = JSON.parse(fs.readFileSync(settingsPath))
 } else {
   console.info('**No custom settings file specified. Retrieving settings from Segment\'s CDN.**')
@@ -59,7 +61,6 @@ buildIntegrations()
 build(async (ajs, integrationVersions, coreVersion) => {
   let compiled
 
-  console.log('cdnDomain', cdnDomain)
   try {
     compiled = await addSettings({
       ajs,
@@ -80,7 +81,7 @@ build(async (ajs, integrationVersions, coreVersion) => {
   }
 
   fs.writeFileSync(fileName, compiled)
-  generateFile(program.writeKey, port)
+  generateFile(writeKey, port)
   server(compiled, filePath, port)
   open(`http://localhost:${port}`)
 })

--- a/compiler/compile
+++ b/compiler/compile
@@ -16,16 +16,16 @@ const buildName = `${Math.floor(new Date() / 1000)}`;
 const fileName = path.join(__dirname, 'builds', `analytics-${buildName}.js`)
 
 program
-  .option('-c, --cdnDomain <cdnDomain>', 'Segment cdn domain, defaults to http://cdn.segment.com')
+  .option('-c, --cdnDomain <cdnDomain>', 'Segment cdn domain', 'http://cdn.segment.com')
   .option('-w, --writeKey <writeKey>', 'Segment writeKey to for viewing events in the debugger')
-  .option('-p, --port [port]', 'Set a port to serve the local ajs file from', 3000)
-  .option('-s, --settings <settings>', 'Relative path to custom integrations settings file')
+  .option('-p, --port <port>', 'Set a port to serve the local ajs file from', 3000)
+  .option('-s, --settings <settings>', '(Optional) Relative path to custom integrations settings file')
   .parse(process.argv)
 
 // Get program parameters.
 const {
-  cdnDomain = 'http://cdn.segment.com',
-  port = 3000,
+  cdnDomain,
+  port,
   settings,
   writeKey,
 } = program

--- a/compiler/compile
+++ b/compiler/compile
@@ -16,6 +16,7 @@ const buildName = `${Math.floor(new Date() / 1000)}`;
 const fileName = path.join(__dirname, 'builds', `analytics-${buildName}.js`)
 
 program
+  .option('-c, --cdnDomain <cdnDomain>', 'Segment cdn domain, defaults to http://cdn.segment.com')
   .option('-w, --writeKey <writeKey>', 'Segment writeKey to for viewing events in the debugger')
   .option('-p, --port [port]', 'Set a port to serve the local ajs file from', 3000)
   .option('-s, --settings <settings>', 'Relative path to custom integrations settings file')
@@ -39,11 +40,15 @@ if (diff.stdout && (diff.stdout).toString().length) {
   spawnSync('yarn install --no-lockfile', opts)
 }
 
-const writeKey = program.writeKey
-const port = program.port || 3000
+const {
+  cdnDomain = 'http://cdn.segment.com',
+  port = 3000,
+  settings,
+  writeKey,
+} = program
 let customSettings
 
-if (program.settings) {
+if (settings) {
   const settingsPath = path.join(__dirname, `${program.settings}`)
   customSettings = JSON.parse(fs.readFileSync(settingsPath))
 } else {
@@ -54,9 +59,11 @@ buildIntegrations()
 build(async (ajs, integrationVersions, coreVersion) => {
   let compiled
 
+  console.log('cdnDomain', cdnDomain)
   try {
     compiled = await addSettings({
       ajs,
+      cdnDomain,
       integrationVersions,
       coreVersion,
       writeKey,

--- a/compiler/scripts/settings.js
+++ b/compiler/scripts/settings.js
@@ -9,12 +9,13 @@ var fs = require('fs')
  *
  * @async
  * @param {String} writeKey A valid Segment Write Key (ex. dhLxf5GwJwaDHt7MBo80V7Yb0PV6FT5H)
+ * @param {String} cdnDomain Base domain for cdn e.g. 'http://cdn.segment.com'
  *
  * @throws {Error} for any network/request error.
  * @returns {Object} Source settings.
  */
-async function getSourceSettings(writeKey) {
-  var url = `http://cdn.segment.com/v1/projects/${writeKey}/settings`;
+async function getSourceSettings(writeKey, cdnDomain) {
+  const url = `${cdnDomain}/v1/projects/${writeKey}/settings`;
   return new Promise((resolve, reject) => {
     request.get({ url: url, gzip: true, headers:{ 'Cache-Control':'no-cache' } }, (err, _, body) => {
       if (err) {
@@ -99,8 +100,16 @@ function getSlug(name) {
     .replace(/[^a-z0-9-]/g, '');
 }
 
-async function context(integrationVersions, coreVersion, writeKey, customSettings) {
-  const settings = customSettings || await getSourceSettings(writeKey);
+/**
+ * @param integrationVersions
+ * @param coreVersion
+ * @param writeKey
+ * @param customSettings
+ * @param {String} cdnDomain
+ * @returns {Promise<{}>}
+ */
+async function context(integrationVersions, coreVersion, writeKey, customSettings, cdnDomain) {
+  const settings = customSettings || await getSourceSettings(writeKey, cdnDomain);
   const integrations = settings.integrations;
 
   const ctx = {};
@@ -121,12 +130,21 @@ async function context(integrationVersions, coreVersion, writeKey, customSetting
   return ctx;
 }
 
-module.exports = async function ({ ajs, integrationVersions, coreVersion, writeKey, customSettings }) {
+/**
+ * @param ajs
+ * @param {String} cdnDomain
+ * @param integrationVersions
+ * @param coreVersion
+ * @param writeKey
+ * @param customSettings
+ * @returns {Promise<*>}
+ */
+module.exports = async function ({ ajs, cdnDomain, integrationVersions, coreVersion, writeKey, customSettings }) {
   const { version } = coreVersion
   let ctx
 
   try {
-    ctx = await context(integrationVersions, version, writeKey, customSettings)
+    ctx = await context(integrationVersions, version, writeKey, customSettings, cdnDomain)
   } catch(err) {
     console.error('Error: ', err)
     return


### PR DESCRIPTION
**What does this PR do?**

```
~/dev/src/github.com/segmentio/analytics.js-integrations/compiler$ ./compile --help
Usage: compile [options]

Options:
  -c, --cdnDomain <cdnDomain>  Segment cdn domain (default: "http://cdn.segment.com")
  -w, --writeKey <writeKey>    Segment writeKey to for viewing events in the debugger
  -p, --port <port>            Set a port to serve the local ajs file from (default: 3000)
  -s, --settings <settings>    (Optional) Relative path to custom integrations settings file
  -h, --help                   output usage information
```

**Are there breaking changes in this PR?**


**Any background context you want to provide?**


**Is there parity with the server-side/android/iOS integration components (if applicable)?**


**Does this require a new integration setting? If so, please explain how the new setting works**


**Links to helpful docs and other external resources**
