### PR TITLE
[STRATCONN-41] GA: Make checkout options optional + support all cases

### DIFF
--- a/integrations/google-analytics/HISTORY.md
+++ b/integrations/google-analytics/HISTORY.md
@@ -1,7 +1,12 @@
+2.18.3 / 2020-03-10
+===================
+
+  * Add support for all casing types for enhanced ecommerce checkout options.
+  * Make checkout options optional
+
 2.18.2  / 2020-02-18
 ===================
   * Fix a bug where we are sending a product level category for the event category. We will send Google Analytics an event category of `'EnhancedEcommerce'` for the following events: `'product clicked'`, `product removed`, `product added` and `product viewed`.
-
 
 2.18.0 / 2019-12-17
 ===================

--- a/integrations/google-analytics/lib/index.js
+++ b/integrations/google-analytics/lib/index.js
@@ -783,11 +783,9 @@ GA.prototype.checkoutStepCompletedEnhanced = function(track) {
 
   // Append checkout option if it is set.
   var params = {
-    step: props.step || 1
+    step: props.step || 1,
+    option: options || undefined
   };
-  if (options) {
-    params.option = options;
-  }
 
   this.loadEnhancedEcommerce(track);
 

--- a/integrations/google-analytics/package.json
+++ b/integrations/google-analytics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-google-analytics",
   "description": "The Google Analytics analytics.js integration.",
-  "version": "2.18.2",
+  "version": "2.18.3-rc.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/google-analytics/package.json
+++ b/integrations/google-analytics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-google-analytics",
   "description": "The Google Analytics analytics.js integration.",
-  "version": "2.18.3-rc.2",
+  "version": "2.18.3",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/google-analytics/package.json
+++ b/integrations/google-analytics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-google-analytics",
   "description": "The Google Analytics analytics.js integration.",
-  "version": "2.18.3-rc.1",
+  "version": "2.18.3-rc.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/google-analytics/test/index.test.js
+++ b/integrations/google-analytics/test/index.test.js
@@ -2121,7 +2121,8 @@ describe('Google Analytics', function() {
             'ec:setAction',
             'checkout_option',
             {
-              step: 2
+              step: 2,
+              option: undefined
             }
           ]);
           analytics.deepEqual(toArray(window.ga.args[3]), [

--- a/integrations/google-analytics/test/index.test.js
+++ b/integrations/google-analytics/test/index.test.js
@@ -2071,7 +2071,7 @@ describe('Google Analytics', function() {
             currency: 'CAD',
             step: 2,
             paymentMethod: 'Visa',
-            shippingMethod: 'FedEx'
+            shipping_method: 'FedEx'
           });
 
           analytics.assert(window.ga.args.length === 4);
@@ -2105,13 +2105,31 @@ describe('Google Analytics', function() {
           analytics.assert(window.ga.args.length === 0);
         });
 
-        it('should not send checkout step completed data without an option', function() {
+        it('should send checkout step completed data without an option', function() {
           analytics.track('checkout step completed', {
             currency: 'CAD',
             step: 2
           });
 
-          analytics.assert(window.ga.args.length === 0);
+          analytics.assert(window.ga.args.length === 4);
+          analytics.deepEqual(toArray(window.ga.args[1]), [
+            'set',
+            '&cu',
+            'CAD'
+          ]);
+          analytics.deepEqual(toArray(window.ga.args[2]), [
+            'ec:setAction',
+            'checkout_option',
+            {
+              step: 2
+            }
+          ]);
+          analytics.deepEqual(toArray(window.ga.args[3]), [
+            'send',
+            'event',
+            'Checkout',
+            'Option'
+          ]);
         });
 
         it('should send simple order completed data', function() {


### PR DESCRIPTION
**What does this PR do?**
- Makes checkout options optional when sending a `Checkout Step Completed` event
- Supports all property casing types when sending a `Checkout Step Completed` event

**Are there breaking changes in this PR?**
No

**Any background context you want to provide?**
https://segment.atlassian.net/browse/STRATCONN-41

**Is there parity with the server-side/android/iOS integration components (if applicable)?**


**Does this require a new integration setting? If so, please explain how the new setting works**


**Links to helpful docs and other external resources**
