### PR TITLE
[STRATCONN-272, STRATCONN-265] Update trackComplete, Stringify context data, Support window-based playhead

### DIFF
--- a/integrations/adobe-analytics/HISTORY.md
+++ b/integrations/adobe-analytics/HISTORY.md
@@ -1,6 +1,8 @@
-1.16.2 / 2020-05-17
+1.16.2 / 2020-07-13
 ===================
 * Reads session playhead values from `window._segHBPlayheads` if it exists. This solves an issue where the playhead is only updated when 'Video Content Playing' (+ various others) events are tracked. To get around this, we allow video implementations to set the playhead value as often as possible without the need to trigger an event.
+* Removes trackComplete from Video Content Completed events and only calls chapterComplete on these events. It also adds trackComplete to Video Playback Completed events. This is in line with Adobe's documentation and also allows for parity between iOS, a.js, and Android.
+* Stringifies context data values which are booleans. The AA SDK tends to reject false boolean values when setting them on the window object. This does not break existing behavior since booleans are stringified when they're sent in the query string.
 
 1.16.1 / 2020-05-15
 ===================

--- a/integrations/adobe-analytics/HISTORY.md
+++ b/integrations/adobe-analytics/HISTORY.md
@@ -1,3 +1,7 @@
+1.16.2 / 2020-05-17
+===================
+* Reads session playhead values from `window._segHBPlayheads` if it exists. This solves an issue where the playhead is only updated when 'Video Content Playing' (+ various others) events are tracked. To get around this, we allow video implementations to set the playhead value as often as possible without the need to trigger an event.
+
 1.16.1 / 2020-05-15
 ===================
 * Supports sending top level `event` as `prop`, `eVar`, `lVar`, `hVar`, or Context Data Variable.

--- a/integrations/adobe-analytics/lib/index.js
+++ b/integrations/adobe-analytics/lib/index.js
@@ -1536,7 +1536,7 @@ function createCustomVideoMetadataContext(track, options) {
     // Adobe's SDK seems to reject a false boolean value. Stringifying is
     // acceptable since these values are appended as query strings anyway.
     if (typeof value === 'boolean') {
-      addContextDatum(key, value.toString());
+      contextData[key] = value.toString();
       return;
     }
 

--- a/integrations/adobe-analytics/lib/index.js
+++ b/integrations/adobe-analytics/lib/index.js
@@ -1531,6 +1531,15 @@ function createCustomVideoMetadataContext(track, options) {
     if (!key || value === undefined || value === null || value === '') {
       return;
     }
+
+    // If context data values are booleans then stringify them.
+    // Adobe's SDK seems to reject a false boolean value. Stringifying is
+    // acceptable since these values are appended as query strings anyway.
+    if (typeof value === 'boolean') {
+      addContextDatum(key, value.toString());
+      return;
+    }
+
     contextData[key] = value;
   }, extractedProperties);
   return contextData;

--- a/integrations/adobe-analytics/lib/index.js
+++ b/integrations/adobe-analytics/lib/index.js
@@ -1317,9 +1317,7 @@ function heartbeatVideoStart(track) {
       chapterObj,
       chapterCustomMetadata
     );
-    this.mediaHeartbeats[
-      props.session_id || 'default'
-    ].chapterInProgress = true;
+    this.mediaHeartbeats[props.session_id || 'default'].chapterInProgress = true;
   }
 }
 
@@ -1332,8 +1330,6 @@ function heartbeatVideoComplete(track) {
     videoAnalytics.MediaHeartbeat.Event.ChapterComplete
   );
   this.mediaHeartbeats[props.session_id || 'default'].chapterInProgress = false;
-
-  this.mediaHeartbeats[props.session_id || 'default'].heartbeat.trackComplete();
 }
 
 function heartbeatVideoPaused(track) {
@@ -1347,9 +1343,8 @@ function heartbeatSessionEnd(track) {
   populateHeartbeat.call(this, track);
 
   var props = track.properties();
-  this.mediaHeartbeats[
-    props.session_id || 'default'
-  ].heartbeat.trackSessionEnd();
+  this.mediaHeartbeats[props.session_id || 'default'].heartbeat.trackComplete();
+  this.mediaHeartbeats[props.session_id || 'default'].heartbeat.trackSessionEnd();
 
   // Remove the session from memory when it's all over.
   delete this.mediaHeartbeats[props.session_id || 'default'];

--- a/integrations/adobe-analytics/lib/index.js
+++ b/integrations/adobe-analytics/lib/index.js
@@ -620,6 +620,14 @@ function updateContextData(facade, options) {
       return;
     }
 
+    // If context data values are booleans then stringify them.
+    // Adobe's SDK seems to reject a false boolean value. Stringifying is
+    // acceptable since these values are appended as query strings anyway.
+    if (typeof value === 'boolean') {
+      addContextDatum(key, value.toString());
+      return;
+    }
+
     addContextDatum(key, value);
   }, contextProperties);
 }

--- a/integrations/adobe-analytics/package.json
+++ b/integrations/adobe-analytics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-adobe-analytics",
   "description": "The Adobe Analytics analytics.js integration.",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/adobe-analytics/test/index.test.js
+++ b/integrations/adobe-analytics/test/index.test.js
@@ -1592,7 +1592,7 @@ describe('Adobe Analytics', function() {
         );
       });
 
