### PR TITLE
[FB Pixel] Add support for preset data processing options

### DIFF
--- a/integrations/facebook-pixel/HISTORY.md
+++ b/integrations/facebook-pixel/HISTORY.md
@@ -1,3 +1,17 @@
+2.11.1/ 2020-07-22
+==================
+
+  * Add support to override the Data Processing Options by pass them in the load options object.
+  ```
+  analytics.load("<writeKey>", {
+    integrations: {
+      'Facebook Pixel': {
+        dataProcessingOptions: [['LDU'], 1, 1000]
+      }
+    }
+  });
+  ```
+
 2.11.0/ 2020-07-16
 ==================
 

--- a/integrations/facebook-pixel/lib/index.js
+++ b/integrations/facebook-pixel/lib/index.js
@@ -105,7 +105,7 @@ FacebookPixel.prototype.initialize = function() {
   }
   if (this.options.limitedDataUse) {
     this.validateAndSetDataProcessing(
-      window.fbDataProcessingOptions || [['LDU'], 0, 0]
+      this.options.dataProcessingOptions || [['LDU'], 0, 0]
     );
   }
   if (this.options.initWithExistingTraits) {

--- a/integrations/facebook-pixel/lib/index.js
+++ b/integrations/facebook-pixel/lib/index.js
@@ -104,7 +104,9 @@ FacebookPixel.prototype.initialize = function() {
     window.fbq('set', 'autoConfig', false, this.options.pixelId);
   }
   if (this.options.limitedDataUse) {
-    window.fbq('dataProcessingOptions', ['LDU'], 0, 0);
+    this.validateAndSetDataProcessing(
+      window.fbDataProcessingOptions || [['LDU'], 0, 0]
+    );
   }
   if (this.options.initWithExistingTraits) {
     var traits = this.formatTraits(this.analytics);
@@ -716,6 +718,29 @@ FacebookPixel.prototype.buildPayload = function(track, isStandardEvent) {
   }
 
   return payload;
+};
+
+/**
+ * Validates that a set of parameters are formatted correctly and passes them to the pixel instance.
+ * https://developers.facebook.com/docs/marketing-apis/data-processing-options#reference
+ *
+ * @param {Array} options
+ *
+ * @api private
+ */
+FacebookPixel.prototype.validateAndSetDataProcessing = function(params) {
+  var lenOk = params.length === 3;
+  var valOk =
+    Array.isArray(params[0]) &&
+    typeof params[1] === 'number' &&
+    typeof params[2] === 'number';
+
+  // Pass the data processing options if they're valid, otherwise, fallback to geolocation.
+  if (lenOk && valOk) {
+    window.fbq('dataProcessingOptions', params[0], params[1], params[2]);
+  } else {
+    window.fbq('dataProcessingOptions', ['LDU'], 0, 0);
+  }
 };
 
 /**

--- a/integrations/facebook-pixel/package.json
+++ b/integrations/facebook-pixel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-facebook-pixel",
   "description": "The Facebook Pixel analytics.js integration.",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/facebook-pixel/test/index.test.js
+++ b/integrations/facebook-pixel/test/index.test.js
@@ -200,6 +200,38 @@ describe('Facebook Pixel', function() {
         );
       });
     });
+
+    describe('#initialize with preset data processing options', function() {
+      before(function() {
+        window.fbDataProcessingOptions = [['LDU'], 99, 99];
+      });
+
+      after(function() {
+        delete window.fbDataProcessingOptions;
+      });
+
+      it('should call dataProcessingOptions with the preset values', function() {
+        analytics.stub(window, 'fbq');
+        analytics.initialize();
+        analytics.called(window.fbq, 'dataProcessingOptions', ['LDU'], 99, 99);
+      });
+    });
+
+    describe('#initialize with fallback data processing options', function() {
+      before(function() {
+        window.fbDataProcessingOptions = ['a string', true, 99];
+      });
+
+      after(function() {
+        delete window.fbDataProcessingOptions;
+      });
+
+      it('should call dataProcessingOptions with fallback values', function() {
+        analytics.stub(window, 'fbq');
+        analytics.initialize();
+        analytics.called(window.fbq, 'dataProcessingOptions', ['LDU'], 0, 0);
+      });
+    });
   });
 
   describe('loading', function() {

--- a/integrations/facebook-pixel/test/index.test.js
+++ b/integrations/facebook-pixel/test/index.test.js
@@ -203,11 +203,11 @@ describe('Facebook Pixel', function() {
 
     describe('#initialize with preset data processing options', function() {
       before(function() {
-        window.fbDataProcessingOptions = [['LDU'], 99, 99];
+        options.dataProcessingOptions = [['LDU'], 99, 99];
       });
 
       after(function() {
-        delete window.fbDataProcessingOptions;
+        delete options.dataProcessingOptions;
       });
 
       it('should call dataProcessingOptions with the preset values', function() {
@@ -219,11 +219,11 @@ describe('Facebook Pixel', function() {
 
     describe('#initialize with fallback data processing options', function() {
       before(function() {
-        window.fbDataProcessingOptions = ['a string', true, 99];
+        options.dataProcessingOptions = ['a string', true, 99];
       });
 
       after(function() {
-        delete window.fbDataProcessingOptions;
+        delete options.dataProcessingOptions;
       });
 
       it('should call dataProcessingOptions with fallback values', function() {


### PR DESCRIPTION
**What does this PR do?**
Updates FB Pixel's data processing logic to look for preset options on the window object. If valid parameters are set on `window.fbDataProcessingOptions` we'll pass those to the Pixel SDK. If the parameters set on the window objects are undefined or invalid then we'll fallback to these default options: `['LDU'], 0, 0`.

For more information on valid values see: https://developers.facebook.com/docs/marketing-apis/data-processing-options#reference

**Are there breaking changes in this PR?**
Nah

**Any background context you want to provide?**


**Is there parity with the server-side/android/iOS integration components (if applicable)?**
server-side and iOS will be updated to support preset options

**Does this require a new integration setting? If so, please explain how the new setting works**


**Links to helpful docs and other external resources**

## Test Plan
- [x] Unit tests
- [x] Testing completed successfully end-to-end in staging

# Rollback Procedure
- Revert this PR
