### PR TITLE
[STRATCONN-139] Allow `context` fields to be mapped to Adobe Context Data Variables on Heartbeat Calls

### DIFF
--- a/integrations/adobe-analytics/HISTORY.md
+++ b/integrations/adobe-analytics/HISTORY.md
@@ -1,7 +1,12 @@
+1.15.2 / 2020-02-12
+===================
+
+  * Support sending custom Context Data Variables on `Video Playback Started`, `Video Playback Resumed`, and `Video Content Started` when using Adobe Heartbeat Tracking URL (from context object)
+
 1.15.1 / 2020-02-12
 ===================
 
-  * Support sending custom Context Data Variables on `Video Playback Started`, `Video Playback Resumed`, and `Video Content Started` when using Adobe Heartbeat Tracking URL
+  * Support sending custom Context Data Variables on `Video Playback Started`, `Video Playback Resumed`, and `Video Content Started` when using Adobe Heartbeat Tracking URL (from properties object)
 
 1.14.3 / 2018-06-25
 ===================

--- a/integrations/adobe-analytics/lib/index.js
+++ b/integrations/adobe-analytics/lib/index.js
@@ -1082,6 +1082,7 @@ function createStandardVideoMetadata(track, mediaObj) {
 function createCustomVideoMetadataContext(track, options) {
   var contextData = {};
 
+  //Check properties object for `settings.contextValue` mappings to assign custom metadata
   var properties = extractProperties(trample(track.properties()), options);
   each(function(value, key) {
     if (!key || value === undefined || value === null || value === '') {
@@ -1089,6 +1090,15 @@ function createCustomVideoMetadataContext(track, options) {
     }
     contextData[key] = value;
   }, properties);
+
+  //Check properties object for `settings.contextValue` mappings to assign custom metadata
+  var contextFields = extractProperties(trample(track.context()), options);
+  each(function(value, key) {
+    if (!key || value === undefined || value === null || value === '') {
+      return;
+    }
+    contextData[key] = value;
+  }, contextFields);
   return contextData;
 }
 

--- a/integrations/adobe-analytics/package.json
+++ b/integrations/adobe-analytics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-adobe-analytics",
   "description": "The Adobe Analytics analytics.js integration.",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/adobe-analytics/test/index.test.js
+++ b/integrations/adobe-analytics/test/index.test.js
@@ -47,7 +47,8 @@ describe('Adobe Analytics', function() {
     contextValues: {
       video_genre: 'video_genre',
       video_asset_title: 'video_asset_title',
-      video_series_name: 'video_series_name'
+      video_series_name: 'video_series_name',
+      'page.title': 'page_title'
     },
     customDataPrefix: '',
     timestampOption: 'enabled',
@@ -1180,7 +1181,7 @@ describe('Adobe Analytics', function() {
         );
       });
 
-      it('should allow for custom metdata to sent on Video Playbak S', function() {
+      it.only('should send custom metdata in properties on Video Playback Started', function() {
         analytics.track('Video Playback Started', {
           session_id: sessionId,
           video_genre: 'Reality, Game Show, Music',
@@ -1200,6 +1201,42 @@ describe('Adobe Analytics', function() {
         analytics.assert(
           adobeAnalytics.mediaHeartbeats[sessionId].heartbeat._aaPlugin
             ._videoMetadata.video_series_name === 'The Masked Singer'
+        );
+      });
+
+      it.only('should send custom metdata in properties and context on Video Playback Started', function() {
+        analytics.track(
+          'Video Playback Started',
+          {
+            session_id: sessionId,
+            video_genre: 'Reality, Game Show, Music',
+            video_asset_title: 'Some Kind of Title',
+            video_series_name: 'The Masked Singer'
+          },
+          {
+            context: {
+              page: { title: 'yolo moves most definitely made' }
+            }
+          }
+        );
+
+        analytics.assert(adobeAnalytics.mediaHeartbeats[sessionId]);
+        analytics.assert(
+          adobeAnalytics.mediaHeartbeats[sessionId].heartbeat._aaPlugin
+            ._videoMetadata.video_genre === 'Reality, Game Show, Music'
+        );
+        analytics.assert(
+          adobeAnalytics.mediaHeartbeats[sessionId].heartbeat._aaPlugin
+            ._videoMetadata.video_asset_title === 'Some Kind of Title'
+        );
+        analytics.assert(
+          adobeAnalytics.mediaHeartbeats[sessionId].heartbeat._aaPlugin
+            ._videoMetadata.video_series_name === 'The Masked Singer'
+        );
+
+        analytics.assert(
+          adobeAnalytics.mediaHeartbeats[sessionId].heartbeat._aaPlugin
+            ._videoMetadata.page_title === 'yolo moves most definitely made'
         );
       });
 


### PR DESCRIPTION
**What does this PR do?**
Currently the Adobe Analytics integration only supports mapping context fields to Context Data Variables (from AA dest settings) for non-HB calls (i.e track and page calls). 

Recently implementation was added to support sending Custom Context Metadata on HB calls but current implementation only supported looking in the properties object. This PR adds functionality to look both in properties and context object of the payload when mapping fields to Context Data Variables on HB calls. 

This was a specific request for Fox and will be UAT on their test source:  https://app.segment.com/foxdcg/sources/web_staging/settings/keys

**Are there breaking changes in this PR?**
No. Tested using the Analytics.js-Integration Tester:

Fired event with custom `contextValue` `page.url: page_url`
```
analytics.track('Video Playback Started', {
   ad_enabled: true,
    ad_type: "",
    app_build: "928",
    app_name: "foxnow",
    app_platform: "web",
    app_version: "3.24.1",
    content_asset_ids: "1694135363597",
    content_pod_id: null,
    content_pod_ids: [
      "1"
    ],
    favorites_content_length: 0,
    favorites_content_list: "",
    favorites_personalities_length: 0,
   favorites_personalities_list: "",
    full_screen: false,
    livestream: false,
    load_type: "dynamic",
    page_content_level_1: "delta:web:home",
    page_content_level_2: "delta:web:home:landing",
    page_content_level_3: "delta:web:home:landing",
    page_content_level_4: "delta:web:home:landing",
    page_is_dark_mode: false,
    page_login_state: "logged out",
    page_name: "delta:web:home:landing",
    page_timePartingDay: "wednesday",
    page_timePartingHour: "18:30",
    page_type: "player:collection",
    position: 0,
    primary_business_unit: "fng",
    secondary_business_unit: "fox",
    session_id: "EgjPdftWuJigqO5QSl_iA7ZepIK0x9qQ",
    sound: 90,
    total_length: 210,
    video_ad_supported: false,
    video_affiliate_window: "none",
    video_airplay: false,
    video_asset_category: "clip",
    video_asset_id: "a395d21d580ff033415ac1a0b6efb64d",
    video_asset_title: "The Llama's First Interview Without The Mask",
    video_authorizing_network: "fox",
    video_content_channel: "fox",
    video_content_length: 210,
    video_content_length_format: "short-form",
    video_content_subscription_type: "unlocked",
    video_content_type: "VOD",
    video_cross_device_play: false,
    video_event_show_type: null,
    video_first_air_date: "2020-02-05T23:25:45.000Z",
    video_first_digital_date: "2020-02-05T23:25:45.000Z",
    video_fox_profile: false,
    video_freewheel_id: "1694135363597",
    video_genre: "Reality, Game Show, Music",
    video_is_autoplay: false,
    video_is_continuous: false,
    video_is_fullscreen: false,
    video_is_livestream: false,
    video_is_restart: false,
    video_is_resume: false,
    video_media_type: "video",
    video_network: "fox",
    video_nielsen_clientid: "us-800251",
    video_nielsen_subbrand: "c01",
    video_originator: "fox",
    video_playback_speed: "1",
    video_player: "jw",
    video_player_content_type: null,
    video_player_state: "start",
    video_player_type: "standard player",
    video_primary_business_unit: "fng",
    video_rating: "TV-PG",
    video_screen_layout: "no multiview",
    video_secondary_business_unit: "fox",
    video_series_name: "The Masked Singer",
    video_station_id: "KTVU",
    video_uid: "EgjPdftWuJigqO5QSl_iA7ZepIK0x9qQ",
    video_volume: 90
});
```
Checked network tab to ensure sent as custom context metadata for HB call: 
Request URL: 
```
http://exchangepartnersegment.hb.omtrdc.net/?s:sc:rsid=sgmbrietest&s:sc:tracking_server=exchangepartnersegment.sc.omtrdc.net&h:sc:ssl=0&s:user:mid=26818440373490278332909558828532224283&s:user:id=i2VTJURQprNfqdwjLFPWYx&s:aam:blob=RKhpRz8krg2tLO6pguXWp5olkAcUniQYPHaMWWgdJ3xzPWQmdj0y&l:aam:loc_hint=9&s:sp:ovp=unknown&s:sp:sdk=unknown&s:sp:player_name=jw&s:sp:hb_version=js-2.0.2.123-150f2b&l:sp:hb_api_lvl=4&s:event:sid=1585256905228922440032&s:event:type=start&l:event:duration=0&l:event:playhead=0&l:event:ts=1585256905232&l:event:prev_ts=-1&s:asset:type=main&s:asset:video_id=unknown%20video%20id&s:asset:publisher=B3CB46FC57C6C8F77F000101%40AdobeOrg&l:asset:length=210&s:stream:type=vod&l:stream:bitrate=0&l:stream:fps=0&l:stream:dropped_frames=0&l:stream:startup_time=0&s:meta:page_url=http%3A%2F%2Flocalhost%3A8080%2F&s:meta:a.media.show=no%20a.media.show&s:meta:a.media.season=no%20a.media.season&s:meta:a.media.episode=no%20a.media.episode&s:meta:a.media.asset=no%20a.media.asset&s:meta:a.media.genre=no%20a.media.genre&s:meta:a.media.airDate=no%20a.media.airDate&s:meta:a.media.originator=no%20a.media.originator&s:meta:a.media.network=no%20a.media.network&s:meta:a.media.rating=no%20a.media.rating
```
<img width="371" alt="Screen Shot 2020-03-26 at 2 11 28 PM" src="https://user-images.githubusercontent.com/31782219/77697235-b8c01000-6f6b-11ea-9cee-1a7b881d915e.png">


**Any background context you want to provide?**
N/A

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
This change is a step towards providing full parity across iOS, Android, Web, and Server on how we handle Context Data Variables.

**Does this require a new integration setting? If so, please explain how the new setting works**
No.

**Links to helpful docs and other external resources**
JIRA: https://segment.atlassian.net/browse/STRATCONN-139