### PR TITLE
feat (Optimizely): Support passing a specific clientInstance to track

### DIFF
--- a/integrations/optimizely/lib/index.js
+++ b/integrations/optimizely/lib/index.js
@@ -118,9 +118,11 @@ Optimizely.prototype.track = function(track) {
 
   push(payload);
 
-  var optimizelyClientInstance = window.optimizelyClientInstance;
+  var optimizelyOptions = track.options('Optimizely');
+  // Prefer the client instance specified via options, falling back to the globally defined one.
+  var optimizelyClientInstance =
+    optimizelyOptions.clientInstance || window.optimizelyClientInstance;
   if (optimizelyClientInstance && optimizelyClientInstance.track) {
-    var optimizelyOptions = track.options('Optimizely');
     var userId =
       optimizelyOptions.userId || track.userId() || this.analytics.user().id();
     var attributes =

--- a/integrations/optimizely/test/index.test.js
+++ b/integrations/optimizely/test/index.test.js
@@ -1125,6 +1125,38 @@ describe('Optimizely', function() {
           window.optimizelyClientInstance.track.restore();
         });
 
+        context(
+          'when the Optimizely.clientInstance option is present',
+          function() {
+            beforeEach(function() {
+              window.otherClientInstance = {};
+              analytics.stub(window.otherClientInstance, 'track');
+            });
+            it('should prefer the specified client instance over the global one', function() {
+              analytics.identify('user1');
+              analytics.track(
+                'event',
+                { purchasePrice: 9.99, property: 'foo' },
+                {
+                  Optimizely: {
+                    userId: 'user1',
+                    attributes: { country: 'usa' },
+                    clientInstance: window.otherClientInstance
+                  }
+                }
+              );
+              analytics.didNotCall(window.optimizelyClientInstance.track);
+              analytics.called(
+                window.otherClientInstance.track,
+                'event',
+                'user1',
+                { country: 'usa' },
+                { purchasePrice: 9.99, property: 'foo' }
+              );
+            });
+          }
+        );
+
         it('should send an event through the Optimizely X Fullstack JS SDK using the logged in user', function() {
           analytics.identify('user1');
           analytics.track('event', { purchasePrice: 9.99, property: 'foo' });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1457,10 +1457,10 @@
     component-cookie "^1.1.2"
     component-url "^0.2.1"
 
-"@segment/tracktor@0.12.0":
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/@segment/tracktor/-/tracktor-0.12.0.tgz#2df0a1f8dad87e13ca4afac51655d6bac7c0c95f"
-  integrity sha512-yOGcYD33y0Wo1qHIA+IFIHcxk0GoRrQwCjpuaKZf2rnz0puZoseSGPdbIX47BgMLSSgEYnBoW3s5aUpCRdkEkw==
+"@segment/tracktor@0.12.1":
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/@segment/tracktor/-/tracktor-0.12.1.tgz#ca3e868f8b51c7da585764a482874addc31ea3e1"
+  integrity sha512-M9/XhBOHzerK1ZoiL/wOaM4gmzBOV6e2Z/xeic85qjKtiFSqNOBthlpyEGfEDKo6niEVBQm6wn86HgcAEkMDAg==
   dependencies:
     element-matches-polyfill "^1.0.0"
     whatwg-fetch "^3.0.0"


### PR DESCRIPTION
**What does this PR do?**

Adds an additional parameter to users of this integration, enabling them to specify which instance the JS SDK to use as part of a track call. 

**Example Usage:**

```typescript
// Instantiate an Optimizely client
var clientInstance = optimizely.createInstance({ datafile });
...
analytics.track('my_event', {}, {
  Optimizely: {
    clientInstance,
  }
})
```

**Are there breaking changes in this PR?**
No - Without this option, the code still uses `window.optimizelyClientInstance`

**Any background context you want to provide?**

Heavy users of our product may instantiate multiple client instances in the same global scope of the browser (window). Today, this integration only supports a single client instance.

With this PR, all callers of `.track` can specify which client instance they want to use for tracking.

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
N/A

**Does this require a new integration setting? If so, please explain how the new setting works**
No


**Links to helpful docs and other external resources**
