### PR TITLE
Map from "Product Viewed" to "PageVisit"

### DIFF
--- a/integrations/pinterest-tag/lib/index.js
+++ b/integrations/pinterest-tag/lib/index.js
@@ -92,7 +92,8 @@ Pinterest.prototype.getPinterestEvent = function(segmentEvent) {
     [analyticsEvents.productListFiltered, 'Search'],
     [analyticsEvents.productAdded, 'AddToCart'],
     [analyticsEvents.orderCompleted, 'Checkout'],
-    [analyticsEvents.videoPlaybackStarted, 'WatchVideo']
+    [analyticsEvents.videoPlaybackStarted, 'WatchVideo'],
+    [analyticsEvents.productViewed, "PageVisit"]
   ];
 
   for (var index in eventMap) {


### PR DESCRIPTION
**Summary**
Hackday project (https://docs.google.com/document/d/1vOFa_LbbE6TfWBCPqfJbhzM30iQQs7lUkzmgyeGxWag/edit) to fix implementation and map "Product Viewed" to the Pinterest's "PageVisit" event type which accepts product data: https://developers.pinterest.com/docs/ad-tools/conversion-tag/

**What does this PR do?**
Maps "Product Viewed" to "PageVisit"

**Are there breaking changes in this PR?**
No, it will only add to existing implementations.

**Any background context you want to provide?**
Spoke to Ben Phillips, SE from Pinterest, who validated the approach.

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
No, this is only web

**Does this require a new integration setting? If so, please explain how the new setting works**
No

**Links to helpful docs and other external resources**
https://docs.google.com/document/d/1vOFa_LbbE6TfWBCPqfJbhzM30iQQs7lUkzmgyeGxWag/edit#

https://developers.pinterest.com/docs/ad-tools/conversion-tag/?