### PR TITLE
[STRATCONN-144] Ability to map top level fields to Adobe 

### DIFF
--- a/integrations/adobe-analytics/lib/index.js
+++ b/integrations/adobe-analytics/lib/index.js
@@ -267,8 +267,7 @@ AdobeAnalytics.prototype.page = function(page) {
   calculateTimestamp(page, this.options);
 
   // Check if any properties match mapped eVar, prop, or hVar in options
-  var properties = page.properties();
-  var props = extractProperties(properties, this.options);
+  var props = extractProperties(page, this.options);
   // Attach them to window.s and push to dynamicKeys
   each(update, props);
 
@@ -419,8 +418,6 @@ AdobeAnalytics.prototype.checkoutStarted = function(track) {
  */
 
 AdobeAnalytics.prototype.processEvent = function(msg, adobeEvent) {
-  var props = msg.properties();
-
   var products = msg.products();
   if (Array.isArray(products) && !window.s.products) {
     // check window because products key could already have been filled upstream
@@ -443,7 +440,7 @@ AdobeAnalytics.prototype.processEvent = function(msg, adobeEvent) {
 
   calculateTimestamp(msg, this.options);
 
-  var mappedProps = extractProperties(props, this.options);
+  var mappedProps = extractProperties(msg, this.options);
   each(update, mappedProps);
 
   if (msg.currency() !== 'USD') update(msg.currency(), 'currencyCode');
@@ -572,7 +569,7 @@ function updateContextData(facade, options) {
   // There is a bug here, but it must be maintained. `extractProperties` will
   // look at *all* our mappings, but only the `contextValues` mapping should be
   // used here.
-  var contextProperties = extractProperties(trample(facade.context()), options);
+  var contextProperties = extractProperties(facade, options, 'context');
   each(function(value, key) {
     if (!key || value === undefined || value === null || value === '') {
       return;
@@ -666,7 +663,7 @@ function clearKeys(keys) {
  * @param {Object} options
  */
 
-function extractProperties(props, options) {
+function extractProperties(facade, options, propType) {
   var result = {};
   var mappings = [
     options.eVars,
@@ -676,6 +673,15 @@ function extractProperties(props, options) {
     options.contextValues
   ];
 
+  var topLevelProperties = ['messageId', 'anonymousId'];
+
+  var props = facade.properties();
+  if (propType === 'mergedPropContext') {
+    props = merge(trample(facade.properties()), trample(facade.context()));
+  } else if (propType === 'context') {
+    props = trample(facade.context());
+  }
+
   // Iterate through each variable mappings to find matching props
   for (var x = 0; x < mappings.length; x++) {
     each(match, mappings[x]);
@@ -683,6 +689,23 @@ function extractProperties(props, options) {
 
   function match(mappedValue, mappedKey) {
     var value = dot(props, mappedKey);
+    // On track and page calls the propType here will be empty. On video HB calls the propTyp will
+    // be 'mergedPropContext'. On those events we use  the extracted properties from this fxn to explicitly
+    // map link vars on `window.s` object.
+    if (topLevelProperties.includes(mappedKey) && propType !== 'context') {
+      value = facade.proxy(mappedKey);
+    }
+
+    // When we are checking the context object for segment property mappings (updateContextData)
+    // we only want set top level fields to Context Data Variables.
+    var contextValueKeys = Object.keys(options.contextValues);
+    if (
+      topLevelProperties.includes(mappedKey) &&
+      propType === 'context' &&
+      contextValueKeys.includes(mappedValue)
+    ) {
+      value = facade.proxy(mappedKey);
+    }
     var isarr = Array.isArray(value);
     // make sure it's an acceptable data type
     if (
@@ -1082,23 +1105,14 @@ function createStandardVideoMetadata(track, mediaObj) {
 function createCustomVideoMetadataContext(track, options) {
   var contextData = {};
 
-  //Check properties object for `settings.contextValue` mappings to assign custom metadata
-  var properties = extractProperties(trample(track.properties()), options);
+  //Check properties & context object for `settings.contextValue` mappings to assign custom metadata
+  var extractedProperties = extractProperties(track, options, 'mergedPropContext');
   each(function(value, key) {
     if (!key || value === undefined || value === null || value === '') {
       return;
     }
     contextData[key] = value;
-  }, properties);
-
-  //Check properties object for `settings.contextValue` mappings to assign custom metadata
-  var contextFields = extractProperties(trample(track.context()), options);
-  each(function(value, key) {
-    if (!key || value === undefined || value === null || value === '') {
-      return;
-    }
-    contextData[key] = value;
-  }, contextFields);
+  }, extractedProperties);
   return contextData;
 }
 
@@ -1140,4 +1154,36 @@ function createQosObject(track) {
     props.fps || 0,
     props.droppedFrames || 0
   );
+}
+
+/**
+ * Merge two javascript objects. This works similarly to `Object.assign({}, obj1, obj2)`
+ * but it's compatible with old browsers. The properties of the first argument takes preference
+ * over the other.
+ *
+ * It does not do fancy stuff, just use it with top level properties.
+ *
+ * @param {Object} obj1 Object 1
+ * @param {Object} obj2 Object 2
+ *
+ * @return {Object} a new object with all the properties of obj1 and the remainder of obj2.
+ */
+function merge(obj1, obj2) {
+  var res = {};
+
+  // All properties of obj1
+  for (var propObj1 in obj1) {
+    if (obj1.hasOwnProperty(propObj1)) {
+      res[propObj1] = obj1[propObj1];
+    }
+  }
+
+  // Extra properties of obj2
+  for (var propObj2 in obj2) {
+    if (obj2.hasOwnProperty(propObj2) && !res.hasOwnProperty(propObj2)) {
+      res[propObj2] = obj2[propObj2];
+    }
+  }
+
+  return res;
 }

--- a/integrations/adobe-analytics/test/index.test.js
+++ b/integrations/adobe-analytics/test/index.test.js
@@ -227,6 +227,27 @@ describe('Adobe Analytics', function() {
         analytics.called(window.s.tl, true, 'o', 'Overlord exploded');
       });
 
+      it('should track set top level fields (msgId and anonId) set as eVars properly', function() {
+        adobeAnalytics.options.eVars = {
+          messageId: 'eVar2',
+          anonymousId: 'eVar3'
+        };
+        analytics.track('Overlord exploded');
+        analytics.equal(window.s.events, 'event7');
+        analytics.assert(window.s.eVar2);
+        analytics.assert(window.s.eVar3);
+        analytics.assert(
+          contains(
+            window.s.linkTrackVars,
+            'events',
+            'timestamp',
+            'eVar2',
+            'eVar3'
+          )
+        );
+        analytics.called(window.s.tl, true, 'o', 'Overlord exploded');
+      });
+
       it('tracks aliased properties', function() {
         analytics.track('Drank Some Milk', {
           type: '2%',
@@ -252,6 +273,27 @@ describe('Adobe Analytics', function() {
         analytics.called(window.s.tl, true, 'o', 'Drank Some Milk');
       });
 
+      it('should track set top level fields (msgId and anonId) set as props properly', function() {
+        adobeAnalytics.options.eVars = {
+          messageId: 'prop1',
+          anonymousId: 'prop2'
+        };
+        analytics.track('Overlord exploded');
+        analytics.equal(window.s.events, 'event7');
+        analytics.assert(window.s.prop1);
+        analytics.assert(window.s.prop2);
+        analytics.assert(
+          contains(
+            window.s.linkTrackVars,
+            'events',
+            'timestamp',
+            'prop1',
+            'prop2'
+          )
+        );
+        analytics.called(window.s.tl, true, 'o', 'Overlord exploded');
+      });
+
       it('should send context properties', function() {
         adobeAnalytics.options.contextValues = {
           'page.referrer': 'page.referrer',
@@ -267,6 +309,17 @@ describe('Adobe Analytics', function() {
           window.location.href
         );
         analytics.equal(window.s.contextData.foo, 'bar');
+        analytics.called(window.s.tl);
+      });
+
+      it('should send top level fields (msgId & anonId) as context properties', function() {
+        adobeAnalytics.options.contextValues = {
+          messageId: 'messageId',
+          anonymousId: 'anonymousId'
+        };
+        analytics.track('Drank Some Milk', { foo: 'bar' });
+        analytics.assert(window.s.contextData.messageId);
+        analytics.assert(window.s.contextData.anonymousId);
         analytics.called(window.s.tl);
       });
 
@@ -1181,7 +1234,7 @@ describe('Adobe Analytics', function() {
         );
       });
 
-      it.only('should send custom metdata in properties on Video Playback Started', function() {
+      it('should send custom metdata in properties on Video Playback Started', function() {
         analytics.track('Video Playback Started', {
           session_id: sessionId,
           video_genre: 'Reality, Game Show, Music',
@@ -1204,7 +1257,7 @@ describe('Adobe Analytics', function() {
         );
       });
 
-      it.only('should send custom metdata in properties and context on Video Playback Started', function() {
+      it('should send custom metdata in properties and context on Video Playback Started', function() {
         analytics.track(
           'Video Playback Started',
           {

--- a/integrations/adobe-analytics/test/index.test.js
+++ b/integrations/adobe-analytics/test/index.test.js
@@ -976,6 +976,22 @@ describe('Adobe Analytics', function() {
         analytics.called(window.s.t);
       });
 
+      it('tracks top level fields (msgId & anonId) as mapped properties', function() {
+        adobeAnalytics.options.props = {
+          anonymousId: 'prop1',
+          messageId: 'prop2'
+        };
+        analytics.page('Drank Some Milk', {
+          type: '2%',
+          hier_group2: 'Lucerne',
+          dog: true
+        });
+        analytics.equal(window.s.pageName, 'Drank Some Milk');
+        analytics.assert(window.s.prop1);
+        analytics.assert(window.s.prop2);
+        analytics.called(window.s.t);
+      });
+
       it('should send context properties', function() {
         adobeAnalytics.options.contextValues = {
           'page.referrer': 'page.referrer',
@@ -995,6 +1011,17 @@ describe('Adobe Analytics', function() {
           window.document.referrer
         );
         analytics.equal(window.s.contextData.url, window.location.href);
+        analytics.called(window.s.t);
+      });
+
+      it('should send top level fields (msgId & anonId) as context properties', function() {
+        adobeAnalytics.options.contextValues = {
+          anonymousId: 'anonymousId',
+          messageId: 'messageId'
+        };
+        analytics.page('Page1', {});
+        analytics.assert(window.s.contextData.anonymousId);
+        analytics.assert(window.s.contextData.messageId);
         analytics.called(window.s.t);
       });
 


### PR DESCRIPTION
**What does this PR do?**
JIRA: https://segment.atlassian.net/browse/STRATCONN-144

Add the ability to map a list of top level properties (currently only messageId and anonymousId) to Adobe Analytics props, eVars, or context data variables. 

**Are there breaking changes in this PR?**
No. 

**Any background context you want to provide?**
This is an ask from both Intuit and Fox to improve their ability to join data from their Warehouses with Adobe Reports. 

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
No. This will need to be implemented on Server Side, iOS and Android to maintain parity. Will create StratConn tickets as a followup action item. 

**Does this require a new integration setting? If so, please explain how the new setting works**
No. 

**Links to helpful docs and other external resources**
Escalated urgency in response to Fox<>Adobe Discrepancy. Details in this doc: https://paper.dropbox.com/doc/Fox-Adobe-Discrepancies-between-Adobe-and-Redshift--AzCREu_W0y_PjJtcip_it0SiAQ-orfqhwMtwHM1TL6ji2RWx