### PR TITLE
Gtag.js Follow-ups

### DIFF
--- a/integrations/gtag/lib/index.js
+++ b/integrations/gtag/lib/index.js
@@ -745,7 +745,8 @@ function setCustomDimensionsAndMetrics(msg, options) {
  * https://support.google.com/analytics/answer/7475939?hl=en#code
  *
  * @api private
- * @param {Track} track
+ * @param {Facade} msg
+ * @param {Object} opts
  */
 function setContentGroups(msg, opts) {
   if (opts.gaContentGroupings && Object.keys(opts.gaContentGroupings).length) {

--- a/integrations/gtag/lib/index.js
+++ b/integrations/gtag/lib/index.js
@@ -23,7 +23,6 @@ var GTAG = (module.exports = integration('Gtag')
   .option('gaWebAppMeasurementId', '')
   .option('awConversionId', '')
   .option('dcFloodLightId', '')
-  .option('trackAllPages', false)
   .option('trackNamedPages', true)
   .option('trackCategorizedPages', true)
   .option('gaOptions', {
@@ -678,14 +677,14 @@ function trackPageViewEvent(page, options) {
   if (options.includeSearch && props.search) {
     str += props.search;
   }
-  if (options.trackAllPages) {
-    push('event', 'page_view', {
-      page_title: name || category,
-      page_location: props.url,
-      page_path: str,
-      non_interaction: nonInteraction
-    });
-  }
+
+  push('event', 'page_view', {
+    page_title: name || category,
+    page_location: props.url,
+    page_path: str,
+    non_interaction: nonInteraction
+  });
+
   if (name && options.trackNamedPages) {
     push('event', 'page_view', {
       page_title: name,

--- a/integrations/gtag/lib/index.js
+++ b/integrations/gtag/lib/index.js
@@ -106,10 +106,23 @@ GTAG.prototype.initialize = function() {
     // set custom dimension and metrics if present
     // To Set persistent values we need to use set instead of config
     // https://developers.google.com/analytics/devguides/collection/gtagjs/setting-values
-    gaSetting.custom_map = merge(
+    var customMap = merge(
       this.options.gaCustomDimensions || {},
       this.options.gaCustomMetrics || {}
     );
+
+    // The dimension and metric mappings are stored as objects where the key is the
+    // event field and the value is the dimension or metric so we swap them!
+    // e.g.; { 'properties.age': 'dimension1' }
+    //
+    var customMapSwap = {};
+    for (var field in customMap) {
+      if (customMap.hasOwnProperty(field)) {
+        customMapSwap[customMap[field]] = field;
+      }
+    }
+
+    gaSetting.custom_map = customMapSwap;
 
     // https://developers.google.com/analytics/devguides/collection/gtagjs/ip-anonymization
     if (this.options.gaAnonymizeIp) {
@@ -218,8 +231,8 @@ GTAG.prototype.identify = function(identify) {
     });
   }
 
-  setContentGroups(identify, opts);
-  setCustomDimensionsAndMetrics(identify, opts);
+  setContentGroups(identify.traits(), opts);
+  setCustomDimensionsAndMetrics(identify.traits(), opts);
 };
 
 /**
@@ -243,8 +256,8 @@ GTAG.prototype.track = function(track, params) {
   var props = track.properties();
   props.event = event;
 
-  setContentGroups(track, this.options);
-  setCustomDimensionsAndMetrics(track, this.options);
+  setContentGroups(track.properties(), this.options);
+  setCustomDimensionsAndMetrics(track.properties(), this.options);
 
   props.non_interaction =
     props.nonInteraction !== undefined
@@ -264,8 +277,8 @@ GTAG.prototype.track = function(track, params) {
  */
 
 GTAG.prototype.page = function(page) {
-  setContentGroups(page, this.options);
-  setCustomDimensionsAndMetrics(page, this.options);
+  setContentGroups(page.properties(), this.options);
+  setCustomDimensionsAndMetrics(page.properties(), this.options);
   this.trackPageViewEvent(page, this.options);
 };
 
@@ -276,8 +289,8 @@ GTAG.prototype.page = function(page) {
  */
 
 GTAG.prototype.productListViewedEnhanced = function(track) {
-  setContentGroups(track, this.options);
-  setCustomDimensionsAndMetrics(track, this.options);
+  setContentGroups(track.properties(), this.options);
+  setCustomDimensionsAndMetrics(track.properties(), this.options);
 
   trackEnhancedEvent('view_item_list', {
     items: getFormattedProductList(track)
@@ -291,8 +304,8 @@ GTAG.prototype.productListViewedEnhanced = function(track) {
  */
 
 GTAG.prototype.productClickedEnhanced = function(track) {
-  setContentGroups(track, this.options);
-  setCustomDimensionsAndMetrics(track, this.options);
+  setContentGroups(track.properties(), this.options);
+  setCustomDimensionsAndMetrics(track.properties(), this.options);
 
   trackEnhancedEvent('select_content', {
     content_type: 'product',
@@ -307,8 +320,8 @@ GTAG.prototype.productClickedEnhanced = function(track) {
  */
 
 GTAG.prototype.productViewedEnhanced = function(track) {
-  setContentGroups(track, this.options);
-  setCustomDimensionsAndMetrics(track, this.options);
+  setContentGroups(track.properties(), this.options);
+  setCustomDimensionsAndMetrics(track.properties(), this.options);
 
   trackEnhancedEvent('view_item', {
     items: [getFormattedProduct(track)]
@@ -322,8 +335,8 @@ GTAG.prototype.productViewedEnhanced = function(track) {
  */
 
 GTAG.prototype.productAddedEnhanced = function(track) {
-  setContentGroups(track, this.options);
-  setCustomDimensionsAndMetrics(track, this.options);
+  setContentGroups(track.properties(), this.options);
+  setCustomDimensionsAndMetrics(track.properties(), this.options);
 
   trackEnhancedEvent('add_to_cart', {
     items: [getFormattedProduct(track)]
@@ -337,8 +350,8 @@ GTAG.prototype.productAddedEnhanced = function(track) {
  */
 
 GTAG.prototype.productRemovedEnhanced = function(track) {
-  setContentGroups(track, this.options);
-  setCustomDimensionsAndMetrics(track, this.options);
+  setContentGroups(track.properties(), this.options);
+  setCustomDimensionsAndMetrics(track.properties(), this.options);
 
   trackEnhancedEvent('remove_from_cart', {
     items: [getFormattedProduct(track)]
@@ -352,8 +365,8 @@ GTAG.prototype.productRemovedEnhanced = function(track) {
  */
 
 GTAG.prototype.promotionViewedEnhanced = function(track) {
-  setContentGroups(track, this.options);
-  setCustomDimensionsAndMetrics(track, this.options);
+  setContentGroups(track.properties(), this.options);
+  setCustomDimensionsAndMetrics(track.properties(), this.options);
 
   trackEnhancedEvent('view_promotion', {
     promotions: [getFormattedPromotion(track)]
@@ -367,8 +380,8 @@ GTAG.prototype.promotionViewedEnhanced = function(track) {
  */
 
 GTAG.prototype.promotionClickedEnhanced = function(track) {
-  setContentGroups(track, this.options);
-  setCustomDimensionsAndMetrics(track, this.options);
+  setContentGroups(track.properties(), this.options);
+  setCustomDimensionsAndMetrics(track.properties(), this.options);
 
   trackEnhancedEvent('select_content', {
     promotions: [getFormattedPromotion(track)]
@@ -382,8 +395,8 @@ GTAG.prototype.promotionClickedEnhanced = function(track) {
  */
 
 GTAG.prototype.checkoutStartedEnhanced = function(track) {
-  setContentGroups(track, this.options);
-  setCustomDimensionsAndMetrics(track, this.options);
+  setContentGroups(track.properties(), this.options);
+  setCustomDimensionsAndMetrics(track.properties(), this.options);
 
   var coupon = track.coupon();
 
@@ -413,8 +426,8 @@ GTAG.prototype.orderUpdatedEnhanced = function(track) {
  */
 
 GTAG.prototype.checkoutStepViewedEnhanced = function(track) {
-  setContentGroups(track, this.options);
-  setCustomDimensionsAndMetrics(track, this.options);
+  setContentGroups(track.properties(), this.options);
+  setCustomDimensionsAndMetrics(track.properties(), this.options);
 
   trackEnhancedEvent('checkout_progress', extractCheckoutOptions(track));
 };
@@ -426,8 +439,8 @@ GTAG.prototype.checkoutStepViewedEnhanced = function(track) {
  */
 
 GTAG.prototype.checkoutStepCompletedEnhanced = function(track) {
-  setContentGroups(track, this.options);
-  setCustomDimensionsAndMetrics(track, this.options);
+  setContentGroups(track.properties(), this.options);
+  setCustomDimensionsAndMetrics(track.properties(), this.options);
 
   trackEnhancedEvent('checkout_progress', extractCheckoutOptions(track));
 };
@@ -470,8 +483,8 @@ GTAG.prototype.orderRefundedEnhanced = function(track) {
     eventData.items = getFormattedProductList(track);
   }
 
-  setContentGroups(track, this.options);
-  setCustomDimensionsAndMetrics(track, this.options);
+  setContentGroups(track.properties(), this.options);
+  setCustomDimensionsAndMetrics(track.properties(), this.options);
 
   trackEnhancedEvent('refund', eventData);
 };
@@ -487,8 +500,8 @@ GTAG.prototype.orderCompletedEnhanced = function(track) {
   var orderId = track.orderId();
   var props = track.properties();
 
-  setContentGroups(track, this.options);
-  setCustomDimensionsAndMetrics(track, this.options);
+  setContentGroups(track.properties(), this.options);
+  setCustomDimensionsAndMetrics(track.properties(), this.options);
 
   trackEnhancedEvent('purchase', {
     transaction_id: orderId,
@@ -508,8 +521,8 @@ GTAG.prototype.orderCompletedEnhanced = function(track) {
  */
 
 GTAG.prototype.productAddedToWishlistEnhanced = function(track) {
-  setContentGroups(track, this.options);
-  setCustomDimensionsAndMetrics(track, this.options);
+  setContentGroups(track.properties(), this.options);
+  setCustomDimensionsAndMetrics(track.properties(), this.options);
 
   trackEnhancedEvent('add_to_wishlist', {
     value: track.price(),
@@ -531,8 +544,8 @@ GTAG.prototype.productSharedEnhanced = function(track) {
     return;
   }
 
-  setContentGroups(track, this.options);
-  setCustomDimensionsAndMetrics(track, this.options);
+  setContentGroups(track.properties(), this.options);
+  setCustomDimensionsAndMetrics(track.properties(), this.options);
 
   trackEnhancedEvent('share', {
     method: props.share_via,
@@ -554,8 +567,8 @@ GTAG.prototype.productsSearchedEnhanced = function(track) {
     return;
   }
 
-  setContentGroups(track, this.options);
-  setCustomDimensionsAndMetrics(track, this.options);
+  setContentGroups(track.properties(), this.options);
+  setCustomDimensionsAndMetrics(track.properties(), this.options);
 
   trackEnhancedEvent('search', {
     search_term: searchQuery
@@ -708,10 +721,11 @@ function trackEnhancedEvent(eventName, payload) {
  * Set custom dimensions and metrics.
  *
  * @api private
- * @param options
+ * @param {Object} props
+ * @param {Object} options
  */
 
-function setCustomDimensionsAndMetrics(msg, options) {
+function setCustomDimensionsAndMetrics(props, options) {
   if (options.gaSetAllMappedProps) {
     // set custom dimension and metrics if present
     // REF: https://developers.google.com/analytics/devguides/collection/gtagjs/custom-dims-mets
@@ -724,7 +738,7 @@ function setCustomDimensionsAndMetrics(msg, options) {
     var customMapValues = {};
     for (var field in customMap) {
       if (customMap.hasOwnProperty(field)) {
-        customMapValues[customMap[field]] = msg.proxy(field);
+        customMapValues[customMap[field]] = props[field];
       }
     }
     if (options.gaWebMeasurementId) {
@@ -745,15 +759,15 @@ function setCustomDimensionsAndMetrics(msg, options) {
  * https://support.google.com/analytics/answer/7475939?hl=en#code
  *
  * @api private
- * @param {Facade} msg
+ * @param {Object} props
  * @param {Object} opts
  */
-function setContentGroups(msg, opts) {
+function setContentGroups(props, opts) {
   if (opts.gaContentGroupings && Object.keys(opts.gaContentGroupings).length) {
     var contentGroupValues = {};
     for (var field in opts.gaContentGroupings) {
       if (opts.gaContentGroupings.hasOwnProperty(field)) {
-        contentGroupValues[opts.gaContentGroupings[field]] = msg.proxy(field);
+        contentGroupValues[opts.gaContentGroupings[field]] = props[field];
       }
     }
 

--- a/integrations/gtag/lib/index.js
+++ b/integrations/gtag/lib/index.js
@@ -5,7 +5,6 @@
  */
 
 var integration = require('@segment/analytics.js-integration');
-var push = require('global-queue')('gtagDataLayer', { wrap: false });
 var Track = require('segmentio-facade').Track;
 var reject = require('reject');
 var defaults = require('@ndhoule/defaults');
@@ -89,6 +88,11 @@ GTAG.on('construct', function(Integration) {
  */
 
 GTAG.prototype.initialize = function() {
+  window.gtagDataLayer = window.gtagDataLayer || [];
+  window.gtag = function() {
+    window.gtagDataLayer.push(arguments);
+  };
+
   var config = [];
   var that = this;
   var gaWebMeasurementId = this.options.gaWebMeasurementId;
@@ -188,7 +192,7 @@ GTAG.prototype.initialize = function() {
   this.load({ accountId: accountId }, function() {
     // Default routing.
     for (var i = 0; i < config.length; i++) {
-      push(config[i][0], config[i][1], config[i][2]);
+      window.gtag(config[i][0], config[i][1], config[i][2]);
     }
     that.ready();
   });
@@ -221,12 +225,12 @@ GTAG.prototype.identify = function(identify) {
     return;
   }
   if (opts.gaWebMeasurementId) {
-    push('config', opts.gaWebMeasurementId, {
+    window.gtag('config', opts.gaWebMeasurementId, {
       user_id: userId
     });
   }
   if (opts.gaWebAppMeasurementId) {
-    push('config', opts.gaWebAppMeasurementId, {
+    window.gtag('config', opts.gaWebAppMeasurementId, {
       user_id: userId
     });
   }
@@ -266,7 +270,7 @@ GTAG.prototype.track = function(track, params) {
 
   delete props.nonInteraction;
 
-  push('event', props.event, props);
+  window.gtag('event', props.event, props);
 };
 
 /**
@@ -654,7 +658,7 @@ GTAG.prototype.trackPageViewEvent = function(page, options) {
   var track;
 
   if (campaign && options.gaWebMeasurementId) {
-    push('config', options.gaWebMeasurementId, {
+    window.gtag('config', options.gaWebMeasurementId, {
       campaign: reject({
         name: campaign.name,
         source: campaign.source,
@@ -666,7 +670,7 @@ GTAG.prototype.trackPageViewEvent = function(page, options) {
   }
 
   if (campaign && options.gaWebAppMeasurementId) {
-    push('config', options.gaWebAppMeasurementId, {
+    window.gtag('config', options.gaWebAppMeasurementId, {
       campaign: reject({
         name: campaign.name,
         source: campaign.source,
@@ -683,7 +687,7 @@ GTAG.prototype.trackPageViewEvent = function(page, options) {
     str += props.search;
   }
 
-  push('event', 'page_view', {
+  window.gtag('event', 'page_view', {
     page_title: name || props.title,
     page_location: props.url,
     page_path: str,
@@ -708,7 +712,7 @@ GTAG.prototype.trackPageViewEvent = function(page, options) {
  * @param payload
  */
 function trackEnhancedEvent(eventName, payload) {
-  push(
+  window.gtag(
     'event',
     eventName,
     extend(payload, {
@@ -740,12 +744,12 @@ function setCustomDimensionsAndMetrics(props, options) {
       }
     }
     if (options.gaWebMeasurementId) {
-      push('config', options.gaWebMeasurementId, {
+      window.gtag('config', options.gaWebMeasurementId, {
         custom_map: reject(customMapValues)
       });
     }
     if (options.gaWebAppMeasurementId) {
-      push('config', options.gaWebAppMeasurementId, {
+      window.gtag('config', options.gaWebAppMeasurementId, {
         custom_map: reject(customMapValues)
       });
     }
@@ -770,10 +774,18 @@ function setContentGroups(props, opts) {
     }
 
     if (opts.gaWebMeasurementId) {
-      push('config', opts.gaWebMeasurementId, reject(contentGroupValues));
+      window.gtag(
+        'config',
+        opts.gaWebMeasurementId,
+        reject(contentGroupValues)
+      );
     }
     if (opts.gaWebAppMeasurementId) {
-      push('config', opts.gaWebAppMeasurementId, reject(contentGroupValues));
+      window.gtag(
+        'config',
+        opts.gaWebAppMeasurementId,
+        reject(contentGroupValues)
+      );
     }
   }
 }

--- a/integrations/gtag/lib/index.js
+++ b/integrations/gtag/lib/index.js
@@ -671,7 +671,20 @@ GTAG.prototype.trackPageViewEvent = function(page, options) {
   var name = page.fullName();
   var category = page.category();
   var props = page.properties();
+  var campaign = page.proxy('context.campaign');
   var track;
+
+  if (campaign && options.gaWebMeasurementId) {
+    push('config', options.gaWebMeasurementId, {
+      campaign: campaign
+    });
+  }
+
+  if (campaign && options.gaWebAppMeasurementId) {
+    push('config', options.gaWebAppMeasurementId, {
+      campaign: campaign
+    });
+  }
 
   var nonInteraction = !!(options && options.nonInteraction);
   var str = props.path;
@@ -680,7 +693,7 @@ GTAG.prototype.trackPageViewEvent = function(page, options) {
   }
 
   push('event', 'page_view', {
-    page_title: name || category,
+    page_title: name || props.title,
     page_location: props.url,
     page_path: str,
     non_interaction: nonInteraction

--- a/integrations/gtag/lib/index.js
+++ b/integrations/gtag/lib/index.js
@@ -727,10 +727,8 @@ function trackEnhancedEvent(eventName, payload) {
 
 function setCustomDimensionsAndMetrics(props, options) {
   if (options.gaSetAllMappedProps) {
-    // set custom dimension and metrics if present
-    // REF: https://developers.google.com/analytics/devguides/collection/gtagjs/custom-dims-mets
-    // For content grouping
-    // https://support.google.com/analytics/answer/7475939?hl=en#code
+    // Set custom dimension and metrics if present
+    // https://developers.google.com/analytics/devguides/collection/gtagjs/custom-dims-mets
     var customMap = merge(
       options.gaCustomDimensions || {},
       options.gaCustomMetrics || {}

--- a/integrations/gtag/lib/index.js
+++ b/integrations/gtag/lib/index.js
@@ -275,7 +275,7 @@ GTAG.prototype.track = function(track, params) {
 
 GTAG.prototype.page = function(page) {
   setCustomDimensionsAndMetrics(this.options);
-  trackPageViewEvent(page, this.options);
+  this.trackPageViewEvent(page, this.options);
 };
 
 /**
@@ -285,7 +285,7 @@ GTAG.prototype.page = function(page) {
  */
 
 GTAG.prototype.pageClassic = function(page) {
-  trackPageViewEvent(page, this.options);
+  this.trackPageViewEvent(page, this.options);
 };
 
 /**
@@ -667,10 +667,11 @@ GTAG.prototype.timingCompletedEnhanced = function(track) {
  * @param  opt
  */
 
-function trackPageViewEvent(page, options) {
+GTAG.prototype.trackPageViewEvent = function(page, options) {
   var name = page.fullName();
   var category = page.category();
   var props = page.properties();
+  var track;
 
   var nonInteraction = !!(options && options.nonInteraction);
   var str = props.path;
@@ -686,22 +687,14 @@ function trackPageViewEvent(page, options) {
   });
 
   if (name && options.trackNamedPages) {
-    push('event', 'page_view', {
-      page_title: name,
-      page_location: props.url,
-      page_path: str,
-      non_interaction: true
-    });
+    track = page.track(name);
+    this.track(track, { nonInteraction: 1 });
   }
   if (category && options.trackCategorizedPages) {
-    push('event', 'page_view', {
-      page_title: name + category,
-      page_location: props.url,
-      page_path: str,
-      non_interaction: true
-    });
+    track = page.track(category);
+    this.track(track, { nonInteraction: 1 });
   }
-}
+};
 
 /**
  * Track enhanced events.

--- a/integrations/gtag/test/index.test.js
+++ b/integrations/gtag/test/index.test.js
@@ -12,7 +12,6 @@ describe('Gtag', function() {
   var options = {
     gaWebAppMeasurementId: 'G_12345678',
     trackNamedPages: true,
-    trackAllPages: false,
     trackCategorizedPages: true,
     gaOptions: {},
     includeSearch: false,
@@ -44,7 +43,6 @@ describe('Gtag', function() {
         .option('awConversionId', '')
         .option('dcFloodLightId', '')
         .option('trackNamedPages', true)
-        .option('trackAllPages', false)
         .option('trackCategorizedPages', true)
         .option('gaOptions', {
           classic: false,
@@ -176,13 +174,11 @@ describe('Gtag', function() {
       });
 
       it('should track page', function() {
-        gtag.options.trackAllPages = true;
         analytics.page();
         analytics.called(window.gtagDataLayer.push);
       });
 
       it('should track named page', function() {
-        gtag.options.trackAllPages = true;
         analytics.page('Pagename');
         analytics.called(window.gtagDataLayer.push, 'event', 'page_view', {
           page_title: 'Pagename',
@@ -195,22 +191,43 @@ describe('Gtag', function() {
       it('should not track named page if option turned off ', function() {
         gtag.options.trackNamedPages = false;
         analytics.page('Pagename');
-        analytics.didNotCall(window.gtagDataLayer.push);
+        analytics.called(window.gtagDataLayer.push, 'event', 'page_view', {
+          page_title: 'Pagename',
+          page_location: window.location.href,
+          page_path: window.location.pathname,
+          non_interaction: false
+        });
+        analytics.assert(window.gtagDataLayer.push.once);
       });
 
       it('should track named page if option turned on', function() {
         gtag.options.trackNamedPages = true;
         analytics.page('Pagename');
+
         analytics.called(window.gtagDataLayer.push, 'event', 'page_view', {
           page_title: 'Pagename',
           page_location: window.location.href,
           page_path: window.location.pathname,
-          non_interaction: true
+          non_interaction: false
         });
+        analytics.called(
+          window.gtagDataLayer.push,
+          'event',
+          'Viewed Pagename Page',
+          {
+            name: 'Pagename',
+            path: '/context.html',
+            referrer: 'http://localhost:9876/?id=14075059',
+            search: '',
+            title: '',
+            url: 'http://localhost:9876/context.html',
+            event: 'Viewed Pagename Page',
+            non_interaction: true
+          }
+        );
       });
 
-      it('should track page if trackAllPages option turned on and nonInteraction passed', function() {
-        gtag.options.trackAllPages = true;
+      it('should track page when and nonInteraction passed', function() {
         gtag.options.nonInteraction = true;
         analytics.page('Pagename');
         analytics.called(window.gtagDataLayer.push, 'event', 'page_view', {
@@ -221,33 +238,34 @@ describe('Gtag', function() {
         });
       });
 
-      it('should not track page if set to false', function() {
-        gtag.options.trackNamedPages = false;
-        gtag.options.trackCategorizedPages = false;
-        analytics.page('Pagename');
-        analytics.page('Category', 'name');
-        analytics.didNotCall(window.gtagDataLayer.push);
-      });
-
       it('should not track page if trackCategorizedPages set to true', function() {
         gtag.options.trackNamedPages = false;
         gtag.options.trackCategorizedPages = true;
-        analytics.page('Pagename');
+        // analytics.page('Pagename');
         analytics.page('Category', 'name');
+
         analytics.called(window.gtagDataLayer.push, 'event', 'page_view', {
-          page_title: 'Category nameCategory',
+          page_title: 'Category name',
           page_location: window.location.href,
           page_path: window.location.pathname,
-          non_interaction: true
+          non_interaction: false
         });
-      });
-
-      it('should not track page if trackNamedPages & trackCategorizedPages set to true', function() {
-        gtag.options.trackNamedPages = true;
-        gtag.options.trackCategorizedPages = true;
-        analytics.page('Pagename');
-        analytics.page('Category', 'Pagename');
-        analytics.calledThrice(window.gtagDataLayer.push);
+        analytics.called(
+          window.gtagDataLayer.push,
+          'event',
+          'Viewed Category Page',
+          {
+            name: 'name',
+            category: 'Category',
+            path: '/context.html',
+            referrer: 'http://localhost:9876/?id=14075059',
+            search: '',
+            title: '',
+            url: 'http://localhost:9876/context.html',
+            event: 'Viewed Category Page',
+            non_interaction: true
+          }
+        );
       });
 
       it('should set custom dimensions if setAllMappedProps set to true', function() {
@@ -320,17 +338,16 @@ describe('Gtag', function() {
 
       it('should send the query if its included', function() {
         gtag.options.includeSearch = true;
-        gtag.options.trackCategorizedPages = true;
         analytics.page('category', 'name', {
           url: 'url',
           path: '/path',
           search: '?q=1'
         });
         analytics.called(window.gtagDataLayer.push, 'event', 'page_view', {
-          page_title: 'category namecategory',
+          page_title: 'category name',
           page_location: 'url',
           page_path: '/path?q=1',
-          non_interaction: true
+          non_interaction: false
         });
       });
     });
@@ -387,7 +404,6 @@ describe('GA Classic', function() {
       });
 
       it('should track page', function() {
-        gtagClassic.options.trackAllPages = true;
         analyticsClassic.page();
         analyticsClassic.called(window.gtagDataLayer.push);
       });

--- a/integrations/gtag/test/index.test.js
+++ b/integrations/gtag/test/index.test.js
@@ -352,6 +352,31 @@ describe('Gtag', function() {
           non_interaction: false
         });
       });
+
+      it('should set campaign data', function() {
+        analytics.page(
+          'Pagename',
+          {},
+          {
+            campaign: {
+              source: 'Some source',
+              medium: 'Some medium'
+            }
+          }
+        );
+
+        analytics.called(
+          window.gtagDataLayer.push,
+          'config',
+          gtag.options.gaWebMeasurementId,
+          {
+            campaign: {
+              source: 'Some source',
+              medium: 'Some medium'
+            }
+          }
+        );
+      });
     });
   });
 });

--- a/integrations/gtag/test/index.test.js
+++ b/integrations/gtag/test/index.test.js
@@ -77,7 +77,13 @@ describe('Gtag', function() {
         gaOptimizeContainerId: 'GTM-XXXXX',
         gaSampleRate: 500,
         gaSiteSpeedSampleRate: 1,
-        gaUseAmpClientId: true
+        gaUseAmpClientId: true,
+        gaCustomDimensions: {
+          company: 'dimension1'
+        },
+        gaCustomMetrics: {
+          age: 'metric1'
+        }
       };
       analytics.once('ready', done);
       analytics.initialize();
@@ -87,14 +93,17 @@ describe('Gtag', function() {
       analytics.assert(window.gtagDataLayer[0] === 'config');
       analytics.assert(window.gtagDataLayer[1] === 'GA_WEB_MEASUREMENT_ID');
       analytics.deepEqual(window.gtagDataLayer[2], {
-        custom_map: {},
         anonymize_ip: true,
         cookie_domain: 'auto',
         link_attribution: true,
         optimize_id: 'GTM-XXXXX',
         sample_rate: 500,
         site_speed_sample_rate: 1,
-        use_amp_client_id: true
+        use_amp_client_id: true,
+        custom_map: {
+          dimension1: 'company',
+          metric1: 'age'
+        }
       });
       analytics.assert(window.gtagDataLayer[3] === 'config');
       analytics.assert(window.gtagDataLayer[4] === 'AW_CONVERSION_ID');
@@ -270,14 +279,14 @@ describe('Gtag', function() {
         gtag.options.trackNamedPages = true;
         gtag.options.gaSetAllMappedProps = true;
         gtag.options.gaCustomDimensions = {
-          'properties.company': 'dimension2'
+          company: 'dimension2'
         };
         gtag.options.gaCustomMetrics = {
-          'properties.age': 'metric1'
+          age: 'metric1'
         };
         gtag.options.gaContentGroupings = {
-          'properties.section': 'content_group1',
-          'properties.score': 'content_group5'
+          section: 'content_group1',
+          score: 'content_group5'
         };
         analytics.page('Page1', {
           loadTime: '100',
@@ -327,7 +336,7 @@ describe('Gtag', function() {
           {
             custom_map: GTAG.merge(
               gtag.options.gaCustomDimensions,
-              gtag.options.gaCustomDimensions
+              gtag.options.gaCustomMetrics
             )
           }
         );

--- a/integrations/gtag/test/index.test.js
+++ b/integrations/gtag/test/index.test.js
@@ -217,10 +217,10 @@ describe('Gtag', function() {
           {
             name: 'Pagename',
             path: '/context.html',
-            referrer: 'http://localhost:9876/?id=14075059',
+            referrer: window.document.referrer,
             search: '',
             title: '',
-            url: 'http://localhost:9876/context.html',
+            url: window.location.href,
             event: 'Viewed Pagename Page',
             non_interaction: true
           }
@@ -241,9 +241,11 @@ describe('Gtag', function() {
       it('should not track page if trackCategorizedPages set to true', function() {
         gtag.options.trackNamedPages = false;
         gtag.options.trackCategorizedPages = true;
-        // analytics.page('Pagename');
+
         analytics.page('Category', 'name');
 
+        console.log(JSON.stringify(window.gtagDataLayer.push.args, null, 4));
+        console.log(window.document.referrer);
         analytics.called(window.gtagDataLayer.push, 'event', 'page_view', {
           page_title: 'Category name',
           page_location: window.location.href,
@@ -258,10 +260,10 @@ describe('Gtag', function() {
             name: 'name',
             category: 'Category',
             path: '/context.html',
-            referrer: 'http://localhost:9876/?id=14075059',
+            referrer: window.document.referrer,
             search: '',
             title: '',
-            url: 'http://localhost:9876/context.html',
+            url: window.location.href,
             event: 'Viewed Category Page',
             non_interaction: true
           }


### PR DESCRIPTION
**What does this PR do?**
- Add campaign (UTM) support to page calls
- Removes `Track All Pages` setting for parity with existing GA integration
- Updates the behavior of `Track Named Pages` and `Track Categorized Pages` to be inline with the existing GA integration

**Are there breaking changes in this PR?**
Nah

**Any background context you want to provide?**


**Is there parity with the server-side/android/iOS integration components (if applicable)?**


**Does this require a new integration setting? If so, please explain how the new setting works**


**Links to helpful docs and other external resources**
