### PR TITLE
Update snyk

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -21,8 +21,6 @@ steps:
             - SAUCE_USERNAME
             - SAUCE_ACCESS_KEY
 
-  - wait: ~
-
   - label: ':hammer: Synk Setup'
     plugins:
       - ssh://git@github.com/segmentio/snyk-buildkite-plugin#v1.3.0:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 env:
-  SEGMENT_CONTEXTS: "snyk,aws-credentials,ecr,saucelabs,npm-publish"
+  SEGMENT_CONTEXTS: 'snyk,aws-credentials,ecr,saucelabs,npm-publish'
 steps:
-  - label: ":hammer: Build and Test"
+  - label: ':hammer: Build and Test'
     command:
       - npm config set "//registry.npmjs.org/:_authToken" $${NPM_TOKEN}
       - yarn install --frozen-lockfile
@@ -11,8 +11,8 @@ steps:
     plugins:
       - ssh://git@github.com/segmentio/cache-buildkite-plugin#v1.0.0:
           key: "v1-cache-dev-{{ checksum 'yarn.lock' }}"
-          paths: ["node_modules/"]
-          s3_bucket_name: "segment-buildkite-cache"
+          paths: ['node_modules/']
+          s3_bucket_name: 'segment-buildkite-cache'
       - docker#v3.3.0:
           image: 528451384384.dkr.ecr.us-west-2.amazonaws.com/analytics.js-integrations-ci
           user: root
@@ -23,17 +23,16 @@ steps:
 
   - wait: ~
 
-  - label: ":hammer: Synk Setup"
+  - label: ':hammer: Synk Setup'
     plugins:
-      - ssh://git@github.com/segmentio/cache-buildkite-plugin#v1.0.0:
-          key: "v1-cache-dev-{{ checksum 'yarn.lock' }}"
-          paths: ["node_modules/"]
-      - ssh://git@github.com/segmentio/snyk-buildkite-plugin#v1.0.0:
+      - ssh://git@github.com/segmentio/snyk-buildkite-plugin#v1.3.0:
           runtime: npm
+          fail-on: upgradable
+          severity-threshold: high
 
   - wait: ~
 
-  - label: ":cloud: Publish"
+  - label: ':cloud: Publish'
     branches: master
     commands:
       - npm config set "//registry.npmjs.org/:_authToken" $${NPM_TOKEN}
@@ -41,7 +40,7 @@ steps:
     plugins:
       - ssh://git@github.com/segmentio/cache-buildkite-plugin#v1.0.0:
           key: "v1-cache-dev-{{ checksum 'yarn.lock' }}"
-          paths: ["node_modules/"]
+          paths: ['node_modules/']
       - docker#v3.3.0:
           image: 528451384384.dkr.ecr.us-west-2.amazonaws.com/analytics.js-integrations-ci
           user: root

--- a/yarn.lock
+++ b/yarn.lock
@@ -1431,10 +1431,10 @@
     component-cookie "^1.1.2"
     component-url "^0.2.1"
 
-"@segment/tracktor@0.8.1":
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/@segment/tracktor/-/tracktor-0.8.1.tgz#548a13e73087cbbf6f692e49389b70fad07a95be"
-  integrity sha512-0k3fOGyx6RexCgE9adYBYBoAXJUndGsIpPiVLDOewnZ0xnoR8ZL0aDr7Z5pz/bcVGR5RhjEm5aslWNNOSM6EhA==
+"@segment/tracktor@0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@segment/tracktor/-/tracktor-0.12.0.tgz#2df0a1f8dad87e13ca4afac51655d6bac7c0c95f"
+  integrity sha512-yOGcYD33y0Wo1qHIA+IFIHcxk0GoRrQwCjpuaKZf2rnz0puZoseSGPdbIX47BgMLSSgEYnBoW3s5aUpCRdkEkw==
   dependencies:
     element-matches-polyfill "^1.0.0"
     whatwg-fetch "^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1431,10 +1431,10 @@
     component-cookie "^1.1.2"
     component-url "^0.2.1"
 
-"@segment/tracktor@0.12.0":
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/@segment/tracktor/-/tracktor-0.12.0.tgz#2df0a1f8dad87e13ca4afac51655d6bac7c0c95f"
-  integrity sha512-yOGcYD33y0Wo1qHIA+IFIHcxk0GoRrQwCjpuaKZf2rnz0puZoseSGPdbIX47BgMLSSgEYnBoW3s5aUpCRdkEkw==
+"@segment/tracktor@0.8.1":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@segment/tracktor/-/tracktor-0.8.1.tgz#548a13e73087cbbf6f692e49389b70fad07a95be"
+  integrity sha512-0k3fOGyx6RexCgE9adYBYBoAXJUndGsIpPiVLDOewnZ0xnoR8ZL0aDr7Z5pz/bcVGR5RhjEm5aslWNNOSM6EhA==
   dependencies:
     element-matches-polyfill "^1.0.0"
     whatwg-fetch "^3.0.0"


### PR DESCRIPTION
**What does this PR do?**
Updates the BuildKite Snyk plugin to the latest version and sets it to fail when there is a high finding with an upgrade available. Also removes `wait` step between build and Snyk, Snyk just needs a `.lock` file for Node projects, it doesn't need the installed deps :) This should speed things up a bit!

More info can be found here: https://github.com/segmentio/snyk-buildkite-plugin

There were a bunch of spacing/quotes changes made by `prettier`, I commented on the changes I actually made

**Are there breaking changes in this PR?**
Nope

**Any background context you want to provide?**
This is related to the recent email I sent

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
N/A

**Does this require a new integration setting? If so, please explain how the new setting works**
No

**Links to helpful docs and other external resources**
N/A