### PR TITLE
[STRATCONN-122] Adobe Analytics: Bump SDKs to latest

### DIFF
--- a/integrations/adobe-analytics/HISTORY.md
+++ b/integrations/adobe-analytics/HISTORY.md
@@ -1,3 +1,12 @@
+1.16.0 / 2020-04-06
+===================
+
+  * Update the AppMeasurement, VisitorAPI, and MediaSDK (previously VideoHeartBeat) libraries to be the latest
+  versions:
+    * AppMeasurement - 2.20.0
+    * VisitorAPI.js - 4.4.0
+    * MediaSDK - 2.2.1
+
 1.15.2 / 2020-02-12
 ===================
 

--- a/integrations/adobe-analytics/lib/index.js
+++ b/integrations/adobe-analytics/lib/index.js
@@ -111,11 +111,11 @@ AdobeAnalytics.global('s')
   .sOption('usePlugins', true)
   .tag(
     'default',
-    '<script src="//cdn.segment.build/integrations/omniture/AppMeasurement-2.20.0/appmeasurement.js">'
+    '<script src="//cdn.segment.com/integrations/omniture/AppMeasurement-2.20.0/appmeasurement.js">'
   )
   .tag(
     'heartbeat',
-    '<script src="//cdn.segment.build/integrations/omniture/AppMeasurement-2.20.0/appmeasurement-heartbeat.js">'
+    '<script src="//cdn.segment.com/integrations/omniture/AppMeasurement-2.20.0/appmeasurement-heartbeat.js">'
   );
 
 /**

--- a/integrations/adobe-analytics/lib/index.js
+++ b/integrations/adobe-analytics/lib/index.js
@@ -111,11 +111,11 @@ AdobeAnalytics.global('s')
   .sOption('usePlugins', true)
   .tag(
     'default',
-    '<script src="//cdn.segment.com/integrations/omniture/AppMeasurement-2.5.0/appmeasurement.js">'
+    '<script src="//cdn.segment.build/integrations/omniture/AppMeasurement-2.20.0/appmeasurement.js">'
   )
   .tag(
     'heartbeat',
-    '<script src="//cdn.segment.com/integrations/omniture/AppMeasurement-2.5.0/appmeasurement-heartbeat.js">'
+    '<script src="//cdn.segment.build/integrations/omniture/AppMeasurement-2.20.0/appmeasurement-heartbeat.js">'
   );
 
 /**

--- a/integrations/adobe-analytics/package.json
+++ b/integrations/adobe-analytics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-adobe-analytics",
   "description": "The Adobe Analytics analytics.js integration.",
-  "version": "1.15.2",
+  "version": "1.16.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/adobe-analytics/test/index.test.js
+++ b/integrations/adobe-analytics/test/index.test.js
@@ -1181,7 +1181,7 @@ describe('Adobe Analytics', function() {
         );
       });
 
-      it.only('should send custom metdata in properties on Video Playback Started', function() {
+      it('should send custom metdata in properties on Video Playback Started', function() {
         analytics.track('Video Playback Started', {
           session_id: sessionId,
           video_genre: 'Reality, Game Show, Music',
@@ -1204,7 +1204,7 @@ describe('Adobe Analytics', function() {
         );
       });
 
-      it.only('should send custom metdata in properties and context on Video Playback Started', function() {
+      it('should send custom metdata in properties and context on Video Playback Started', function() {
         analytics.track(
           'Video Playback Started',
           {


### PR DESCRIPTION
**What does this PR do?**
Updates the AppMeasurement, VisitorAPI, and MediaSDK (previously VideoHeartBeat) libraries to be the latest versions:
    * AppMeasurement - 2.20.0
    * VisitorAPI.js - 4.4.0
    * MediaSDK - 2.2.

This will be verified by a customer sometime in the next week or two. Tests will pass once the SDK is uploaded to our production buckets. I've tested this in staging!

⚠️ **Do not release this until the new SDKs are added to our production CDN bucket.** ⚠️ 
The new SDKs have been added to our stage s3 bucket. The folder and objects must be copied over to the production and production backup buckets. You must assume the platform role to do so.

**Are there breaking changes in this PR?**
Negative

**Any background context you want to provide?**
https://segment.atlassian.net/browse/STRATCONN-122

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
N/a

**Does this require a new integration setting? If so, please explain how the new setting works**
N/A

**Links to helpful docs and other external resources**
