### PR TITLE
[STRATCONN-14] DC Floodlight Pass Top Level UserId on Conversion Event

### DIFF
--- a/integrations/doubleclick-floodlight/HISTORY.md
+++ b/integrations/doubleclick-floodlight/HISTORY.md
@@ -1,9 +1,10 @@
 1.5.1 / 2020-04-16
 ==================
 
-  * Adds support for top level `{{userId}}` proprety to be used as Custom Variable on Conversion Events. 
+  * Adds support for top level `{{userId}}` proprety to be used as Custom Variable on Conversion Events.
   * Adds support for nested products propreties (ie. `products.$.price`) to be mapped in as a comma separated array on Conversion Events.
-  
+  * Adds support to use Transaction Method instead of Items Sold for `qty` if `useTransactionCounting` setting is enabled. 
+
 1.5.0 / 2019-12-05
 ==================
 

--- a/integrations/doubleclick-floodlight/HISTORY.md
+++ b/integrations/doubleclick-floodlight/HISTORY.md
@@ -1,3 +1,9 @@
+1.5.1 / 2020-04-16
+==================
+
+  * Adds support for top level `{{userId}}` proprety to be used as Custom Variable on Conversion Events. 
+  * Adds support for nested products propreties (ie. `products.$.price`) to be mapped in as a comma separated array on Conversion Events.
+  
 1.5.0 / 2019-12-05
 ==================
 

--- a/integrations/doubleclick-floodlight/lib/index.js
+++ b/integrations/doubleclick-floodlight/lib/index.js
@@ -80,6 +80,7 @@ Floodlight.prototype.track = function(track) {
       mappedEvents.push(item);
     }
   }
+
   var settings = this.options;
 
   // Must have events mapped and DoubleClick Advertiser ID
