### PR TITLE
Support Limited Data Use in Facebook Pixel

### DIFF
--- a/integrations/facebook-pixel/lib/index.js
+++ b/integrations/facebook-pixel/lib/index.js
@@ -30,6 +30,7 @@ var FacebookPixel = (module.exports = integration('Facebook Pixel')
   .option('standardEventsCustomProperties', [])
   .option('keyForExternalId', '')
   .option('userIdAsExternalId', false)
+  .option('limitedDataUse', true)
   .mapping('standardEvents')
   .mapping('legacyEvents')
   .mapping('contentTypes')
@@ -101,6 +102,9 @@ FacebookPixel.prototype.initialize = function() {
   this.load(this.ready);
   if (!this.options.automaticConfiguration) {
     window.fbq('set', 'autoConfig', false, this.options.pixelId);
+  }
+  if (this.options.limitedDataUse) {
+    window.fbq('dataProcessingOptions', ['LDU'], 0, 0);
   }
   if (this.options.initWithExistingTraits) {
     var traits = this.formatTraits(this.analytics);

--- a/integrations/facebook-pixel/test/index.test.js
+++ b/integrations/facebook-pixel/test/index.test.js
@@ -35,6 +35,7 @@ describe('Facebook Pixel', function() {
     pixelId: '123123123',
     agent: 'test',
     initWithExistingTraits: false,
+    limitedDataUse: true,
     whitelistPiiProperties: [],
     blacklistPiiProperties: [],
     standardEventsCustomProperties: []
@@ -145,6 +146,12 @@ describe('Facebook Pixel', function() {
           false,
           options.pixelId
         );
+      });
+
+      it('should call dataProcessingOptions if limitedDataUse is enabled', function() {
+        analytics.stub(window, 'fbq');
+        analytics.initialize();
+        analytics.called(window.fbq, 'dataProcessingOptions', ['LDU'], 0, 0);
       });
 
       before(function() {


### PR DESCRIPTION
**What does this PR do?**
This PR will make a ```dataProcessingOptions``` call before ```init``` to opt-in to Limited Data Use. It will do this by default.

**Are there breaking changes in this PR?**
No.

**Any background context you want to provide?**
Facebook has [announced](https://developers.facebook.com/docs/marketing-apis/data-processing-options) a new Limited Data Use feature that is designed to assist with compliance with the California Consumer Privacy Act (CCPA). Data tagged as Limited Data Use will only be processed by Facebook in ways that allow Facebook to fit within the definition of Service Provider under the CCPA, thus avoiding the possibility that website operators using Facebook Pixel could be considered to be "selling" data to Facebook.

During the month of July Facebook will automatically tag events coming from California as Limited Data Use. But starting in August, clients must opt-in to this behavior by making a ```dataProcessingOptions``` call before ```init```.

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
Facebook Pixel is only a Device - Web integration.

There are similar options in the [Facebook App Events](https://developers.facebook.com/docs/marketing-apis/data-processing-options#app-events-api) and [Facebook Offline Conversions](https://developers.facebook.com/docs/marketing-apis/data-processing-options#server-side-api-and-offline-conversions-api) APIs, which may be of interest to those using those integrations.

**Does this require a new integration setting? If so, please explain how the new setting works**
This adds the ```limitedDataUse``` setting, a boolean which defaults to true. If this setting is true, a ```dataProcessingOptions``` call will be made instructing Facebook to apply Limited Data Use if Facebook's geolocation determines the client is in the state of California.

**Links to helpful docs and other external resources**
