### PR TITLE
[STRATCONN-86] Add support for transaction based counting in DCF 

### DIFF
--- a/integrations/doubleclick-floodlight/lib/index.js
+++ b/integrations/doubleclick-floodlight/lib/index.js
@@ -20,6 +20,7 @@ var Floodlight = (module.exports = integration('DoubleClick Floodlight')
   .option('getDoubleClickId', false)
   .option('googleNetworkId', '')
   .option('segmentWriteKey', '')
+  .option('useTransactionCounting', false)
   .tag(
     'counter',
     '<iframe src="https://{{ src }}.fls.doubleclick.net/activityi;src={{ src }};type={{ type }};cat={{ cat }};dc_lat=;dc_rdid=;tag_for_child_directed_treatment=;ord={{ ord }}{{ customVariables }}?">'
@@ -159,6 +160,8 @@ Floodlight.prototype.track = function(track) {
           quantity = properties.quantity;
         }
         if (quantity) tagParams.qty = quantity;
+        // overwrite qty param with 1 if customer is using Trasaction Counting mehtod instead of Items Sold method
+        if (settings.useTransactionCounting) tagParams.qty = 1;
         // doubleclick wants revenue under this cost param, yes
         if (track.revenue()) tagParams.cost = track.revenue();
         tagParams.ord = track.proxy(tag.ordKey);

--- a/integrations/doubleclick-floodlight/test/index.test.js
+++ b/integrations/doubleclick-floodlight/test/index.test.js
@@ -265,6 +265,60 @@ describe('DoubleClick Floodlight', function() {
         analytics.loaded(iframe);
       });
 
+      it('should fire a floodlight sales tag properly with qty default to 1 when useTransactionCounting', function() {
+        floodlight.options.useTransactionCounting = true;
+        var properties = {
+          checkout_id: 'fksdjfsdjfisjf9sdfjsd9f',
+          order_id: '50314b8e9bcf000000000000',
+          affiliation: 'Google Store',
+          total: 30,
+          revenue: 25,
+          shipping: 3,
+          tax: 2,
+          discount: 2.5,
+          coupon: 'hasbros',
+          currency: 'USD',
+          products: [
+            {
+              product_id: '507f1f77bcf86cd799439011',
+              sku: '45790-32',
+              name: 'Monopoly: 3rd Edition',
+              price: 19,
+              quantity: 1,
+              category: 'Games'
+            },
+            {
+              product_id: '505bd76785ebb509fc183733',
+              sku: '46493-32',
+              name: 'Uno Card Game',
+              price: 3,
+              quantity: 2,
+              category: 'Games'
+            }
+          ]
+        };
+        var iframe =
+          '<iframe src="https://' +
+          options.source +
+          '.fls.doubleclick.net/activityi' +
+          ';src=' +
+          options.source +
+          ';type=' +
+          options.events[1].value.type +
+          ';cat=' +
+          options.events[1].value.cat +
+          ';qty=' +
+          1 +
+          ';cost=' +
+          properties.revenue +
+          ';dc_lat=;dc_rdid=;tag_for_child_directed_treatment=' +
+          ';ord=50314b8e9bcf000000000000?">';
+
+        analytics.track('Order Completed', properties);
+        analytics.called(floodlight.load);
+        analytics.loaded(iframe);
+      });
+
       it('should fire a floodlight sales tag properly with top level userId when identify previously triggered', function() {
         floodlight.options.events[3] = {
           key: 'Order Completed',


### PR DESCRIPTION
JIRA: https://segment.atlassian.net/browse/STRATCONN-86

**NOTE:** I will merge this into https://github.com/segmentio/analytics.js-integrations/pull/457 and release concurrently. 

**What does this PR do?**
DCF supports two methods of counting: Items Sold and Transaction based. Currently our DCF Integration only supports Items Sold. Current implementation sets `tagParams.qty` by # of products in products array, falling back to checking for an actual property called quantity. 

For this new change we will implement a new setting `useTransactionCounting` that will default to false as to not cause any regressions for current customers. When this setting is enabled, and the event is a Sales Tag, we will always default to set to `tagParams.qty` to 1 per the Transaction counting method. 

**Are there breaking changes in this PR?**
No these changes were validated and tested. 
To test these changes will introduce no regressions, I validated a Checkout Started eventt with these settings: 
```
{
  "integrations": {
    "DoubleClick Floodlight": {
      "activityTag":"objec0",
      "events":[
        {
            "event":"Checkout Started",
            "cat":"objec00",
            "type":"objec0",
            "isSalesTag":true,
            "ordKey":"",
            "customVariable":[
              {
                  "key":"userId",
                  "value":"u1"
              },
              {
                  "key":"{{userId}}",
                  "value":"u2"
              },
              {
                  "key":"products.$.category",
                  "value":"u8"
              }
            ]
        }
      ],
      "getDoubleClickId":false,
      "googleNetworkId":"",
      "groupTag":"brows0",
      "segmentWriteKey":"",
      "source":"1234567", 
      "useTransactionCounting": false
    }
  }
}
```
Quantity is properly listed as 2:
<img width="1678" alt="Screen Shot 2020-04-16 at 2 50 58 PM" src="https://user-images.githubusercontent.com/31782219/79510743-c577d700-7ff2-11ea-99b2-f241b611c7b1.png">

I then changed useTransactionCounting to true and sent thee same event and qty defaulted to 1:
![Uploading Screen Shot 2020-04-16 at 2.50.02 PM.png…]()


**Any background context you want to provide?**
DCF documentation on counting methods: https://support.google.com/dcm/answer/7358417?hl=en

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
No, this will need to be added to SS at a later point in time. 

**Does this require a new integration setting? If so, please explain how the new setting works**
Yes, it will default to false so we will not need to backfill settings and it will not introduce any regreessions.

**Links to helpful docs and other external resources**
N/A