### PR TITLE
Fix xid changing when navigating subdomains.

### DIFF
--- a/integrations/segmentio/lib/index.js
+++ b/integrations/segmentio/lib/index.js
@@ -470,15 +470,10 @@ Segment.prototype.retrieveCrossDomainId = function(callback) {
   var self = this;
   var writeKey = this.options.apiKey;
 
-  // Exclude the current domain from the list of servers we're querying
-  // var currentTld = getTld(window.location.hostname);
   var domains = [];
   for (var i = 0; i < this.options.crossDomainIdServers.length; i++) {
     var domain = this.options.crossDomainIdServers[i];
     domains.push(domain);
-    // if (getTld(domain) !== currentTld) {
-    //   domains.push(domain);
-    // }
   }
 
   getCrossDomainIdFromServerList(domains, writeKey, function(err, res) {

--- a/integrations/segmentio/lib/index.js
+++ b/integrations/segmentio/lib/index.js
@@ -470,10 +470,14 @@ Segment.prototype.retrieveCrossDomainId = function(callback) {
   var self = this;
   var writeKey = this.options.apiKey;
 
+  // Exclude the current domain from the list of servers we're querying
+  var currentTld = getTld(window.location.hostname);
   var domains = [];
   for (var i = 0; i < this.options.crossDomainIdServers.length; i++) {
     var domain = this.options.crossDomainIdServers[i];
-    domains.push(domain);
+    if (getTld(domain) !== currentTld) {
+      domains.push(domain);
+    }
   }
 
   getCrossDomainIdFromServerList(domains, writeKey, function(err, res) {
@@ -521,7 +525,9 @@ Segment.prototype.retrieveCrossDomainId = function(callback) {
  */
 Segment.prototype.getCachedCrossDomainId = function() {
   if (this.options.saveCrossDomainIdInLocalStorage) {
-    return localstorage('seg_xid');
+    if (localstorage('seg_xid') !== null) {
+      return localstorage('seg_xid');
+    }
   }
   return this.cookie('seg_xid');
 };

--- a/integrations/segmentio/lib/index.js
+++ b/integrations/segmentio/lib/index.js
@@ -471,13 +471,14 @@ Segment.prototype.retrieveCrossDomainId = function(callback) {
   var writeKey = this.options.apiKey;
 
   // Exclude the current domain from the list of servers we're querying
-  var currentTld = getTld(window.location.hostname);
+  // var currentTld = getTld(window.location.hostname);
   var domains = [];
   for (var i = 0; i < this.options.crossDomainIdServers.length; i++) {
     var domain = this.options.crossDomainIdServers[i];
-    if (getTld(domain) !== currentTld) {
-      domains.push(domain);
-    }
+    domains.push(domain);
+    // if (getTld(domain) !== currentTld) {
+    //   domains.push(domain);
+    // }
   }
 
   getCrossDomainIdFromServerList(domains, writeKey, function(err, res) {
@@ -525,9 +526,7 @@ Segment.prototype.retrieveCrossDomainId = function(callback) {
  */
 Segment.prototype.getCachedCrossDomainId = function() {
   if (this.options.saveCrossDomainIdInLocalStorage) {
-    if (localstorage('seg_xid') !== null) {
-      return localstorage('seg_xid');
-    }
+    return localstorage('seg_xid');
   }
   return this.cookie('seg_xid');
 };

--- a/integrations/segmentio/lib/index.js
+++ b/integrations/segmentio/lib/index.js
@@ -470,14 +470,10 @@ Segment.prototype.retrieveCrossDomainId = function(callback) {
   var self = this;
   var writeKey = this.options.apiKey;
 
-  // Exclude the current domain from the list of servers we're querying
-  var currentTld = getTld(window.location.hostname);
   var domains = [];
   for (var i = 0; i < this.options.crossDomainIdServers.length; i++) {
     var domain = this.options.crossDomainIdServers[i];
-    if (getTld(domain) !== currentTld) {
-      domains.push(domain);
-    }
+    domains.push(domain);
   }
 
   getCrossDomainIdFromServerList(domains, writeKey, function(err, res) {

--- a/integrations/segmentio/package.json
+++ b/integrations/segmentio/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-segmentio",
   "description": "The Segmentio analytics.js integration.",
-  "version": "4.2.3",
+  "version": "4.2.5",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",


### PR DESCRIPTION
**What does this PR do?**
Changes the segmentio integration to check the current domain for pre-existing xids as well, as subdomains cannot check localstorage or the httpOnly cookies that are being set (previously it would only check other xid domains for the xid)

**Are there breaking changes in this PR?**
No

**Any background context you want to provide?**
Customers were having an issue with their users xids changing when navigating to a subdomain rather than a different domain.

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
N/A

**Links to helpful docs and other external resources**
https://segment.atlassian.net/browse/CC-6393