### PR TITLE
refactor: Clean up the Optimizely integration

### DIFF
--- a/integrations/optimizely/HISTORY.md
+++ b/integrations/optimizely/HISTORY.md
@@ -1,4 +1,12 @@
 
+4.0.0 / 2020-06-12
+==================
+
+  * Don't attempt to interface with Optimizely Classic Web, since Classic is finally dead
+  * Prepare to support Optimizely Edge, an alternative to Optimizely Web
+  * Drop all references to customCampaignProperties. It seems to have been documented [here](https://segment.com/docs/connections/destinations/catalog/optimizely-web/#settings) but it couldn't possibly have worked.
+  * Generally refactor the code and tests.
+
 3.5.0 / 2019-12-28
 ==================
 

--- a/integrations/optimizely/lib/index.js
+++ b/integrations/optimizely/lib/index.js
@@ -23,8 +23,7 @@ var Optimizely = (module.exports = integration('Optimizely')
   .option('listen', true) // send data via `.track()`
   .option('nonInteraction', false)
   .option('sendRevenueOnlyForOrderCompleted', true)
-  .option('customExperimentProperties', {})
-  .option('customCampaignProperties', {}));
+);
 
 /**
  * The name and version for this integration.
@@ -38,9 +37,6 @@ var optimizelyContext = {
 /**
  * Initialize.
  *
- * https://www.optimizely.com/docs/api#function-calls
- * https://jsfiddle.net/ushmw723/ <- includes optimizely snippets for capturing campaign and experiment data
- *
  * @api public
  */
 
@@ -51,38 +47,29 @@ Optimizely.prototype.initialize = function() {
     type: 'integration',
     OAuthClientId: '5360906403'
   });
-  // Initialize listeners for both Classic and New Optimizely
-  // crazying binding because that's just how javascript works
+  // Initialize listeners for Optimizely Web decisions.
   // We're caling this on the next tick to be safe so we don't hold up
   // initializing the integration even though the function below is designed to be async,
   // just want to be extra safe
   tick(function() {
-    Optimizely.initOptimizelyIntegration({
-      referrerOverride: self.setEffectiveReferrer.bind(self),
-      sendExperimentData: self.sendClassicDataToSegment.bind(self),
-      sendCampaignData: self.sendNewDataToSegment.bind(self)
-    });
+    this.initWebIntegration();
   });
 
   this.ready();
 };
 
 /**
- * Track. The Optimizely X Web event API accepts a single payload object.
- *        It works with Classic Optimizely as well.
+ * Track.
  *
- * Optimizely X:  https://developers.optimizely.com/x/solutions/javascript/reference/index.html#function_setevent
+ * If Optimizely Web or Optimizely Edge is implemented on the page, its JS API can accept a custom event.
+ * https://docs.developers.optimizely.com/web/docs/event
+ * https://docs.developers.optimizely.com/performance-edge/reference/event
  *
- * The new-style X API is forward compatible from Optimizely Classic to Optimizely X.
- *   - Classic will correctly consume the tags object to identify the revenue
- *   - In bundled mode, it will be forwarded along to the X API with the entire payload
- *
- * If the Optimizely X Fullstack JavaScript SDK is being used we should pass along
- * the event to it. Any properties in the track object will be passed along as event tags.
+ * If the Optimizely Full Stack JavaScript SDK is initialized on the page, its API can also accept a custom event.
+ * Any properties in the track object will be passed along as event tags.
  * If the userId is not passed into the options object of the track call, we'll
  * attempt to use the userId of the track event, which is set using the analytics.identify call.
- *
- * https://developers.optimizely.com/x/solutions/sdks/reference/?language=javascript#tracking
+ * https://docs.developers.optimizely.com/full-stack/docs/track-javascript
  *
  * @api public
  * @param {Track} track
@@ -108,7 +95,6 @@ Optimizely.prototype.track = function(track) {
     eventProperties.revenue = Math.round(eventProperties.revenue * 100);
   }
 
-  // Use the new-style API (which is compatible with Classic and X)
   var eventName = track.event().replace(/:/g, '_'); // can't have colons so replacing with underscores
   var payload = {
     type: 'event',
@@ -116,8 +102,10 @@ Optimizely.prototype.track = function(track) {
     tags: eventProperties
   };
 
+  // Track via Optimizely Web
   push(payload);
 
+  // Track via Optimizely Full Stack
   var optimizelyClientInstance = window.optimizelyClientInstance;
   if (optimizelyClientInstance && optimizelyClientInstance.track) {
     var optimizelyOptions = track.options('Optimizely');
@@ -141,8 +129,6 @@ Optimizely.prototype.track = function(track) {
 /**
  * Page.
  *
- * https://www.optimizely.com/docs/api#track-event
- *
  * @api public
  * @param {Page} page
  */
