### PR TITLE
[PD-154] - Send hosted match id

### DIFF
--- a/integrations/doubleclick-floodlight/lib/index.js
+++ b/integrations/doubleclick-floodlight/lib/index.js
@@ -31,7 +31,7 @@ var Floodlight = (module.exports = integration('DoubleClick Floodlight')
   )
   .tag(
     'doubleclick id',
-    '<img src="//cm.g.doubleclick.net/pixel?google_cm&google_nid={{ googleNetworkId }}&segment_write_key={{ segmentWriteKey }}&user_id={{ userId }}&anonymous_id={{ anonymousId }}"/>'
+    '<img src="//cm.g.doubleclick.net/pixel?google_cm&google_nid={{ googleNetworkId }}&segment_write_key={{ segmentWriteKey }}&user_id={{ userId }}&anonymous_id={{ anonymousId }}&google_hm={{ hostedMatchId }}"/>'
   ));
 
 /**
@@ -51,7 +51,8 @@ Floodlight.prototype.initialize = function() {
       segmentWriteKey: this.options.segmentWriteKey,
       // TODO: handle userId being nulls/undefined.
       userId: this.analytics.user().id(),
-      anonymousId: this.analytics.user().anonymousId()
+      anonymousId: this.analytics.user().anonymousId(),
+      hostedMatchId: btoa(this.analytics.user().anonymousId())
     });
   }
   this.ready();

--- a/integrations/doubleclick-floodlight/lib/index.js
+++ b/integrations/doubleclick-floodlight/lib/index.js
@@ -31,7 +31,7 @@ var Floodlight = (module.exports = integration('DoubleClick Floodlight')
   )
   .tag(
     'doubleclick id',
-    '<img src="//cm.g.doubleclick.net/pixel?google_cm&google_nid={{ googleNetworkId }}&segment_write_key={{ segmentWriteKey }}&user_id={{ userId }}&anonymous_id={{ anonymousId }}&google_hm={{ hostedMatchId }}"/>'
+    '<img src="//cm.g.doubleclick.net/pixel?google_cm&google_nid={{ googleNetworkId }}&segment_write_key={{ segmentWriteKey }}&user_id={{ userId }}&anonymous_id={{ anonymousId }}&google_hm={{ partnerProvidedId }}"/>'
   ));
 
 /**
@@ -52,7 +52,8 @@ Floodlight.prototype.initialize = function() {
       // TODO: handle userId being nulls/undefined.
       userId: this.analytics.user().id(),
       anonymousId: this.analytics.user().anonymousId(),
-      hostedMatchId: btoa(this.analytics.user().anonymousId())
+      // Hosted match table id https://developers.google.com/authorized-buyers/rtb/cookie-guide#match-table
+      partnerProvidedId: btoa(this.analytics.user().anonymousId())
     });
   }
   this.ready();


### PR DESCRIPTION
**What does this PR do?**
We have a June 1st deadline to migrate away from the "partner hosted match table" in favor of a [Google hosted match table](https://developers.google.com/authorized-buyers/rtb/cookie-guide#match-table)

[The `google_gid` identifier that we consume in `idsync-service`](https://github.com/segmentio/record/blob/master/idsync-service/cmd/idsync-service/handler.go#L53) (the service responsible for implementing our hosted match table) will no longer be sent after this date

> Google will no longer send google_gid parameter in the cookie matching request for the users in California.

This PR directly sends an anon id to google via the [`google_hm`](https://developers.google.com/authorized-buyers/rtb/cookie-guide#match-table) param since they will be responsible for maintaining the link between our anon ids and their internal gids. 


**Are there breaking changes in this PR?**
No

**Any background context you want to provide?**


**Is there parity with the server-side/android/iOS integration components (if applicable)?**


**Does this require a new integration setting? If so, please explain how the new setting works**


**Links to helpful docs and other external resources**

Personas DV360 List Integration change
https://github.com/segmentio/record/pull/2753