### PR TITLE
[STRATCONN-182]AA-Allow event name to be sent as context data variable

### DIFF
--- a/integrations/adobe-analytics/HISTORY.md
+++ b/integrations/adobe-analytics/HISTORY.md
@@ -1,3 +1,7 @@
+1.16.1 / 2020-05-15
+===================
+* Supports sending top level `event` as `prop`, `eVar`, `lVar`, `hVar`, or Context Data Variable.
+
 1.16.0 / 2020-05-05
 ===================
 * Supports sending top level `messageId` and `anonymousId` as `prop`, `eVar`, `lVar`, `hVar`, or Context Data Variable.

--- a/integrations/adobe-analytics/lib/index.js
+++ b/integrations/adobe-analytics/lib/index.js
@@ -821,7 +821,7 @@ function extractProperties(facade, options, propType) {
     options.contextValues
   ];
 
-  var topLevelProperties = ['messageId', 'anonymousId'];
+  var topLevelProperties = ['messageId', 'anonymousId', 'event'];
 
   var props = facade.properties();
   if (propType === 'mergedPropContext') {

--- a/integrations/adobe-analytics/package.json
+++ b/integrations/adobe-analytics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-adobe-analytics",
   "description": "The Adobe Analytics analytics.js integration.",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/adobe-analytics/test/index.test.js
+++ b/integrations/adobe-analytics/test/index.test.js
@@ -229,22 +229,25 @@ describe('Adobe Analytics', function() {
         analytics.called(window.s.tl, true, 'o', 'Overlord exploded');
       });
 
-      it('should track set top level fields (msgId and anonId) set as eVars properly', function() {
+      it('should track set top level fields (msgId, anonId, event) set as eVars properly', function() {
         adobeAnalytics.options.eVars = {
           messageId: 'eVar2',
-          anonymousId: 'eVar3'
+          anonymousId: 'eVar3',
+          event: 'eVar4'
         };
         analytics.track('Overlord exploded');
         analytics.equal(window.s.events, 'event7');
         analytics.assert(window.s.eVar2);
         analytics.assert(window.s.eVar3);
+        analytics.assert(window.s.eVar4);
         analytics.assert(
           contains(
             window.s.linkTrackVars,
             'events',
             'timestamp',
             'eVar2',
-            'eVar3'
+            'eVar3',
+            'eVar4'
           )
         );
         analytics.called(window.s.tl, true, 'o', 'Overlord exploded');
@@ -275,22 +278,25 @@ describe('Adobe Analytics', function() {
         analytics.called(window.s.tl, true, 'o', 'Drank Some Milk');
       });
 
-      it('should track set top level fields (msgId and anonId) set as props properly', function() {
+      it('should track set top level fields (msgId, anonId, event) set as props properly', function() {
         adobeAnalytics.options.eVars = {
           messageId: 'prop1',
-          anonymousId: 'prop2'
+          anonymousId: 'prop2',
+          event: 'prop3'
         };
         analytics.track('Overlord exploded');
         analytics.equal(window.s.events, 'event7');
         analytics.assert(window.s.prop1);
         analytics.assert(window.s.prop2);
+        analytics.assert(window.s.prop3);
         analytics.assert(
           contains(
             window.s.linkTrackVars,
             'events',
             'timestamp',
             'prop1',
-            'prop2'
+            'prop2',
+            'prop3'
           )
         );
         analytics.called(window.s.tl, true, 'o', 'Overlord exploded');
@@ -314,14 +320,16 @@ describe('Adobe Analytics', function() {
         analytics.called(window.s.tl);
       });
 
-      it('should send top level fields (msgId & anonId) as context properties', function() {
+      it('should send top level fields (msgId, anonId, event) as context properties', function() {
         adobeAnalytics.options.contextValues = {
           messageId: 'messageIdAdobe',
-          anonymousId: 'anonymousIdAdobe'
+          anonymousId: 'anonymousIdAdobe',
+          event: 'adobeEvent'
         };
         analytics.track('Drank Some Milk', { foo: 'bar' });
         analytics.assert(window.s.contextData.messageIdAdobe);
         analytics.assert(window.s.contextData.anonymousIdAdobe);
+        analytics.assert(window.s.contextData.adobeEvent);
         analytics.called(window.s.tl);
       });
 
@@ -1203,10 +1211,11 @@ describe('Adobe Analytics', function() {
         analytics.called(window.s.t);
       });
 
-      it('tracks top level fields (msgId & anonId) as mapped properties', function() {
+      it('tracks top level fields (msgId, anonId, event) as mapped properties', function() {
         adobeAnalytics.options.props = {
           anonymousId: 'prop1',
-          messageId: 'prop2'
+          messageId: 'prop2',
+          event: 'prop3'
         };
         analytics.page('Drank Some Milk', {
           type: '2%',
@@ -1216,6 +1225,7 @@ describe('Adobe Analytics', function() {
         analytics.equal(window.s.pageName, 'Drank Some Milk');
         analytics.assert(window.s.prop1);
         analytics.assert(window.s.prop2);
+        analytics.assert(window.s.prop3);
         analytics.called(window.s.t);
       });
 
@@ -1241,14 +1251,16 @@ describe('Adobe Analytics', function() {
         analytics.called(window.s.t);
       });
 
-      it('should send top level fields (msgId & anonId) as context properties', function() {
+      it('should send top level fields (msgId, anonId, event) as context properties', function() {
         adobeAnalytics.options.contextValues = {
           anonymousId: 'anonymousId',
-          messageId: 'messageId'
+          messageId: 'messageId',
+          event: 'eventContextData'
         };
         analytics.page('Page1', {});
         analytics.assert(window.s.contextData.anonymousId);
         analytics.assert(window.s.contextData.messageId);
+        analytics.assert(window.s.contextData.eventContextData);
         analytics.called(window.s.t);
       });
 


### PR DESCRIPTION
**What does this PR do?**
Add support for customers to map event as top level property to context data variables. This is a specific Fox request: 

> Fox is requesting the ability to send the event name (stored in the event top-level field on track calls) to Adobe as a Context Data Variable

**Are there breaking changes in this PR?**
No. Tested with compiler. 

**Any background context you want to provide?**
This is to resolve outstanding issues in #fox-adobe-discrepancy issue.

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
Not at this time. Updates to those components will be followed in this ticket. and prioritized at at a later point in time. https://segment.atlassian.net/browse/STRATCONN-182

**Does this require a new integration setting? If so, please explain how the new setting works**
No. 

**Links to helpful docs and other external resources**
