### PR TITLE
Gtag: Bump beta version to force publish

### DIFF
--- a/integrations/gtag/package.json
+++ b/integrations/gtag/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-gtag",
   "description": "The Gtag analytics.js integration.",
-  "version": "1.0.0-beta",
+  "version": "1.0.0-beta.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",


### PR DESCRIPTION
**What does this PR do?**
Bumps the Gtag version to `1.0.0-beta.1`. This was bump in version was overlooked in #458.

**Are there breaking changes in this PR?**
No.

- Testing not required because the actual changes were tested in #458.

**Any background context you want to provide?**


**Is there parity with the server-side/android/iOS integration components (if applicable)?**


**Does this require a new integration setting? If so, please explain how the new setting works**


**Links to helpful docs and other external resources**
