### PR TITLE
Brie/nielsen dcr livestream

### DIFF
--- a/integrations/nielsen-dcr/HISTORY.md
+++ b/integrations/nielsen-dcr/HISTORY.md
@@ -1,3 +1,8 @@
+1.5.1 / 2020-05-15
+==================
+
+  * Adds new setting `sendCurrentTimeLivestream` that when enabled will default to sending current time in seconds to Nielsen for livestream videos. If a position is passed and this setting is disabled we will calculate an offset of `currentTime` + `position` from properties object. 
+
 1.3.3 / 2019-10-11
 ==================
 

--- a/integrations/nielsen-dcr/lib/index.js
+++ b/integrations/nielsen-dcr/lib/index.js
@@ -22,6 +22,7 @@ var NielsenDCR = (module.exports = integration('Nielsen DCR')
   .option('adAssetIdPropertyName', '')
   .option('subbrandPropertyName', '')
   .option('clientIdPropertyName', '')
+  .option('sendCurrentTimeLivestream', false)
   .option('contentLengthPropertyName', 'total_length')
   .option('optout', false)
   .tag(
@@ -135,12 +136,11 @@ NielsenDCR.prototype.heartbeat = function(assetId, position, livestream) {
 
   if (livestream) {
     // for livestream events, we calculate a unix timestamp based on the current time an offset value, which should be passed in properties.position
-    this.currentPosition = getOffsetTime(position);
+    this.currentPosition = getOffsetTime(position, self.options);
   } else if (position >= 0) {
     // this.currentPosition defaults to 0 upon initialization
     this.currentPosition = position;
   }
-
   this.heartbeatId = setInterval(function() {
     self._client.ggPM('setPlayheadPosition', self.currentPosition);
     self.currentPosition++;
@@ -293,12 +293,14 @@ NielsenDCR.prototype.videoContentPlaying = function(track) {
  */
 
 NielsenDCR.prototype.videoContentCompleted = function(track) {
+  var self = this;
+
   clearInterval(this.heartbeatId);
 
   var position = track.proxy('properties.position');
   var livestream = track.proxy('properties.livestream');
 
-  if (livestream) position = getOffsetTime(position);
+  if (livestream) position = getOffsetTime(position, self.options);
 
   this._client.ggPM('setPlayheadPosition', position);
   this._client.ggPM('stop', position);
@@ -381,12 +383,13 @@ NielsenDCR.prototype.videoAdCompleted = function(track) {
 NielsenDCR.prototype.videoPlaybackPaused = NielsenDCR.prototype.videoPlaybackSeekStarted = NielsenDCR.prototype.videoPlaybackBufferStarted = function(
   track
 ) {
+  var self = this;
   clearInterval(this.heartbeatId);
 
   var position = track.proxy('properties.position');
   var livestream = track.proxy('properties.livestream');
 
-  if (livestream) position = getOffsetTime(position);
+  if (livestream) position = getOffsetTime(position, self.options);
 
   this._client.ggPM('stop', position);
 };
@@ -444,12 +447,12 @@ NielsenDCR.prototype.videoPlaybackResumed = NielsenDCR.prototype.videoPlaybackSe
 NielsenDCR.prototype.videoPlaybackCompleted = NielsenDCR.prototype.videoPlaybackInterrupted = function(
   track
 ) {
+  var self = this;
   clearInterval(this.heartbeatId);
-
   var position = track.proxy('properties.position');
   var livestream = track.proxy('properties.livestream');
 
-  if (livestream) position = getOffsetTime(position);
+  if (livestream) position = getOffsetTime(position, self.options);
 
   this._client.ggPM('setPlayheadPosition', position);
   this._client.ggPM('end', position);
@@ -501,14 +504,15 @@ function formatLoadType(integrationOpts, track, propertiesPath) {
  * handles offsets for livestreams, if applicable.
  *
  * @param {*} position Should be negative int representing livestream offset
+ * @param {*} options Integration settings
  * @returns {Number} Unix timestamp in seconds
  *
  * @api private
  */
 
-function getOffsetTime(position) {
+function getOffsetTime(position, options) {
   var date = Math.floor(Date.now() / 1000);
-  if (!position) return date;
+  if (!position || options.sendCurrentTimeLivestream) return date;
 
   try {
     if (typeof position !== 'number') {

--- a/integrations/nielsen-dcr/package.json
+++ b/integrations/nielsen-dcr/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-nielsen-dcr",
   "description": "The Nielsen DCR analytics.js integration.",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/nielsen-dcr/test/index.test.js
+++ b/integrations/nielsen-dcr/test/index.test.js
@@ -45,6 +45,7 @@ describe('NielsenDCR', function() {
         .option('clientIdPropertyName', '')
         .option('contentLengthPropertyName', 'total_length')
         .option('optout', false)
+        .option('sendCurrentTimeLivestream', false)
         .tag(
           'http',
           '<script src="http://cdn-gl.imrworldwide.com/conf/{{ appId }}.js#name={{ instanceName }}&ns=NOLBUNDLE">'
@@ -223,6 +224,37 @@ describe('NielsenDCR', function() {
             livestream: true
           };
           timestamp = Math.floor(Date.now() / 1000) + props.position;
+          analytics.track('video playback completed', props);
+          analytics.called(window.clearInterval);
+          analytics.called(
+            nielsenDCR._client.ggPM,
+            'setPlayheadPosition',
+            timestamp
+          );
+          analytics.called(nielsenDCR._client.ggPM, 'end', timestamp);
+        });
+
+        it('video playback completed w livestream when `sendCurrentTimeLivestream` enabled', function() {
+          nielsenDCR.options.sendCurrentTimeLivestream = true;
+          var timestamp;
+          var props = {
+            session_id: '12345',
+            content_asset_id: null,
+            content_pod_id: null,
+            ad_asset_id: 'ad907',
+            ad_pod_id: 'adSegB',
+            ad_type: null,
+            position: -100,
+            total_length: 392,
+            sound: 88,
+            bitrate: 100,
+            full_screen: false,
+            video_player: 'youtube',
+            ad_enabled: false,
+            quality: 'hd1080',
+            livestream: true
+          };
+          timestamp = Math.floor(Date.now() / 1000);
           analytics.track('video playback completed', props);
           analytics.called(window.clearInterval);
           analytics.called(


### PR DESCRIPTION
**What does this PR do?**

1. add new setting sendCurrentTimeLivestream
2. updates getOffsetTime to check if setting is enabled. When video is livestream and setting enabled to only set playhead position to current time.

**Are there breaking changes in this PR?**
No default behavior is the same as current behavior. 

**Any background context you want to provide?**
This is to resolve outstanding issues in #fox-adobe-discrepancy issue. 

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
Yes PRs are submitted and ready to be deployed to iOS and Android. 

**Does this require a new integration setting? If so, please explain how the new setting works**
Yes there is a new integration setting `sendCurrentTimeLivestream`. It defaults to false so does not require a DCS migration or backfill. 

**Links to helpful docs and other external resources**
N/A
