### PR TITLE
Add compiler noRebuild configuration, helpful for testing compiler

### DIFF
--- a/compiler/.gitignore
+++ b/compiler/.gitignore
@@ -68,3 +68,6 @@ typings/
 
 # dotenv environment variables file
 .env
+
+# Local settings.json files for testing.
+*.settings.json

--- a/compiler/compile
+++ b/compiler/compile
@@ -16,10 +16,11 @@ const buildName = `${Math.floor(new Date() / 1000)}`;
 const fileName = path.join(__dirname, 'builds', `analytics-${buildName}.js`)
 
 program
-  .option('-c, --cdnDomain <cdnDomain>', 'Segment cdn domain', 'http://cdn.segment.com')
   .option('-w, --writeKey <writeKey>', 'Segment writeKey to for viewing events in the debugger')
-  .option('-p, --port <port>', 'Set a port to serve the local ajs file from', 3000)
   .option('-s, --settings <settings>', '(Optional) Relative path to custom integrations settings file')
+  .option('-c, --cdnDomain <cdnDomain>', 'Segment CDN domain', 'http://cdn.segment.com')
+  .option('-n, --noRebuild', 'Skips yarn rebuild')
+  .option('-p, --port <port>', 'Set a port to serve the local ajs file from', 3000)
   .parse(process.argv)
 
 // Get program parameters.
@@ -27,6 +28,7 @@ const {
   cdnDomain,
   port,
   settings,
+  noRebuild,
   writeKey,
 } = program
 
@@ -40,12 +42,14 @@ const opts = {
   cwd: __dirname
 }
 
-// check if any files have changed since most recent `git add`
-const diff = spawnSync('git diff --name-only', opts)
-if (diff.stdout && (diff.stdout).toString().length) {
-  opts.stdio = 'inherit'
-  // if not, run `yarn install --no-lockfile` to pull in any updates made in the /integrations directory
-  spawnSync('yarn install --no-lockfile', opts)
+if (!noRebuild) {
+  // check if any files have changed since most recent `git add`
+  const diff = spawnSync('git diff --name-only', opts)
+  if (diff.stdout && (diff.stdout).toString().length) {
+    opts.stdio = 'inherit'
+    // if not, run `yarn install --no-lockfile` to pull in any updates made in the /integrations directory
+    spawnSync('yarn install --no-lockfile', opts)
+  }
 }
 
 let customSettings

--- a/compiler/scripts/settings.js
+++ b/compiler/scripts/settings.js
@@ -1,8 +1,8 @@
 const ejs = require('ejs');
 const { keys, pick, get } = require('lodash')
-var request = require('request');
-var path = require('path')
-var fs = require('fs')
+const request = require('request');
+const path = require('path')
+const fs = require('fs')
 
 /**
  * Retrieves the settings for the provided Segment Write Key.
@@ -114,7 +114,7 @@ async function context(integrationVersions, coreVersion, writeKey, customSetting
 
   const ctx = {};
   const availableIntegrations = readIntegrationsPackages();
-  ctx.enabled = await getEnabledIntegrations(settings, availableIntegrations);
+  ctx.enabled = getEnabledIntegrations(settings, availableIntegrations);
   ctx.integrations = pick(integrations, keys(ctx.enabled));
 
   const versions = {


### PR DESCRIPTION
**What does this PR do?**

```
~/dev/src/github.com/segmentio/analytics.js-integrations/compiler$ ./compile --help
Usage: compile [options]

Options:
  -w, --writeKey <writeKey>    Segment writeKey to for viewing events in the debugger
  -s, --settings <settings>    (Optional) Relative path to custom integrations settings file
  -c, --cdnDomain <cdnDomain>  Segment CDN domain (default: "http://cdn.segment.com")
  -n, --noRebuild              Skips yarn rebuild
  -p, --port <port>            Set a port to serve the local ajs file from (default: 3000)
  -h, --help                   output usage information
```

The yarn rebuild runs whenever there are non `git add`-ed files. I found that when in development this is often the case. So the `-n` option helped me move faster to just restart compiler at times. There could probably be some more work to just do yarn rebuild for the integrations that changed. That would be nice but not sure how to do that.

I tested this change manually. No need for more testing, just the a.js compiler.

**Are there breaking changes in this PR?**


**Any background context you want to provide?**


**Is there parity with the server-side/android/iOS integration components (if applicable)?**


**Does this require a new integration setting? If so, please explain how the new setting works**


**Links to helpful docs and other external resources**