@@ -164,165 +150,32 @@ Optimizely.prototype.page = function(page) {
 };
 
 /**
- * sendClassicDataToSegment (Optimizely Classic)
- *
- * This function is executed for each experiment created in Classic Optimizely that is running on the page.
- * This function will also be executed for any experiments activated at a later stage since initOptimizelyIntegration
- * attached listeners on the page
- *
- * @api private
- * @param {Object} experimentState: contains all information regarding experiments
- * @param {Object} experimentState.experiment: the experiment running on the page
- * @param {String} experimentState.experiment.name: name of the experiment
- * @param {String} experimentState.experiment.id: ID of the experiment
- * @param {String} experimentState.experiment.referrer: available if effective referrer if experiment is a redirect
- * @param {Array} experimentState.variations: the variations the current user on page is seeing
- * @param {String} experimentState.variations[].name: the name of the variation
- * @param {String} experimentState.variations[].id: the ID of the variation
- * @param {Object} experimentState.sections: the sections for the experiment (only defined for multivariate experiments) keyed by sectionId
- * @param {String} experimentState.sections[sectionId].name: the name of section
- * @param {Array} experimentState.sections[sectionId].variation_ids: the IDs of the variations in the section
- *
- */
-
-Optimizely.prototype.sendClassicDataToSegment = function(experimentState) {
-  var experiment = experimentState.experiment;
-  var variations = experimentState.variations;
-  var sections = experimentState.sections;
-  var context = { integration: optimizelyContext }; // backward compatibility
-
-  // Reformatting this data structure into hash map so concatenating variation ids and names is easier later
-  var variationsMap = foldl(
-    function(results, variation) {
-      var res = results;
-      res[variation.id] = variation.name;
-      return res;
-    },
-    {},
-    variations
-  );
-
-  // Sorting for consistency across browsers
-  var variationIds = keys(variationsMap).sort();
-  var variationNames = values(variationsMap).sort();
-
-  // Send data via `.track()`
-  if (this.options.listen) {
-    var props = {
-      experimentId: experiment.id,
-      experimentName: experiment.name,
-      variationId: variationIds.join(), // eg. '123' or '123,455'
-      variationName: variationNames.join(', ') // eg. 'Variation X' or 'Variation 1, Variation 2'
-    };
-
-    // If this was a redirect experiment and the effective referrer is different from document.referrer,
-    // this value is made available. So if a customer came in via google.com/ad -> tb12.com -> redirect experiment -> Belichickgoat.com
-    // `experiment.referrer` would be google.com/ad here NOT `tb12.com`.
-    if (experiment.referrer) {
-      props.referrer = experiment.referrer;
-      context.page = { referrer: experiment.referrer };
-    }
-
-    // When there is a multivariate experiment
-    if (sections) {
-      // Since `sections` include all the possible sections on the page, we need to find the names of the sections
-      // if any of its variations were used. Experiments could display variations from multiple sections.
-      // The global optimizely data object does not expose a mapping between which section(s) were involved within an experiment.
-      // So we will build our own mapping to quickly get the section name(s) and id(s) for any displayed variation.
-      var activeSections = {};
-      var variationIdsToSectionsMap = foldl(
-        function(results, section, sectionId) {
-          var res = results;
-          each(function(variationId) {
-            res[variationId] = { id: sectionId, name: section.name };
-          }, section.variation_ids);
-          return res;
-        },
-        {},
-        sections
-      );
-      for (var j = 0; j < variationIds.length; j++) {
-        var activeVariation = variationIds[j];
-        var activeSection = variationIdsToSectionsMap[activeVariation];
-        if (activeSection)
-          activeSections[activeSection.id] = activeSection.name;
-      }
-
-      // Sorting for consistency across browsers
-      props.sectionId = keys(activeSections)
-        .sort()
-        .join(); // Not adding space for backward compat/consistency reasons since all IDs we've never had spaces
-      props.sectionName = values(activeSections)
-        .sort()
-        .join(', ');
-    }
-
-    // For Google's nonInteraction flag
-    if (this.options.nonInteraction) props.nonInteraction = 1;
-
-    // If customExperimentProperties is provided overide the props with it.
-    // If valid customExperimentProperties present it will override existing props.
-    var customExperimentProperties = this.options.customExperimentProperties;
-    var customPropsKeys = Object.keys(customExperimentProperties);
-    var data = window.optimizely && window.optimizely.data;
-
-    if (data && customPropsKeys.length) {
-      for (var index = 0; index < customPropsKeys.length; index++) {
-        var segmentProp = customPropsKeys[index];
-        var optimizelyProp = customExperimentProperties[segmentProp];
-        if (typeof data[optimizelyProp] !== 'undefined') {
-          props[segmentProp] = data[optimizelyProp];
-        }
-      }
-    }
-
-    // Send to Segment
-    this.analytics.track('Experiment Viewed', props, context);
-  }
-
-  // Send data via `.identify()` (not recommended!)
-  // TODO: deprecate this feature
-  if (this.options.variations) {
-    // Note: The only "breaking" behavior is that now there will be an `.identify()` call per active experiment
-    // Legacy behavior was that we would look up all active experiments on the page after init and send one `.identify()` call
-    // with all experiment/variation data as traits.
-    // New behavior will call `.identify()` per active experiment with isolated experiment/variation data for that single experiment
-    // However, since traits are cached, subsequent experiments that trigger `.identify()` calls will likely contain previous experiment data
-    var traits = {};
-    traits['Experiment: ' + experiment.name] = variationNames.join(', '); // eg. 'Variation X' or 'Variation 1, Variation 2'
-
-    // Send to Segment
-    this.analytics.identify(traits);
-  }
-};
-
-/**
- * sendNewDataToSegment (Optimizely X)
+ * sendWebDecisionToSegment (Optimizely X)
  *
  * This function is called for each experiment created in New Optimizely that are running on the page.
  * New Optimizely added a dimension called "Campaigns" that encapsulate over the Experiments. So a campaign can have multiple experiments.
  * Multivariate experiments are no longer supported in New Optimizely.
- * This function will also be executed for any experiments activated at a later stage since initOptimizelyIntegration
+ * This function will also be executed for any experiments activated at a later stage since initWebIntegration
  * attached listeners on the page
  *
  * @api private
- * @param {Object} campaignState: contains all information regarding experiments and campaign
- * @param {String} campaignState.id: the ID of the campaign
- * @param {String} campaignState.campaignName: the name of the campaign
- * @param {Array} campaignState.audiences: "Audiences" the visitor is considered part of related to this campaign
- * @param {String} campaignState.audiences[].id: the id of the Audience
- * @param {String} campaignState.audiences[].name: the name of the Audience
- * @param {Object} campaignState.experiment: the experiment the visitor is seeing
- * @param {String} campaignState.experiment.id: the id of the experiment
- * @param {String} campaignState.experiment.name: the name of the experiment
- * @param {String} campaignState.experiment.referrer: the effective referrer of the experiment (only defined for redirect)
- * @param {Object} campaignState.variation: the variation the visitor is seeing
- * @param {String} campaignState.variation.id: the id of the variation
- * @param {String} campaignState.variation.name: the name of the variation
- * @param {String} campaignState.isInCampaignHoldback: whether the visitor is in the Campaign holdback
+ * @param {String} id
+ * @param {String|undefined} referrer
  */
 
