### PR TITLE
Order Completed Events "fan-out"

### DIFF
--- a/integrations/vero/lib/index.js
+++ b/integrations/vero/lib/index.js
@@ -127,6 +127,8 @@ Vero.prototype.orderCompleted = function(track) {
   }
 
   push('track', track.event(), track.properties(), { source: 'segment' });
+  var tags = track.options('Vero').tags;
+  if (tags) this.addOrRemoveTags(tags);
 };
 
 /**

--- a/integrations/vero/lib/index.js
+++ b/integrations/vero/lib/index.js
@@ -109,6 +109,27 @@ Vero.prototype.track = function(track) {
 };
 
 /**
+ * Completed Order.
+ *
+ * https://www.getvero.com/api/http/#actions
+ * https://github.com/getvero/vero-api/blob/master/sections/js.md#tracking-events
+ *
+ * @api public
+ * @param {Track} track
+ */
+
+Vero.prototype.orderCompleted = function(track) {
+  var products = track.properties().products;
+  if (products && Array.isArray(products)) {
+    for (var x = 0; x < products.length; x++) {
+      push('track', 'Ordered Product', products[x], { source: 'segment' });
+    }
+  }
+
+  push('track', track.event(), track.properties(), { source: 'segment' });
+};
+
+/**
  * Alias.
  *
  * https://www.getvero.com/api/http/#users

--- a/integrations/vero/lib/index.js
+++ b/integrations/vero/lib/index.js
@@ -109,7 +109,7 @@ Vero.prototype.track = function(track) {
 };
 
 /**
- * Completed Order.
+ * Order Completed.
  *
  * https://www.getvero.com/api/http/#actions
  * https://github.com/getvero/vero-api/blob/master/sections/js.md#tracking-events

--- a/integrations/vero/test/index.test.js
+++ b/integrations/vero/test/index.test.js
@@ -170,6 +170,142 @@ describe('Vero', function() {
         analytics.track('unsubscribe', { id: 'id' });
         analytics.called(window._veroq.push, ['unsubscribe', { id: 'id' }]);
       });
+
+      it('should send order completed', function() {
+        analytics.track('Order Completed', {
+          order_id: '50314b8e9bcf000000000000',
+          total: 30,
+          revenue: 25,
+          shipping: 3,
+          tax: 2,
+          discount: 2.5,
+          coupon: 'foobar',
+          currency: 'USD',
+          products: [
+            {
+              product_id: '507f1f77bcf86cd799439011',
+              sku: '45790-32',
+              name: 'foobarbaz',
+              price: 19,
+              quantity: 1,
+              category: 'foo',
+              productUrl: 'http://www.example.com/path/to/product',
+              imageUrl: 'http://www.example.com/path/to/product/image.png'
+            },
+            {
+              product_id: '505bd76785ebb509fc183733',
+              sku: '46493-32',
+              name: 'barbazqux',
+              price: 17.38,
+              quantity: 2,
+              category: 'bar'
+            }
+          ]
+        });
+        analytics.called(window._veroq.push, [
+          'track',
+          'Order Completed',
+          {
+            order_id: '50314b8e9bcf000000000000',
+            total: 30,
+            revenue: 25,
+            shipping: 3,
+            tax: 2,
+            discount: 2.5,
+            coupon: 'foobar',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '507f1f77bcf86cd799439011',
+                sku: '45790-32',
+                name: 'foobarbaz',
+                price: 19,
+                quantity: 1,
+                category: 'foo',
+                productUrl: 'http://www.example.com/path/to/product',
+                imageUrl: 'http://www.example.com/path/to/product/image.png'
+              },
+              {
+                product_id: '505bd76785ebb509fc183733',
+                sku: '46493-32',
+                name: 'barbazqux',
+                price: 17.38,
+                quantity: 2,
+                category: 'bar'
+              }
+            ]
+          },
+          {
+            source: 'segment'
+          }
+        ]);
+      });
+
+      it('should send ordered product', function() {
+        analytics.track('Order Completed', {
+          order_id: '50314b8e9bcf000000000000',
+          total: 30,
+          revenue: 25,
+          shipping: 3,
+          tax: 2,
+          discount: 2.5,
+          coupon: 'foobar',
+          currency: 'USD',
+          products: [
+            {
+              product_id: '505bd76785ebb509fc183733',
+              sku: '46493-32',
+              name: 'barbazqux',
+              price: 17.38,
+              quantity: 2,
+              category: 'bar'
+            }
+          ]
+        });
+        analytics.calledTwice(window._veroq.push);
+        analytics.called(window._veroq.push, [
+          'track',
+          'Order Completed',
+          {
+            order_id: '50314b8e9bcf000000000000',
+            total: 30,
+            revenue: 25,
+            shipping: 3,
+            tax: 2,
+            discount: 2.5,
+            coupon: 'foobar',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '505bd76785ebb509fc183733',
+                sku: '46493-32',
+                name: 'barbazqux',
+                price: 17.38,
+                quantity: 2,
+                category: 'bar'
+              }
+            ]
+          },
+          {
+            source: 'segment'
+          }
+        ]);
+        analytics.called(window._veroq.push, [
+          'track',
+          'Ordered Product',
+          {
+            product_id: '505bd76785ebb509fc183733',
+            sku: '46493-32',
+            name: 'barbazqux',
+            price: 17.38,
+            quantity: 2,
+            category: 'bar'
+          },
+          {
+            source: 'segment'
+          }
+        ]);
+      });
     });
 
     describe('#alias', function() {

--- a/integrations/vero/test/index.test.js
+++ b/integrations/vero/test/index.test.js
@@ -371,6 +371,46 @@ describe('Vero', function() {
         ]);
       });
 
+      it('should work for Order Completed calls', function() {
+        analytics.track(
+          'Order Completed',
+          {
+            order_id: '50314b8e9bcf000000000000',
+            total: 30,
+            revenue: 25,
+            shipping: 3,
+            tax: 2,
+            discount: 2.5,
+            coupon: 'foobar',
+            currency: 'USD',
+            products: [
+              {
+                product_id: '505bd76785ebb509fc183733',
+                sku: '46493-32',
+                name: 'barbazqux',
+                price: 17.38,
+                quantity: 2,
+                category: 'bar'
+              }
+            ]
+          },
+          {
+            integrations: {
+              Vero: {
+                tags: {
+                  action: 'add',
+                  values: ['yoloer']
+                }
+              }
+            }
+          }
+        );
+        analytics.assert.deepEqual(window._veroq.push.args[2][0], [
+          'tags',
+          { add: ['yoloer'] }
+        ]);
+      });
+
       it('should work for .identify calls', function() {
         analytics.identify(
           'user-id',


### PR DESCRIPTION
In order to make it easier to segment on individual product properties,
order completed events will iterate over the array of products, sending
one Ordered Product event for each product, as well as an Order Completed event.


**What does this PR do?**
Creates parity for web device connection mode with https://github.com/segmentio/analytics-cloud-integrations/pull/64

**Are there breaking changes in this PR?**
No, this PR should only create new events, not change anything else about how events are currently processed.

**Any background context you want to provide?**
https://github.com/segmentio/analytics-cloud-integrations/pull/61

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
This should create parity with the cloud connection mode integration

**Does this require a new integration setting? If so, please explain how the new setting works**
No.