### PR TITLE
[LIBWEB-52] Added strict UTML params processing

### DIFF
--- a/integrations/segmentio/lib/index.js
+++ b/integrations/segmentio/lib/index.js
@@ -301,7 +301,7 @@ Segment.prototype.normalize = function(message) {
   }
   // if user provides campaign via context, do not overwrite with UTM qs param
   if (query && !ctx.campaign) {
-    ctx.campaign = utm(query);
+    ctx.campaign = utm.strict(query);
   }
   this.referrerId(query, ctx);
   msg.userId = msg.userId || user.id();

--- a/integrations/segmentio/package.json
+++ b/integrations/segmentio/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-segmentio",
   "description": "The Segmentio analytics.js integration.",
-  "version": "4.2.3",
+  "version": "4.3.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/segmentio/test/index.test.js
+++ b/integrations/segmentio/test/index.test.js
@@ -241,6 +241,24 @@ describe('Segment.io', function() {
         Segment.global = window;
       });
 
+      it('should filter non-standard .campaign items', function() {
+        Segment.global = { navigator: {}, location: {} };
+        Segment.global.location.search =
+          '?utm_source=source&utm_medium=medium&utm_term=term&utm_content=content&utm_campaign=name&utm_random=random';
+        Segment.global.location.hostname = 'localhost';
+        segment.normalize(object);
+        analytics.assert(object);
+        analytics.assert(object.context);
+        analytics.assert(object.context.campaign);
+        analytics.assert(object.context.campaign.source === 'source');
+        analytics.assert(object.context.campaign.medium === 'medium');
+        analytics.assert(object.context.campaign.term === 'term');
+        analytics.assert(object.context.campaign.content === 'content');
+        analytics.assert(object.context.campaign.name === 'name');
+        analytics.assert(object.context.campaign.random === undefined);
+        Segment.global = window;
+      });
+
       it('should allow override of .campaign', function() {
         Segment.global = { navigator: {}, location: {} };
         Segment.global.location.search =


### PR DESCRIPTION
**What does this PR do?**
Looks like in our docs we mention that we allow only 5 standard UTM parameters, but the implementation captures any UTM param. This PR uses strict UTM processing. More info on this ticket: https://segment.atlassian.net/browse/LIBWEB-52

**Are there breaking changes in this PR?**
There is a change in behaviour of the library, so considered breaking change. 

**Notes** 
Need to confirm with @osamakhn if we want to do what explained on the ticket since it is a breaking change. 