-      it('should call trackComplete when a video completes', function() {
+      it('should set chapterInProgress when a video completes', function() {
         analytics.track('Video Playback Started', {
           session_id: sessionId,
           channel: 'Black Mesa',
@@ -1606,7 +1606,7 @@ describe('Adobe Analytics', function() {
 
         analytics.stub(
           adobeAnalytics.mediaHeartbeats[sessionId].heartbeat,
-          'trackComplete'
+          'trackEvent'
         );
 
         analytics.track('Video Content Completed', {
@@ -1621,7 +1621,12 @@ describe('Adobe Analytics', function() {
         });
 
         analytics.called(
-          adobeAnalytics.mediaHeartbeats[sessionId].heartbeat.trackComplete
+          adobeAnalytics.mediaHeartbeats[sessionId].heartbeat.trackEvent,
+          window.ADB.va.MediaHeartbeat.Event.ChapterComplete
+        );
+        analytics.equal(
+          false,
+          adobeAnalytics.mediaHeartbeats[sessionId].chapterInProgress
         );
       });
 
@@ -1658,7 +1663,7 @@ describe('Adobe Analytics', function() {
         );
       });
 
-      it('should delete the instance when the session is over', function() {
+      it('should call final hb methods and delete the instance when the session is over', function() {
         analytics.track('Video Playback Started', {
           session_id: sessionId,
           channel: 'Black Mesa',
@@ -1674,6 +1679,7 @@ describe('Adobe Analytics', function() {
 
         // We need to save this reference for the upcoming check, since we delete the higher property after the next call.
         var heartbeatRef = adobeAnalytics.mediaHeartbeats[sessionId].heartbeat;
+        analytics.stub(heartbeatRef, 'trackComplete');
         analytics.stub(heartbeatRef, 'trackSessionEnd');
 
         analytics.track('Video Playback Completed', {
@@ -1687,8 +1693,9 @@ describe('Adobe Analytics', function() {
           livestream: false
         });
 
-        analytics.assert(!adobeAnalytics.mediaHeartbeats[sessionId]);
+        analytics.called(heartbeatRef.trackComplete);
         analytics.called(heartbeatRef.trackSessionEnd);
+        analytics.assert(!adobeAnalytics.mediaHeartbeats[sessionId]);
       });
 
       it('should start an Ad Break and Ad Tracking when an ad starts', function() {

--- a/integrations/adobe-analytics/test/index.test.js
+++ b/integrations/adobe-analytics/test/index.test.js
@@ -1175,6 +1175,30 @@ describe('Adobe Analytics', function() {
           });
           analytics.equal(window.s.events, 'prodView,event1,event38');
         });
+
+        it('should stringify bool context data', function() {
+          adobeAnalytics.options.contextValues = {
+            'page.referrer': 'page.referrer',
+            'page.url': 'page.title',
+            'page.bickenBack': 'page.bickenBack'
+          };
+          analytics.track(
+            'Drank Some Milk',
+            { foo: 'bar' },
+            { page: { bickenBack: false } }
+          );
+          analytics.equal(
+            window.s.contextData['page.referrer'],
+            window.document.referrer
+          );
+          analytics.equal(
+            window.s.contextData['page.title'],
+            window.location.href
+          );
+          analytics.equal(window.s.contextData['page.bickenBack'], 'false');
+          analytics.equal(window.s.contextData.foo, 'bar');
+          analytics.called(window.s.tl);
+        });
       });
     });
 

--- a/integrations/adobe-analytics/test/index.test.js
+++ b/integrations/adobe-analytics/test/index.test.js
@@ -1864,6 +1864,26 @@ describe('Adobe Analytics', function() {
           'trackPause'
         );
       });
+
+      it('should return the playhead value from the window object', function() {
+        analytics.track('Video Playback Started', {
+          session_id: sessionId,
+          channel: 'Black Mesa',
+          video_player: 'Transit Announcement System',
+          playhead: 5,
+          asset_id: 'Gordon Freeman',
+          title: 'Half-Life',
+          total_length: 1260,
+          livestream: false
+        });
+
+        window._segHBPlayheads[sessionId] = 5.111;
+
+        var actual = adobeAnalytics.mediaHeartbeats[
+          sessionId
+        ].delegate.getCurrentPlaybackTime();
+        analytics.assert(actual, 5.111);
+      });
     });
   });
 });


### PR DESCRIPTION
https://segment.atlassian.net/browse/CC-6682

**What does this PR do?**
- Removes trackComplete from Video Content Completed events and only calls chapterComplete on these events. It also adds trackComplete to Video Playback Completed events. This is in line with Adobe's documentation and also allows for parity between iOS, a.js, and Android. 
- Stringifies context data values which are booleans. The AA SDK tends to reject `false` boolean values when setting them on the window object. This does not break existing behavior since booleans are stringified when they're sent in the query string.
- Reads session playhead values from window._segHBPlayheads if it exists. This solves an issue where the playhead is only updated when Video Content Playing (+ various others) events are tracked. To get around this, we allow video implementations to set the playhead value as often as possible without the need to trigger an event. Adobe Analytics expects the playhead to be updated at least every second.

_Note: It does not seem like we pause the playhead ever in the a.js integration so I did not add this to Video Playback Completed._

**Are there breaking changes in this PR?**
No.

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
iOS and a.js integrations are being updated with the same changes.

**Does this require a new integration setting? If so, please explain how the new setting works**
No.

**Links to helpful docs and other external resources**
Adobe docs
Core playback on Android: https://docs.adobe.com/content/help/en/media-analytics/using/sdk-implement/track-av-playback/track-core/track-core-javascript/track-core-js3.html
Chapters on Android: https://docs.adobe.com/content/help/en/media-analytics/using/sdk-implement/track-chapters/track-chapters-js/track-chapters-js3.html