### PR TITLE
Adobe Analytics: Window-based playhead values

### DIFF
--- a/integrations/adobe-analytics/HISTORY.md
+++ b/integrations/adobe-analytics/HISTORY.md
@@ -1,3 +1,7 @@
+1.16.2 / 2020-05-17
+===================
+* Reads session playhead values from `window._segHBPlayheads` if it exists. This solves an issue where the playhead is only updated when 'Video Content Playing' (+ various others) events are tracked. To get around this, we allow video implementations to set the playhead value as often as possible without the need to trigger an event.
+
 1.16.1 / 2020-05-15
 ===================
 * Supports sending top level `event` as `prop`, `eVar`, `lVar`, `hVar`, or Context Data Variable.

--- a/integrations/adobe-analytics/lib/index.js
+++ b/integrations/adobe-analytics/lib/index.js
@@ -135,6 +135,10 @@ AdobeAnalytics.prototype.initialize = function() {
   // In case this has been defined already
   window.s_account = window.s_account || options.reportSuiteId;
 
+  // Initialize a window object that can be used to update the playhead value of a session
+  // WITHOUT sending several 'Video Content Playing' events. (see line 1242)
+  window._segHBPlayheads = {};
+
   // Load the larger Heartbeat script only if the customer has it enabled in settings.
   // This file is considerably bigger, so this check is necessary.
   if (options.heartbeatTrackingServerUrl) {
@@ -1236,7 +1240,17 @@ function initHeartbeat(track) {
   mediaHeartbeatConfig.debugLogging = !!window._enableHeartbeatDebugLogging; // Optional beta flag for seeing debug output.
 
   mediaHeartbeatDelegate.getCurrentPlaybackTime = function() {
-    return self.playhead || 0; // TODO: Bind to the Heartbeat events we have specced.
+    var playhead = self.playhead || 0;
+
+    // We allow implementions to set the playhead value of a video session on a shared
+    // window object. This allows us to relay the playhead to AA's heartbeat SDK several
+    // times a second, without relying on a 'Video Content Playing' event to update the position.
+    var sessions = window._segHBPlayheads || {};
+    if (sessions[props.session_id]) {
+      playhead = sessions[props.session_id];
+    }
+
+    return playhead;
   };
 
   mediaHeartbeatDelegate.getQoSObject = function() {

--- a/integrations/adobe-analytics/package.json
+++ b/integrations/adobe-analytics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-adobe-analytics",
   "description": "The Adobe Analytics analytics.js integration.",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/adobe-analytics/test/index.test.js
+++ b/integrations/adobe-analytics/test/index.test.js
@@ -1833,6 +1833,26 @@ describe('Adobe Analytics', function() {
           'trackPause'
         );
       });
+
+      it('should return the playhead value from the window object', function() {
+        analytics.track('Video Playback Started', {
+          session_id: sessionId,
+          channel: 'Black Mesa',
+          video_player: 'Transit Announcement System',
+          playhead: 5,
+          asset_id: 'Gordon Freeman',
+          title: 'Half-Life',
+          total_length: 1260,
+          livestream: false
+        });
+
+        window._segHBPlayheads[sessionId] = 5.111;
+
+        var actual = adobeAnalytics.mediaHeartbeats[
+          sessionId
+        ].delegate.getCurrentPlaybackTime();
+        analytics.assert(actual, 5.111);
+      });
     });
   });
 });


### PR DESCRIPTION
**What does this PR do?**
Reads session playhead values from `window._segHBPlayheads` if it exists. This solves an issue where the playhead is only updated when `Video Content Playing` (+ various others) events are tracked. To get around this, we allow video implementations to set the playhead value as often as possible without the need to trigger an event. 

Adobe Analytics expects the playhead to be updated at least every second.

**Are there breaking changes in this PR?**
Nah

**Any background context you want to provide?**


**Is there parity with the server-side/android/iOS integration components (if applicable)?**


**Does this require a new integration setting? If so, please explain how the new setting works**


**Links to helpful docs and other external resources**
