### PR TITLE
[DEST-1852] Bump FullStory to 2.2.3

### DIFF
--- a/integrations/fullstory/HISTORY.md
+++ b/integrations/fullstory/HISTORY.md
@@ -2,6 +2,7 @@
 ==================
 
   * Update fs.js source to CDN at edge.fullstory.com
+  * Update snippet code to latest version
 
 2.2.2 / 2019-11-26
 ==================

--- a/integrations/fullstory/HISTORY.md
+++ b/integrations/fullstory/HISTORY.md
@@ -1,4 +1,4 @@
-2.2.3 / 2019-02-17
+2.2.3 / 2020-02-17
 ==================
 
   * Update fs.js source to CDN at edge.fullstory.com

--- a/integrations/fullstory/HISTORY.md
+++ b/integrations/fullstory/HISTORY.md
@@ -1,3 +1,8 @@
+2.2.3 / 2019-02-17
+==================
+
+  * Update fs.js source to CDN at edge.fullstory.com
+
 2.2.2 / 2019-11-26
 ==================
 

--- a/integrations/fullstory/lib/index.js
+++ b/integrations/fullstory/lib/index.js
@@ -21,7 +21,7 @@ var FullStory = (module.exports = integration('FullStory')
   .option('trackNamedPages', false)
   .option('trackCategorizedPages', false)
   .tag(
-    '<script async src="https://www.fullstory.com/s/fs.js" crossorigin="anonymous"></script>'
+    '<script async src="https://edge.fullstory.com/s/fs.js" crossorigin="anonymous"></script>'
   ));
 
 /**
@@ -36,7 +36,7 @@ var apiSource = 'segment';
  */
 FullStory.prototype.initialize = function() {
   window._fs_debug = this.options.debug;
-  window._fs_host = 'www.fullstory.com';
+  window._fs_host = 'fullstory.com';
   window._fs_org = this.options.org;
   window._fs_namespace = 'FS';
 

--- a/integrations/fullstory/lib/index.js
+++ b/integrations/fullstory/lib/index.js
@@ -52,6 +52,8 @@ FullStory.prototype.initialize = function() {
     g.consent=function(a){g("consent",!arguments.length||a)};
     g.identifyAccount=function(i,v){o='account';v=v||{};v.acctId=i;g(o,v)};
     g.clearUserCookie=function(){};
+    g._w={};y='XMLHttpRequest';g._w[y]=m[y];y='fetch';g._w[y]=m[y];
+    if(m[y])m[y]=function(){return g._w[y].apply(this,arguments)};
   })(window,document,window['_fs_namespace'],'script','user');
   /* eslint-enable */
 

--- a/integrations/fullstory/package.json
+++ b/integrations/fullstory/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-fullstory",
   "description": "The Fullstory analytics.js integration.",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",


### PR DESCRIPTION
**What does this PR do?**
- Jira: https://segment.atlassian.net/browse/DEST-1852
- This PR incorporated partner updates submitted in https://github.com/segmentio/analytics.js-integrations/pull/427#issuecomment-599704778.

**Are there breaking changes in this PR?**
- No, no breaking changes according to FullStory engineer. All unit tests continue to pass, and FullStory can be initialized via Segment and events are sent to FullStory from the browser without any issues when I loaded the integration using my test source.

**Any background context you want to provide?**
- n/a

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
- n/a

**Does this require a new integration setting? If so, please explain how the new setting works**
- No.

**Links to helpful docs and other external resources**
- n/a