@@ -105,7 +106,11 @@ Floodlight.prototype.track = function(track) {
 
         if (Array.isArray(segmentProp)) {
           segmentProp = segmentProp.pop();
-          segmentPropValue = find(track.json(), segmentProp);
+          if (segmentProp === 'userId') {
+            segmentPropValue = self.analytics.user().id();
+          } else {
+            segmentPropValue = find(track.json(), segmentProp);
+          }
         } else {
           segmentPropValue = properties[segmentProp];
         }

--- a/integrations/doubleclick-floodlight/lib/index.js
+++ b/integrations/doubleclick-floodlight/lib/index.js
@@ -20,6 +20,7 @@ var Floodlight = (module.exports = integration('DoubleClick Floodlight')
   .option('getDoubleClickId', false)
   .option('googleNetworkId', '')
   .option('segmentWriteKey', '')
+  .option('useTransactionCounting', false)
   .tag(
     'counter',
     '<iframe src="https://{{ src }}.fls.doubleclick.net/activityi;src={{ src }};type={{ type }};cat={{ cat }};dc_lat=;dc_rdid=;tag_for_child_directed_treatment=;ord={{ ord }}{{ customVariables }}?">'
@@ -159,6 +160,8 @@ Floodlight.prototype.track = function(track) {
           quantity = properties.quantity;
         }
         if (quantity) tagParams.qty = quantity;
+        // overwrite qty param with 1 if customer is using Trasaction Counting mehtod instead of Items Sold method
+        if (settings.useTransactionCounting) tagParams.qty = 1;
         // doubleclick wants revenue under this cost param, yes
         if (track.revenue()) tagParams.cost = track.revenue();
         tagParams.ord = track.proxy(tag.ordKey);

--- a/integrations/doubleclick-floodlight/lib/index.js
+++ b/integrations/doubleclick-floodlight/lib/index.js
@@ -115,7 +115,7 @@ Floodlight.prototype.track = function(track) {
               productPropArray.push(product[segmentProp]);
             }
           }, track.products());
-          segmentPropValue = productPropArray;
+          segmentPropValue = productPropArray.join(',');
         } else if (Array.isArray(segmentProp)) {
           segmentProp = segmentProp.pop();
           if (segmentProp === 'userId') {

--- a/integrations/doubleclick-floodlight/lib/index.js
+++ b/integrations/doubleclick-floodlight/lib/index.js
@@ -102,9 +102,21 @@ Floodlight.prototype.track = function(track) {
       each(function(variable) {
         var floodlightProp = variable.value;
         var segmentProp = variable.key.match(/{{(.*)}}/) || variable.key;
-        var segmentPropValue;
+        if (variable.key.includes('$')) {
+          segmentProp = variable.key.split('.$.');
+        }
 
-        if (Array.isArray(segmentProp)) {
+        var segmentPropValue;
+        if (Array.isArray(segmentProp) && segmentProp[0] === 'products') {
+          segmentProp = segmentProp.pop();
+          var productPropArray = [];
+          each(function(product) {
+            if (product[segmentProp]) {
+              productPropArray.push(product[segmentProp]);
+            }
+          }, track.products());
+          segmentPropValue = productPropArray;
+        } else if (Array.isArray(segmentProp)) {
           segmentProp = segmentProp.pop();
           if (segmentProp === 'userId') {
             segmentPropValue = self.analytics.user().id();

--- a/integrations/doubleclick-floodlight/package.json
+++ b/integrations/doubleclick-floodlight/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-doubleclick-floodlight",
   "description": "The DoubleClick Floodlight analytics.js integration.",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/doubleclick-floodlight/test/index.test.js
+++ b/integrations/doubleclick-floodlight/test/index.test.js
@@ -265,7 +265,7 @@ describe('DoubleClick Floodlight', function() {
         analytics.loaded(iframe);
       });
 
-      it('should fire a basic floodlight sales tag properly', function() {
+      it('should fire a floodlight sales tag properly with top level userId when identify previously triggered', function() {
         floodlight.options.events[3] = {
           key: 'Order Completed',
           value: {
@@ -328,6 +328,76 @@ describe('DoubleClick Floodlight', function() {
           properties.revenue +
           ';dc_lat=;dc_rdid=;tag_for_child_directed_treatment=' +
           ';ord=50314b8e9bcf000000000000;u8=some_previous_userId?">';
+
+        analytics.identify('some_previous_userId');
+        analytics.track('Order Completed', properties);
+        analytics.called(floodlight.load);
+        analytics.loaded(iframe);
+      });
+
+      it('should fire a floodlight sales tag properly with product information', function() {
+        floodlight.options.events[3] = {
+          key: 'Order Completed',
+          value: {
+            event: 'Order Completed',
+            cat: 'activityTag',
+            type: 'groupTag',
+            customVariable: [
+              {
+                key: 'products.$.category',
+                value: 'u8'
+              }
+            ],
+            isSalesTag: true,
+            ordKey: 'orderId'
+          }
+        };
+        var properties = {
+          checkout_id: 'fksdjfsdjfisjf9sdfjsd9f',
+          order_id: '50314b8e9bcf000000000000',
+          affiliation: 'Google Store',
+          total: 30,
+          revenue: 25,
+          shipping: 3,
+          tax: 2,
+          discount: 2.5,
+          coupon: 'hasbros',
+          currency: 'USD',
+          products: [
+            {
+              product_id: '507f1f77bcf86cd799439011',
+              sku: '45790-32',
+              name: 'Monopoly: 3rd Edition',
+              price: 19,
+              quantity: 1,
+              category: 'Games'
+            },
+            {
+              product_id: '505bd76785ebb509fc183733',
+              sku: '46493-32',
+              name: 'Uno Card Game',
+              price: 3,
+              quantity: 2,
+              category: 'Games'
+            }
+          ]
+        };
+        var iframe =
+          '<iframe src="https://' +
+          options.source +
+          '.fls.doubleclick.net/activityi' +
+          ';src=' +
+          options.source +
+          ';type=' +
+          options.events[1].value.type +
+          ';cat=' +
+          options.events[1].value.cat +
+          ';qty=' +
+          3 +
+          ';cost=' +
+          properties.revenue +
+          ';dc_lat=;dc_rdid=;tag_for_child_directed_treatment=' +
+          ';ord=50314b8e9bcf000000000000;u8%5B0%5D=Games;u8%5B1%5D=Games?">';
 
         analytics.identify('some_previous_userId');
         analytics.track('Order Completed', properties);

--- a/integrations/doubleclick-floodlight/test/index.test.js
+++ b/integrations/doubleclick-floodlight/test/index.test.js
@@ -265,6 +265,60 @@ describe('DoubleClick Floodlight', function() {
         analytics.loaded(iframe);
       });
 
+      it('should fire a floodlight sales tag properly with qty default to 1 when useTransactionCounting', function() {
+        floodlight.options.useTransactionCounting = true;
+        var properties = {
+          checkout_id: 'fksdjfsdjfisjf9sdfjsd9f',
+          order_id: '50314b8e9bcf000000000000',
+          affiliation: 'Google Store',
+          total: 30,
+          revenue: 25,
+          shipping: 3,
+          tax: 2,
+          discount: 2.5,
+          coupon: 'hasbros',
+          currency: 'USD',
+          products: [
+            {
+              product_id: '507f1f77bcf86cd799439011',
+              sku: '45790-32',
+              name: 'Monopoly: 3rd Edition',
+              price: 19,
+              quantity: 1,
+              category: 'Games'
+            },
+            {
+              product_id: '505bd76785ebb509fc183733',
+              sku: '46493-32',
+              name: 'Uno Card Game',
+              price: 3,
+              quantity: 2,
+              category: 'Games'
+            }
+          ]
+        };
+        var iframe =
+          '<iframe src="https://' +
+          options.source +
+          '.fls.doubleclick.net/activityi' +
+          ';src=' +
+          options.source +
+          ';type=' +
+          options.events[1].value.type +
+          ';cat=' +
+          options.events[1].value.cat +
+          ';qty=' +
+          1 +
+          ';cost=' +
+          properties.revenue +
+          ';dc_lat=;dc_rdid=;tag_for_child_directed_treatment=' +
+          ';ord=50314b8e9bcf000000000000?">';
+
+        analytics.track('Order Completed', properties);
+        analytics.called(floodlight.load);
+        analytics.loaded(iframe);
+      });
+
       it('should fire a floodlight sales tag properly with top level userId when identify previously triggered', function() {
         floodlight.options.events[3] = {
           key: 'Order Completed',

--- a/integrations/doubleclick-floodlight/test/index.test.js
+++ b/integrations/doubleclick-floodlight/test/index.test.js
@@ -397,7 +397,7 @@ describe('DoubleClick Floodlight', function() {
           ';cost=' +
           properties.revenue +
           ';dc_lat=;dc_rdid=;tag_for_child_directed_treatment=' +
-          ';ord=50314b8e9bcf000000000000;u8%5B0%5D=Games;u8%5B1%5D=Games?">';
+          ';ord=50314b8e9bcf000000000000;u8=Games%2CGames?">';
 
         analytics.identify('some_previous_userId');
         analytics.track('Order Completed', properties);

--- a/integrations/doubleclick-floodlight/test/index.test.js
+++ b/integrations/doubleclick-floodlight/test/index.test.js
@@ -265,6 +265,76 @@ describe('DoubleClick Floodlight', function() {
         analytics.loaded(iframe);
       });
 
+      it('should fire a basic floodlight sales tag properly', function() {
+        floodlight.options.events[3] = {
+          key: 'Order Completed',
+          value: {
+            event: 'Order Completed',
+            cat: 'activityTag',
+            type: 'groupTag',
+            customVariable: [
+              {
+                key: '{{userId}}',
+                value: 'u8'
+              }
+            ],
+            isSalesTag: true,
+            ordKey: 'orderId'
+          }
+        };
+        var properties = {
+          checkout_id: 'fksdjfsdjfisjf9sdfjsd9f',
+          order_id: '50314b8e9bcf000000000000',
+          affiliation: 'Google Store',
+          total: 30,
+          revenue: 25,
+          shipping: 3,
+          tax: 2,
+          discount: 2.5,
+          coupon: 'hasbros',
+          currency: 'USD',
+          products: [
+            {
+              product_id: '507f1f77bcf86cd799439011',
+              sku: '45790-32',
+              name: 'Monopoly: 3rd Edition',
+              price: 19,
+              quantity: 1,
+              category: 'Games'
+            },
+            {
+              product_id: '505bd76785ebb509fc183733',
+              sku: '46493-32',
+              name: 'Uno Card Game',
+              price: 3,
+              quantity: 2,
+              category: 'Games'
+            }
+          ]
+        };
+        var iframe =
+          '<iframe src="https://' +
+          options.source +
+          '.fls.doubleclick.net/activityi' +
+          ';src=' +
+          options.source +
+          ';type=' +
+          options.events[1].value.type +
+          ';cat=' +
+          options.events[1].value.cat +
+          ';qty=' +
+          3 +
+          ';cost=' +
+          properties.revenue +
+          ';dc_lat=;dc_rdid=;tag_for_child_directed_treatment=' +
+          ';ord=50314b8e9bcf000000000000;u8=some_previous_userId?">';
+
+        analytics.identify('some_previous_userId');
+        analytics.track('Order Completed', properties);
+        analytics.called(floodlight.load);
+        analytics.loaded(iframe);
+      });
+
       it('should handle property lookups as custom variable keys', function() {
         var event = options.events[4];
         var context = { campaign: { name: 'campaignName' } };


### PR DESCRIPTION
JIRA: https://segment.atlassian.net/browse/STRATCONN-14
JIRA: https://segment.atlassian.net/browse/STRATCONN-12
JIRA: https://segment.atlassian.net/browse/STRATCONN-86
CC: https://segment.atlassian.net/browse/CC-6331

**What does this PR do?**
**STRATCONN-14**
Currently users are reporting that when they fire an `identify()` event for a user, on subsequent `track()` calls that top level `userId()` is not being sent to DC Floodlight, only the `userId()` nested in properties within the `track()` call itself is being sent. 

This PR adds functionality specifically for `userId`, where if the segmentProp from settings is `{{userId}}` indicating the customer wants to use the top level `userId()` (which would only be present if the customer fired an identify event on the window), then check `self.analytics.user().id()`, otherwise proceed with existing functionality. 

**NOTE** this change is specific for calls where an `identify()` call was previously made and the `userId()` is stored on the analytics object **AND** the customer wants to map the top level `userId()` field as seen from their Segment debugger (which is the `userId()` on the analytics object). 

**STRATCONN-12**
Adds support for products array Custom Variables. Customer confirmed that DCF would expect the products array to pass through as a comma separated array. For example, say you whitelisted products.$.sku  to the custom Floodlight variable u1​ and passed a call like the one below:
```
analytics.track('Checkout Started', {
sku: '1324abcd',
products: [ { sku: 'sku1' } , { sku: 'sku2' } , { sku: 'sku3' } ]
});
```
DCF would expect the the u1​ parameter to be set as a comma-separated array (example:  `[sku1,sku2,sku3]`​).

**STRATCONN-86**
DCF supports two methods of counting: Items Sold and Transaction based. Currently our DCF Integration only supports Items Sold. Current implementation sets tagParams.qty by # of products in products array, falling back to checking for an actual property called quantity.

For this new change we will implement a new setting useTransactionCounting that will default to false as to not cause any regressions for current customers. When this setting is enabled, and the event is a Sales Tag, we will always default to set to tagParams.qty to 1 per the Transaction counting method.

**Are there breaking changes in this PR?**
No, this was you cans see changes validated below: 
<img width="1182" alt="Screen Shot 2020-04-16 at 12 01 14 PM" src="https://user-images.githubusercontent.com/31782219/79498553-5bedcd80-7fde-11ea-8bd9-46949f54ecaa.png">


**Any background context you want to provide?**
N/A

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
N/A

**Does this require a new integration setting? If so, please explain how the new setting works**
No

**Links to helpful docs and other external resources**
N/A