-Optimizely.prototype.sendNewDataToSegment = function(campaignState) {
+Optimizely.prototype.sendWebDecisionToSegment = function(id, referrer) {
+  var state = window.optimizely.get && window.optimizely.get('state');
+  if (!state) {
+    return;
+  }
+
+  var activeCampaigns = state.getCampaignStates({
+    isActive: true
+  });
+  var campaignState = activeCampaigns[id];
+  // Legacy. It's more accurate to use on context.page.referrer or window.optimizelyEffectiveReferrer.
+  if (referrer) campaignState.experiment.referrer = referrer;
+
   var experiment = campaignState.experiment;
   var variation = campaignState.variation;
   var context = { integration: optimizelyContext }; // backward compatibility
@@ -371,21 +224,6 @@ Optimizely.prototype.sendNewDataToSegment = function(campaignState) {
     // For Google's nonInteraction flag
     if (this.options.nonInteraction) props.nonInteraction = 1;
 
-    // If customCampaignProperties is provided overide the props with it.
-    // If valid customCampaignProperties present it will override existing props.
-    var customCampaignProperties = this.options.customCampaignProperties;
-    var customPropsKeys = Object.keys(customCampaignProperties);
-    var data = window.optimizely && window.optimizely.newMockData;
-    if (data && customPropsKeys.length) {
-      for (var index = 0; index < customPropsKeys.length; index++) {
-        var segmentProp = customPropsKeys[index];
-        var optimizelyProp = customCampaignProperties[segmentProp];
-        if (typeof data[optimizelyProp] !== 'undefined') {
-          props[segmentProp] = data[optimizelyProp];
-        }
-      }
-    }
-
     // Send to Segment
     this.analytics.track('Experiment Viewed', props, context);
   }
@@ -426,205 +264,85 @@ Optimizely.prototype.setEffectiveReferrer = function(referrer) {
 };
 
 /**
- * initOptimizelyIntegration(handlers)
- *
- * This function was provided by Optimizely's Engineering team. The function below once initialized can detect which version of
- * Optimizely a customer is using and call the appropriate callback functions when an experiment runs on the page.
- * Instead of Segment looking up the experiment data, we can now just bind Segment APIs to their experiment listener/handlers!
+ * This function fetches all active Optimizely Web campaigns and experiments,
+ * invoking the sendWebDecisionToSegment callback for each one.
  *
  * @api private
- * @param {Object} handlers
- * @param {Function} referrerOverride: called if the effective refferer value differs from the current `document.referrer` due to a
- * invocation of a redirect experiment on the page
- * @param {Function} sendExperimentData: called for every running experiment on the page (Classic)
- * @param {Function} sendCampaignData: called for every running campaign on the page (New)
  */
+Optimizely.prototype.initWebIntegration = function() {
+  var self = this;
 
-Optimizely.initOptimizelyIntegration = function(handlers) {
-  /**
-   * `initClassicOptimizelyIntegration` fetches all the experiment data from the classic Optimizely client
-   * and calls the functions provided in the arguments with the data that needs to
-   * be used for sending information. It is recommended to leave this function as is
-   * and to create your own implementation of the functions referrerOverride and
-   * sendExperimentData.
-   *
-   * @param {Function} referrerOverride - This function is called if the effective referrer value differs from
-   *   the current document.referrer value. The only argument provided is the effective referrer value.
-   * @param {Function} sendExperimentData - This function is called for every running experiment on the page.
-   *   The function is called with all the relevant ids and names.
-   */
-  var initClassicOptimizelyIntegration = function(
-    referrerOverride,
-    sendExperimentData
-  ) {
-    var data = window.optimizely && window.optimizely.data;
-    var state = data && data.state;
+  var checkReferrer = function() {
+    var state = window.optimizely.get && window.optimizely.get('state');
     if (state) {
-      var activeExperiments = state.activeExperiments;
-      if (state.redirectExperiment) {
-        var redirectExperimentId = state.redirectExperiment.experimentId;
-        var index = -1;
-        for (var i = 0; i < state.activeExperiments.length; i++) {
-          if (state.activeExperiments[i] === redirectExperimentId) {
-            index = i;
-            break;
-          }
-        }
-        if (index === -1) {
-          activeExperiments.push(redirectExperimentId);
-        }
-        referrerOverride(state.redirectExperiment.referrer);
-      }
+      var referrer =
+        state.getRedirectInfo() && state.getRedirectInfo().referrer;
 
-      for (var k = 0; k < activeExperiments.length; k++) {
-        var currentExperimentId = activeExperiments[k];
-        var activeExperimentState = {
-          experiment: {
-            id: currentExperimentId,
-            name: data.experiments[currentExperimentId].name
-          },
-          variations: [],
-          /** Segment added code */
-          // we need to send sectionName for multivariate experiments
-          sections: data.sections
-          /**/
-        };
-
-        /** Segment added code */
-        // for backward compatability since we send referrer with the experiment properties
-        if (
-          state.redirectExperiment &&
-          currentExperimentId === state.redirectExperiment.experimentId &&
-          state.redirectExperiment.referrer
-        ) {
-          activeExperimentState.experiment.referrer =
-            state.redirectExperiment.referrer;
-        }
-        /**/
-
-        var variationIds =
-          state.variationIdsMap[activeExperimentState.experiment.id];
-        for (var j = 0; j < variationIds.length; j++) {
-          var id = variationIds[j];
-          var name = data.variations[id].name;
-          activeExperimentState.variations.push({
-            id: id,
-            name: name
-          });
-        }
-        sendExperimentData(activeExperimentState);
+      if (referrer) {
+        self.setEffectiveReferrer(referrer);
+        return referrer; // Segment added code: so I can pass this referrer value in cb
       }
     }
   };
 
   /**
-   * This function fetches all the campaign data from the new Optimizely client
-   * and calls the functions provided in the arguments with the data that needs to
-   * be used for sending information. It is recommended to leave this function as is
-   * and to create your own implementation of the functions referrerOverride and
-   * sendCampaignData.
-   *
-   * @param {Function} referrerOverride - This function is called if the effective referrer value differs from
-   *   the current document.referrer value. The only argument provided is the effective referrer value.
-   * @param {Function} sendCampaignData - This function is called for every running campaign on the page.
-   *   The function is called with the campaignState for the activated campaign
+   * A campaign or experiment can be activated after we have initialized.
+   * This function registers a listener that listens to newly activated campaigns and
+   * handles them.
    */
-  var initNewOptimizelyIntegration = function(
-    referrerOverride,
-    sendCampaignData
-  ) {
-    var newActiveCampaign = function(id, referrer) {
-      var state = window.optimizely.get && window.optimizely.get('state');
-      if (state) {
-        var activeCampaigns = state.getCampaignStates({
-          isActive: true
-        });
-        var campaignState = activeCampaigns[id];
-        // Segment added code: in case this is a redirect experiment
-        if (referrer) campaignState.experiment.referrer = referrer;
-        sendCampaignData(campaignState);
+  var registerFutureActiveCampaigns = function() {
+    window.optimizely = window.optimizely || [];
+    window.optimizely.push({
+      type: 'addListener',
+      filter: {
+        type: 'lifecycle',
+        name: 'campaignDecided'
+      },
+      handler: function(event) {
+        var id = event.data.campaign.id;
+        self.sendWebDecisionToSegment(id);
       }
-    };
+    });
+  };
 
-    var checkReferrer = function() {
-      var state = window.optimizely.get && window.optimizely.get('state');
-      if (state) {
-        var referrer =
-          state.getRedirectInfo() && state.getRedirectInfo().referrer;
-
-        if (referrer) {
-          referrerOverride(referrer);
-          return referrer; // Segment added code: so I can pass this referrer value in cb
+  /**
+   * If this code is running after Optimizely on the page, there might already be
+   * some campaigns or experiments active. This function retrieves and handlers them.
+   *
+   * This function also checks for an effective referrer if the visitor got to the current
+   * page via an Optimizely redirect variation.
+   */
+  var registerCurrentlyActiveCampaigns = function() {
+    window.optimizely = window.optimizely || [];
+    var state = window.optimizely.get && window.optimizely.get('state');
+    if (state) {
+      var referrer = checkReferrer();
+      var activeCampaigns = state.getCampaignStates({
+        isActive: true
+      });
+      for (var id in activeCampaigns) {
+        if ({}.hasOwnProperty.call(activeCampaigns, id)) {
+          // Segment modified code: need to pass down referrer in the cb for backward compat reasons
+          if (referrer) {
+            self.sendWebDecisionToSegment(id, referrer);
+          } else {
+            self.sendWebDecisionToSegment(id);
+          }
         }
       }
-    };
-
-    /**
-     * At any moment, a new campaign can be activated (manual or conditional activation).
-     * This function registers a listener that listens to newly activated campaigns and
-     * handles them.
-     */
-    var registerFutureActiveCampaigns = function() {
-      window.optimizely = window.optimizely || [];
+    } else {
       window.optimizely.push({
         type: 'addListener',
         filter: {
           type: 'lifecycle',
-          name: 'campaignDecided'
+          name: 'initialized'
         },
-        handler: function(event) {
-          var id = event.data.campaign.id;
-          newActiveCampaign(id);
+        handler: function() {
+          checkReferrer();
         }
       });
-    };
-
-    /**
-     * If this code is running after Optimizely on the page, there might already be
-     * some campaigns active. This function makes sure all those campaigns are
-     * handled.
-     */
-    var registerCurrentlyActiveCampaigns = function() {
-      window.optimizely = window.optimizely || [];
-      var state = window.optimizely.get && window.optimizely.get('state');
-      if (state) {
-        var referrer = checkReferrer();
-        var activeCampaigns = state.getCampaignStates({
-          isActive: true
-        });
-        for (var id in activeCampaigns) {
-          if ({}.hasOwnProperty.call(activeCampaigns, id)) {
-            // Segment modified code: need to pass down referrer in the cb for backward compat reasons
-            if (referrer) {
-              newActiveCampaign(id, referrer);
-            } else {
-              newActiveCampaign(id);
-            }
-          }
-        }
-      } else {
-        window.optimizely.push({
-          type: 'addListener',
-          filter: {
-            type: 'lifecycle',
-            name: 'initialized'
-          },
-          handler: function() {
-            checkReferrer();
-          }
-        });
-      }
-    };
-    registerCurrentlyActiveCampaigns();
-    registerFutureActiveCampaigns();
+    }
   };
-
-  initClassicOptimizelyIntegration(
-    handlers.referrerOverride,
-    handlers.sendExperimentData
-  );
-  initNewOptimizelyIntegration(
-    handlers.referrerOverride,
-    handlers.sendCampaignData
-  );
+  registerCurrentlyActiveCampaigns();
+  registerFutureActiveCampaigns();
 };

--- a/integrations/optimizely/test/index.test.js
+++ b/integrations/optimizely/test/index.test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var _ = require('lodash');
 var Analytics = require('@segment/analytics.js-core').constructor;
 var sandbox = require('@segment/clear-env');
 var tester = require('@segment/analytics.js-integration-tester');
@@ -8,54 +9,9 @@ var tick = require('next-tick');
 
 /**
  * Test account: han@segment.com
- *
- * Docs for Optimizely data object: https://developers.optimizely.com/javascript/personalization/index.html#reading-data-and-state
  */
 
-var mockOptimizelyClassicDataObject = function() {
-  // Classic
-  window.optimizely.data = {
-    experiments: {
-      0: { name: 'Test' },
-      1: { name: 'MultiVariate Test' },
-      2: { name: 'Inactive Test' },
-      11: { name: 'Redirect Test' }
-    },
-    variations: {
-      22: { name: 'Redirect Variation', code: '' },
-      123: { name: 'Variation #123', code: '' },
-      789: { name: 'Var 789', code: '' },
-      44: { name: 'Var 44', code: '' }
-    },
-    sections: undefined, // we'll set this during multivariate test since that's when this is set by Optimizely's API
-    state: {
-      activeExperiments: ['0', '11'],
-      variationNamesMap: {
-        0: 'Variation #123',
-        1: 'Variation #123, Redirect Variation, Var 789', // this is the data format
-        2: 'Inactive Variation',
-        11: 'Redirect Variation'
-      },
-      variationIdsMap: {
-        0: ['123'],
-        1: ['123', '22', '789'],
-        11: ['22'],
-        2: ['44']
-      },
-      redirectExperiment: {
-        variationId: '22',
-        experimentId: '11',
-        referrer: 'google.com'
-      }
-    }
-  };
-};
-
-// Optimizely X
-var mockOptimizelyXDataObject = function() {
-  // remove Classic data object
-  delete window.optimizely.data;
-
+var mockWindowOptimizely = function() {
   window.optimizely.newMockData = {
     2347102720: {
       audiences: [
@@ -131,37 +87,26 @@ var mockOptimizelyXDataObject = function() {
       visitorRedirected: false
     }
   };
-  // Optimizely init snippet uses new API methods below to access data rather than the global optimizely.data object
-  window.optimizely.get = function() {
-    return {
-      getCampaignStates: function(options) {
-        if (!('isActive' in options)) return window.optimizely.newMockData;
-        // returns all campaigns with option to return just active ones (which is what we do in the snippet)
-        var ret = {};
-        for (var campaign in window.optimizely.newMockData) {
-          if (
-            window.optimizely.newMockData[campaign].isActive ===
-            options.isActive
-          ) {
-            ret[campaign] = window.optimizely.newMockData[campaign];
+
+  window.optimizely = {
+    get: function() {
+      return {
+        getCampaignStates: function(options) {
+          if (!options.isActive) {
+            throw new Error('Incorrect call to getCampaignStates');
+          }
+          return _.filter(window.optimizely.newMockData, {isActive: options.isActive});
+        },
+        getRedirectInfo: function() {
+          var campaigns = this.getCampaignStates({ isActive: true });
+          for (var id in campaigns) {
+            if (campaigns[id].visitorRedirected)
+              return { referrer: 'barstools.com' };
           }
         }
-        return ret;
-      },
-      getRedirectInfo: function() {
-        var campaigns = this.getCampaignStates({ isActive: true });
-        for (var id in campaigns) {
-          if (campaigns[id].visitorRedirected)
-            return { referrer: 'barstools.com' };
-        }
-      }
-    };
+      };
+    }
   };
-};
-
-var mockBothOptimizelyDataObjects = function() {
-  mockOptimizelyXDataObject();
-  mockOptimizelyClassicDataObject();
 };
 
 // passed into context.integration (not context.integrations!) for all track calls for some reason
@@ -198,29 +143,22 @@ describe('Optimizely', function() {
   });
 
   describe('before loading', function() {
-    beforeEach(function() {
-      analytics.stub(
-        Optimizely,
-        'initOptimizelyIntegration',
-        Optimizely.initOptimizelyIntegration
-      ); // Reference to constructor intentionally
-      analytics.stub(optimizely, 'load');
-      analytics.stub(optimizely, 'sendClassicDataToSegment');
-      analytics.stub(optimizely, 'sendNewDataToSegment');
-      analytics.stub(optimizely, 'setEffectiveReferrer');
-    });
-
     describe('#initialize', function() {
       beforeEach(function(done) {
+        analytics.stub(optimizely, 'initWebIntegration');
         analytics.stub(window.optimizely, 'push');
         analytics.once('ready', done);
         analytics.initialize();
         analytics.page();
       });
 
-      it('should call initOptimizelyIntegration', function(done) {
+      afterEach(function() {
+        optimizely.initWebIntegration.restore();
+      });
+
+      it('should call initWebIntegration', function(done) {
         executeAsyncTest(done, function() {
-          analytics.called(Optimizely.initOptimizelyIntegration);
+          analytics.called(Optimizely.initWebIntegration);
         });
       });
 
@@ -232,260 +170,101 @@ describe('Optimizely', function() {
       });
     });
 
-    describe('#initOptimizelyIntegration', function() {
-      // Testing the behavior of the Optimizely provided private init function
-      // to ensure that proper callback functions were executed with expected params
-      // given each of the possible Optimizely snippet you could have on the page (Classic, X, Both)
-      describe('Classic', function() {
-        beforeEach(function(done) {
-          mockOptimizelyClassicDataObject();
-          analytics.initialize();
-          tick(done);
-        });
+    describe('#initWebIntegration', function() {
+      beforeEach(function() {
+        analytics.stub(optimizely, 'sendWebDecisionToSegment');
+        analytics.stub(optimizely, 'setEffectiveReferrer');
+        mockWindowOptimizely();
+      });
 
-        it('should call setEffectiveReferrer for redirect experiments', function() {
-          analytics.called(optimizely.setEffectiveReferrer, 'google.com');
-        });
+      afterEach(function() {
+        optimizely.sendWebDecisionToSegment.restore();
+        optimizely.setEffectiveReferrer.restore();
+      });
 
-        it('should call sendClassicDataToSegment for active Classic experiments', function() {
-          // we have two active experiments running in the mock data object
-          analytics.calledTwice(optimizely.sendClassicDataToSegment);
-          analytics.deepEqual(optimizely.sendClassicDataToSegment.args[0], [
-            {
-              experiment: {
-                id: '0',
-                name: 'Test'
-              },
-              variations: [
-                {
-                  id: '123',
-                  name: 'Variation #123'
-                }
-              ],
-              sections: undefined
-            }
-          ]);
-          analytics.deepEqual(optimizely.sendClassicDataToSegment.args[1], [
-            {
-              experiment: {
-                id: '11',
-                name: 'Redirect Test',
-                referrer: 'google.com'
-              },
-              variations: [
-                {
-                  id: '22',
-                  name: 'Redirect Variation'
-                }
-              ],
-              sections: undefined
-            }
-          ]);
+      it('should not call setEffectiveReferrer for non redirect experiments', function(done) {
+        // by default mock data has no redirect experiments active
+        analytics.initialize();
+        executeAsyncTest(done, function() {
+          analytics.didNotCall(optimizely.setEffectiveReferrer);
         });
       });
 
-      describe('New', function() {
-        beforeEach(function() {
-          mockOptimizelyXDataObject();
-        });
-
-        it('should not call setEffectiveReferrer for non redirect experiments', function(done) {
-          // by default mock data has no redirect experiments active
-          analytics.initialize();
-          executeAsyncTest(done, function() {
-            analytics.didNotCall(optimizely.setEffectiveReferrer);
-          });
-        });
-
-        it('should call setEffectiveReferrer for redirect experiments', function(done) {
-          // enable redirect experiment
-          window.optimizely.newMockData[2347102720].isActive = true;
-          analytics.initialize();
-          executeAsyncTest(done, function() {
-            analytics.called(optimizely.setEffectiveReferrer, 'barstools.com');
-          });
-        });
-
-        it('should call sendNewDataToSegment for active Optimizely X campaigns', function(done) {
-          analytics.initialize();
-          executeAsyncTest(done, function() {
-            analytics.calledTwice(optimizely.sendNewDataToSegment);
-            analytics.deepEqual(optimizely.sendNewDataToSegment.args[0], [
-              {
-                audiences: [
-                  {
-                    name: 'Penthouse 6',
-                    id: '8888222438'
-                  },
-                  {
-                    name: 'Fam Yolo',
-                    id: '1234567890'
-                  }
-                ],
-                campaignName: 'Coding Bootcamp',
-                id: '7222777766',
-                experiment: {
-                  id: '1111182111',
-                  name: 'Coding Bootcamp'
-                },
-                variation: {
-                  id: '7333333333',
-                  name: 'Variation DBC'
-                },
-                isActive: true,
-                isInCampaignHoldback: false,
-                reason: undefined,
-                visitorRedirected: false
-              }
-            ]);
-            analytics.deepEqual(optimizely.sendNewDataToSegment.args[1], [
-              {
-                audiences: [
-                  {
-                    name: 'Trust Tree',
-                    id: '7527565438'
-                  }
-                ],
-                campaignName: 'URF',
-                id: '7547101713',
-                experiment: {
-                  id: '7547682694',
-                  name: 'Worlds Group Stage'
-                },
-                variation: {
-                  id: '7557950020',
-                  name: 'Variation #1'
-                },
-                isActive: true,
-                isInCampaignHoldback: true,
-                reason: undefined,
-                visitorRedirected: false
-              }
-            ]);
-          });
+      it('should call setEffectiveReferrer for redirect experiments', function(done) {
+        // enable redirect experiment
+        window.optimizely.newMockData[2347102720].isActive = true;
+        analytics.initialize();
+        executeAsyncTest(done, function() {
+          analytics.called(optimizely.setEffectiveReferrer, 'barstools.com');
         });
       });
 
-      describe('Both', function() {
-        beforeEach(function() {
-          mockBothOptimizelyDataObjects();
-          analytics.initialize();
-        });
-
-        // Note: we're not testing setEffectiveReferrer here since you can only have one version
-        // or the other, not both. And each one has been tested in the above unit tests
-
-        it('should call both sendClassicDataToSegment and sendNewDataToSegment', function(done) {
-          // we have two active experiments running in the mock data object for both versions
-          executeAsyncTest(done, function() {
-            analytics.calledTwice(optimizely.sendClassicDataToSegment);
-            analytics.calledTwice(optimizely.sendNewDataToSegment);
-            analytics.deepEqual(optimizely.sendClassicDataToSegment.args[0], [
-              {
-                experiment: {
-                  id: '0',
-                  name: 'Test'
+      it('should call sendWebDecisionToSegment for active Optimizely X campaigns', function(done) {
+        analytics.initialize();
+        executeAsyncTest(done, function() {
+          analytics.calledTwice(optimizely.sendWebDecisionToSegment);
+          analytics.deepEqual(optimizely.sendWebDecisionToSegment.args[0], [
+            {
+              audiences: [
+                {
+                  name: 'Penthouse 6',
+                  id: '8888222438'
                 },
-                variations: [
-                  {
-                    id: '123',
-                    name: 'Variation #123'
-                  }
-                ],
-                sections: undefined
-              }
-            ]);
-            analytics.deepEqual(optimizely.sendClassicDataToSegment.args[1], [
-              {
-                experiment: {
-                  id: '11',
-                  name: 'Redirect Test',
-                  referrer: 'google.com'
-                },
-                variations: [
-                  {
-                    id: '22',
-                    name: 'Redirect Variation'
-                  }
-                ],
-                sections: undefined
-              }
-            ]);
-            analytics.deepEqual(optimizely.sendNewDataToSegment.args[0], [
-              {
-                audiences: [
-                  {
-                    name: 'Penthouse 6',
-                    id: '8888222438'
-                  },
-                  {
-                    name: 'Fam Yolo',
-                    id: '1234567890'
-                  }
-                ],
-                campaignName: 'Coding Bootcamp',
-                id: '7222777766',
-                experiment: {
-                  id: '1111182111',
-                  name: 'Coding Bootcamp'
-                },
-                variation: {
-                  id: '7333333333',
-                  name: 'Variation DBC'
-                },
-                isActive: true,
-                isInCampaignHoldback: false,
-                reason: undefined,
-                visitorRedirected: false
-              }
-            ]);
-            analytics.deepEqual(optimizely.sendNewDataToSegment.args[1], [
-              {
-                audiences: [
-                  {
-                    name: 'Trust Tree',
-                    id: '7527565438'
-                  }
-                ],
-                campaignName: 'URF',
-                id: '7547101713',
-                experiment: {
-                  id: '7547682694',
-                  name: 'Worlds Group Stage'
-                },
-                variation: {
-                  id: '7557950020',
-                  name: 'Variation #1'
-                },
-                isActive: true,
-                isInCampaignHoldback: true,
-                reason: undefined,
-                visitorRedirected: false
-              }
-            ]);
-          });
+                {
+                  name: 'Fam Yolo',
+                  id: '1234567890'
+                }
+              ],
+              campaignName: 'Coding Bootcamp',
+              id: '7222777766',
+              experiment: {
+                id: '1111182111',
+                name: 'Coding Bootcamp'
+              },
+              variation: {
+                id: '7333333333',
+                name: 'Variation DBC'
+              },
+              isActive: true,
+              isInCampaignHoldback: false,
+              reason: undefined,
+              visitorRedirected: false
+            }
+          ]);
+          analytics.deepEqual(optimizely.sendWebDecisionToSegment.args[1], [
+            {
+              audiences: [
+                {
+                  name: 'Trust Tree',
+                  id: '7527565438'
+                }
+              ],
+              campaignName: 'URF',
+              id: '7547101713',
+              experiment: {
+                id: '7547682694',
+                name: 'Worlds Group Stage'
+              },
+              variation: {
+                id: '7557950020',
+                name: 'Variation #1'
+              },
+              isActive: true,
+              isInCampaignHoldback: true,
+              reason: undefined,
+              visitorRedirected: false
+            }
+          ]);
         });
       });
     });
   });
 
   describe('#setEffectiveReferrer', function() {
-    describe('Classic', function() {
-      beforeEach(function(done) {
-        mockOptimizelyClassicDataObject();
-        analytics.initialize();
-        tick(done);
-      });
-
-      it('should set a global variable `window.optimizelyEffectiveReferrer`', function() {
-        analytics.equal(window.optimizelyEffectiveReferrer, 'google.com');
-      });
-    });
-
-    describe('New', function() {
+    describe('Web', function() {
       beforeEach(function() {
-        mockOptimizelyXDataObject();
-        // enable redirect experiment
+        mockWindowOptimizely();
+        // Make sure window.optimizely.getRedirectInfo returns something
         window.optimizely.newMockData[2347102720].isActive = true;
         analytics.initialize();
       });
@@ -496,299 +275,11 @@ describe('Optimizely', function() {
         });
       });
     });
-
-    // Again -- we're not testing for both since there is no point.
-    // You can't have this function execute twice each with different referrer value
-    // It will always either just call one or the other
   });
 
-  describe('#sendClassicDataToSegment', function() {
+  describe('#sendWebDecisionToSegment', function() {
     beforeEach(function() {
-      mockOptimizelyClassicDataObject();
-    });
-
-    describe('#options.variations', function() {
-      beforeEach(function(done) {
-        optimizely.options.variations = true;
-        analytics.stub(analytics, 'identify');
-        analytics.initialize();
-        tick(done);
-      });
-
-      it('should send each experiment via `.identify()`', function() {
-        // Since we have two experiments in `window.optimizely.data.state.activeExperiments`
-        // This test proves the breaking changes for the option (it used to send both experiment data in one
-        // `.identify()` call)
-        analytics.calledTwice(analytics.identify);
-        analytics.deepEqual(analytics.identify.args[0], [
-          {
-            'Experiment: Test': 'Variation #123'
-          }
-        ]);
-        analytics.deepEqual(analytics.identify.args[1], [
-          {
-            'Experiment: Redirect Test': 'Redirect Variation'
-          }
-        ]);
-      });
-    });
-
-    describe('#options.sendRevenueOnlyForOrderCompleted', function() {
-      beforeEach(function() {
-        analytics.stub(window.optimizely, 'push');
-      });
-
-      it('should not include revenue on a non Order Completed event if `onlySendRevenueOnOrderCompleted` is enabled', function() {
-        analytics.initialize();
-        analytics.track('Order Updated', {
-          revenue: 25
-        });
-        analytics.called(window.optimizely.push, {
-          type: 'event',
-          eventName: 'Order Updated',
-          tags: {}
-        });
-      });
-
-      it('should send revenue only on Order Completed if `onlySendRevenueOnOrderCompleted` is enabled', function() {
-        analytics.initialize();
-        analytics.track('Order Completed', {
-          revenue: 9.99
-        });
-        analytics.called(window.optimizely.push, {
-          type: 'event',
-          eventName: 'Order Completed',
-          tags: {
-            revenue: 999
-          }
-        });
-      });
-
-      it('should send revenue on all events with properties.revenue if `onlySendRevenueOnOrderCompleted` is disabled', function() {
-        optimizely.options.sendRevenueOnlyForOrderCompleted = false;
-        analytics.initialize();
-        analytics.track('Checkout Started', {
-          revenue: 9.99
-        });
-        analytics.called(window.optimizely.push, {
-          type: 'event',
-          eventName: 'Checkout Started',
-          tags: {
-            revenue: 999
-          }
-        });
-      });
-    });
-
-    describe('#options.listen', function() {
-      beforeEach(function() {
-        optimizely.options.listen = true;
-        analytics.stub(analytics, 'track');
-      });
-
-      it('should send each standard active experiment data via `.track()`', function(done) {
-        // activate standard experiment
-        window.optimizely.data.state.activeExperiments = ['0'];
-        analytics.initialize();
-        executeAsyncTest(done, function() {
-          analytics.deepEqual(analytics.track.args[0], [
-            'Experiment Viewed',
-            {
-              experimentId: '0',
-              experimentName: 'Test',
-              variationId: '123',
-              variationName: 'Variation #123'
-            },
-            { integration: optimizelyContext }
-          ]);
-        });
-      });
-
-      it('should map custom properties and send each standard active experiment data via `.track()`', function(done) {
-        optimizely.options.customExperimentProperties = {
-          experimentId: 'experiment_id',
-          experimentName: 'experiment_name',
-          variationId: 'variation_id',
-          variationName: 'variation_name'
-        };
-
-        window.optimizely.data.experiment_id = '124';
-        window.optimizely.data.experiment_name = 'custom experiment name';
-        window.optimizely.data.variation_id = '421';
-        window.optimizely.data.variation_name = 'custom variation name';
-
-        window.optimizely.data.state.activeExperiments = ['0'];
-        analytics.initialize();
-        executeAsyncTest(done, function() {
-          analytics.deepEqual(analytics.track.args[0], [
-            'Experiment Viewed',
-            {
-              experimentId: '124',
-              experimentName: 'custom experiment name',
-              variationId: '421',
-              variationName: 'custom variation name'
-            },
-            { integration: optimizelyContext }
-          ]);
-        });
-      });
-
-      it('should not map existing properties if custom properties not specified`', function(done) {
-        optimizely.options.customExperimentProperties = {
-          variationId: 'variation_id',
-          variationName: 'variation_name'
-        };
-
-        window.optimizely.data.experiment_id = '124';
-        window.optimizely.data.experiment_name = 'custom experiment name';
-        window.optimizely.data.variation_id = '421';
-        window.optimizely.data.variation_name = 'custom variation name';
-
-        window.optimizely.data.state.activeExperiments = ['0'];
-        analytics.initialize();
-        executeAsyncTest(done, function() {
-          analytics.deepEqual(analytics.track.args[0], [
-            'Experiment Viewed',
-            {
-              experimentId: '0',
-              experimentName: 'Test',
-              variationId: '421',
-              variationName: 'custom variation name'
-            },
-            { integration: optimizelyContext }
-          ]);
-        });
-      });
-
-      it('should send multivariate active experiment data via `.track()`', function(done) {
-        // activate multivariate experiment and set section info
-        window.optimizely.data.state.activeExperiments = ['0'];
-        window.optimizely.data.sections = {
-          123409: { name: 'Section 1', variation_ids: ['123'] }
-        };
-        analytics.initialize();
-        executeAsyncTest(done, function() {
-          analytics.deepEqual(analytics.track.args[0], [
-            'Experiment Viewed',
-            {
-              experimentId: '0',
-              experimentName: 'Test',
-              variationId: '123',
-              variationName: 'Variation #123',
-              sectionName: 'Section 1',
-              sectionId: '123409'
-            },
-            { integration: optimizelyContext }
-          ]);
-        });
-      });
-
-      it('should dedupe sectionNames for multi section multivariate active experiment data via `.track()`', function(done) {
-        // activate multivariate experiment and set section info
-        window.optimizely.data.state.activeExperiments = ['1'];
-        window.optimizely.data.sections = {
-          123409: { name: 'Section 1', variation_ids: ['123', '22', '789'] }
-        };
-        analytics.initialize();
-        executeAsyncTest(done, function() {
-          analytics.deepEqual(analytics.track.args[0], [
-            'Experiment Viewed',
-            {
-              experimentId: '1',
-              experimentName: 'MultiVariate Test',
-              variationId: '123,22,789',
-              variationName: 'Redirect Variation, Var 789, Variation #123',
-              sectionName: 'Section 1',
-              sectionId: '123409'
-            },
-            { integration: optimizelyContext }
-          ]);
-        });
-      });
-
-      it('should send multivariate active experiment with multiple section data via `.track()`', function(done) {
-        // activate multivariate experiment and set section info
-        window.optimizely.data.state.activeExperiments = ['1'];
-        window.optimizely.data.sections = {
-          112309: { name: 'Section 1', variation_ids: ['123'] },
-          111111: { name: 'Section 2', variation_ids: ['22', '789'] }
-        };
-        analytics.initialize();
-        executeAsyncTest(done, function() {
-          analytics.deepEqual(analytics.track.args[0], [
-            'Experiment Viewed',
-            {
-              experimentId: '1',
-              experimentName: 'MultiVariate Test',
-              variationId: '123,22,789',
-              variationName: 'Redirect Variation, Var 789, Variation #123',
-              sectionName: 'Section 1, Section 2',
-              sectionId: '111111,112309'
-            },
-            { integration: optimizelyContext }
-          ]);
-        });
-      });
-
-      it('should send redirect active experiment data via `.track()`', function(done) {
-        // activate redirect experiment
-        window.optimizely.data.state.activeExperiments = [];
-        var context = {
-          integration: optimizelyContext,
-          page: { referrer: 'google.com' }
-        };
-        analytics.initialize();
-        executeAsyncTest(done, function() {
-          analytics.deepEqual(analytics.track.args[0], [
-            'Experiment Viewed',
-            {
-              experimentId: '11',
-              experimentName: 'Redirect Test',
-              referrer: 'google.com',
-              variationId: '22',
-              variationName: 'Redirect Variation'
-            },
-            context
-          ]);
-        });
-      });
-
-      it("should send Google's nonInteraction flag via `.track()`", function(done) {
-        // flip the nonInteraction option on and activate standard experiment
-        optimizely.options.nonInteraction = true;
-        window.optimizely.data.state.activeExperiments = ['0'];
-        analytics.initialize();
-        executeAsyncTest(done, function() {
-          analytics.deepEqual(analytics.track.args[0], [
-            'Experiment Viewed',
-            {
-              experimentId: '0',
-              experimentName: 'Test',
-              variationId: '123',
-              variationName: 'Variation #123',
-              nonInteraction: 1
-            },
-            { integration: optimizelyContext }
-          ]);
-        });
-      });
-
-      it('should not send inactive experiments', function(done) {
-        // clear out the redirect experiment
-        window.optimizely.data.state.redirectExperiment = undefined;
-        // disable all active experiments
-        window.optimizely.data.state.activeExperiments = [];
-        analytics.initialize();
-        executeAsyncTest(done, function() {
-          analytics.didNotCall(analytics.track);
-        });
-      });
-    });
-  });
-
-  describe('#sendNewDataToSegment', function() {
-    beforeEach(function() {
-      mockOptimizelyXDataObject();
+      mockWindowOptimizely();
     });
 
     describe('#options.variations', function() {
@@ -1061,61 +552,63 @@ describe('Optimizely', function() {
     beforeEach(function(done) {
       analytics.once('ready', done);
       analytics.initialize();
-      mockBothOptimizelyDataObjects();
       analytics.page();
     });
 
     describe('#track', function() {
-      beforeEach(function() {
-        analytics.stub(window.optimizely, 'push');
-      });
+      context('when the Optimizely Web snippet has initialized', function() {
+        beforeEach(function() {
+          mockWindowOptimizely();
+          analytics.stub(window.optimizely, 'push');
+        });
 
-      it('should send an event', function() {
-        analytics.track('event');
-        analytics.called(window.optimizely.push, {
-          type: 'event',
-          eventName: 'event',
-          tags: {}
+        it('should send an event', function() {
+          analytics.track('event');
+          analytics.called(window.optimizely.push, {
+            type: 'event',
+            eventName: 'event',
+            tags: {}
+          });
+        });
+
+        it('should replace colons with underscore in eventName', function() {
+          analytics.track('event:foo:bar');
+          analytics.called(window.optimizely.push, {
+            type: 'event',
+            eventName: 'event_foo_bar',
+            tags: {}
+          });
+        });
+
+        it('should send all additional properties along as tags', function() {
+          analytics.track('event', { id: 'c00lHa$h', name: 'jerry' });
+          analytics.called(window.optimizely.push, {
+            type: 'event',
+            eventName: 'event',
+            tags: { id: 'c00lHa$h', name: 'jerry' }
+          });
+        });
+
+        it('should change revenue to cents and include in tags', function() {
+          analytics.track('Order Completed', { revenue: 9.99 });
+          analytics.called(window.optimizely.push, {
+            type: 'event',
+            eventName: 'Order Completed',
+            tags: { revenue: 999 }
+          });
+        });
+
+        it('should round the revenue value to an integer value if passed in as a floating point number', function() {
+          analytics.track('Order Completed', { revenue: 534.3099999999999 });
+          analytics.called(window.optimizely.push, {
+            type: 'event',
+            eventName: 'Order Completed',
+            tags: { revenue: 53431 }
+          });
         });
       });
 
-      it('should repace colons with underscore in eventName', function() {
-        analytics.track('event:foo:bar');
-        analytics.called(window.optimizely.push, {
-          type: 'event',
-          eventName: 'event_foo_bar',
-          tags: {}
-        });
-      });
-
-      it('should send all additional properties along as tags', function() {
-        analytics.track('event', { id: 'c00lHa$h', name: 'jerry' });
-        analytics.called(window.optimizely.push, {
-          type: 'event',
-          eventName: 'event',
-          tags: { id: 'c00lHa$h', name: 'jerry' }
-        });
-      });
-
-      it('should change revenue to cents and include in tags', function() {
-        analytics.track('Order Completed', { revenue: 9.99 });
-        analytics.called(window.optimizely.push, {
-          type: 'event',
-          eventName: 'Order Completed',
-          tags: { revenue: 999 }
-        });
-      });
-
-      it('should round the revenue value to an integer value if passed in as a floating point number', function() {
-        analytics.track('Order Completed', { revenue: 534.3099999999999 });
-        analytics.called(window.optimizely.push, {
-          type: 'event',
-          eventName: 'Order Completed',
-          tags: { revenue: 53431 }
-        });
-      });
-
-      describe('the Optimizely X Fullstack JavaScript client is present', function() {
+      context('when the Optimizely Full Stack JavaScript SDK has initialized', function() {
         beforeEach(function() {
           window.optimizelyClientInstance = {};
           analytics.stub(window.optimizelyClientInstance, 'track');
@@ -1125,7 +618,7 @@ describe('Optimizely', function() {
           window.optimizelyClientInstance.track.restore();
         });
 
-        it('should send an event through the Optimizely X Fullstack JS SDK using the logged in user', function() {
+        it('should send an event through the Optimizely X Full Stack JS SDK using the logged in user', function() {
           analytics.identify('user1');
           analytics.track('event', { purchasePrice: 9.99, property: 'foo' });
           analytics.called(
@@ -1213,42 +706,45 @@ describe('Optimizely', function() {
     });
 
     describe('#page', function() {
-      beforeEach(function() {
-        analytics.stub(window.optimizely, 'push');
-      });
-
-      it('should send an event for a named page', function() {
-        var referrer = window.document.referrer;
-        analytics.page('Home');
-        analytics.called(window.optimizely.push, {
-          type: 'event',
-          eventName: 'Viewed Home Page',
-          tags: {
-            name: 'Home',
-            path: '/context.html',
-            referrer: referrer,
-            search: '',
-            title: '',
-            url: 'http://localhost:9876/context.html'
-          }
+      context('when the Optimizely Web snippet has initialized', function() {
+        beforeEach(function() {
+          mockWindowOptimizely();
+          analytics.stub(window.optimizely, 'push');
         });
-      });
 
-      it('should send an event for a named and categorized page', function() {
-        var referrer = window.document.referrer;
-        analytics.page('Blog', 'New Integration');
-        analytics.called(window.optimizely.push, {
-          type: 'event',
-          eventName: 'Viewed Blog New Integration Page',
-          tags: {
-            name: 'New Integration',
-            category: 'Blog',
-            path: '/context.html',
-            referrer: referrer,
-            search: '',
-            title: '',
-            url: 'http://localhost:9876/context.html'
-          }
+        it('should send an event for a named page', function() {
+          var referrer = window.document.referrer;
+          analytics.page('Home');
+          analytics.called(window.optimizely.push, {
+            type: 'event',
+            eventName: 'Viewed Home Page',
+            tags: {
+              name: 'Home',
+              path: '/context.html',
+              referrer: referrer,
+              search: '',
+              title: '',
+              url: 'http://localhost:9876/context.html'
+            }
+          });
+        });
+
+        it('should send an event for a named and categorized page', function() {
+          var referrer = window.document.referrer;
+          analytics.page('Blog', 'New Integration');
+          analytics.called(window.optimizely.push, {
+            type: 'event',
+            eventName: 'Viewed Blog New Integration Page',
+            tags: {
+              name: 'New Integration',
+              category: 'Blog',
+              path: '/context.html',
+              referrer: referrer,
+              search: '',
+              title: '',
+              url: 'http://localhost:9876/context.html'
+            }
+          });
         });
       });
     });


### PR DESCRIPTION
## What does this PR do?

* Don't attempt to interface with Optimizely Classic Web, since Classic is finally dead
* Prepare to support Optimizely Edge, an alternative to Optimizely Web
* Drop all references to customCampaignProperties. It seems to have been documented [here](https://segment.com/docs/connections/destinations/catalog/optimizely-web/#settings) but it couldn't possibly have worked.
* Generally refactor the code and tests.

## Are there breaking changes in this PR?

* Technically yes, but effectively no, since the removed functionality hasn't been relevant for a while.

## Any background context you want to provide?

* Our Classic Web product, the predecessor to X Web, is long gone.
* We recently launched Optimizely Performance Edge, which may be implemented instead of Optimizely Web on any given page. We'll extend analytics.js-integrations to add support for it in a followup pull request.

## Is there parity with the server-side/android/iOS integration components (if applicable)?

N/A

## Does this require a new integration setting? If so, please explain how the new setting works

No. On the contrary, the "Custom Experiment Properties" setting described [here](https://segment.com/docs/connections/destinations/catalog/optimizely-web/#settings) is obsolete now that Optimizely Classic is gone (and was also incorrectly documented or implemented), and the "Custom Campaign Properties" setting can also be un-documented because it too was incorrectly implemented and is now being removed.

**Links to helpful docs and other external resources**

I've linked to some API docs from JSDoc comments!