### PR TITLE
[FB Pixel] Explicitly disable LDU in FB Pixel when LDU setting is false

### DIFF
--- a/integrations/facebook-pixel/HISTORY.md
+++ b/integrations/facebook-pixel/HISTORY.md
@@ -1,3 +1,8 @@
+2.11.2/ 2020-07-28
+==================
+
+  * Explicitly not enable Limited Data Use (LDU) mode in the FB Pixel SDK when the Limited Data Use Segment setting is disabled.
+
 2.11.1/ 2020-07-22
 ==================
 

--- a/integrations/facebook-pixel/lib/index.js
+++ b/integrations/facebook-pixel/lib/index.js
@@ -107,6 +107,9 @@ FacebookPixel.prototype.initialize = function() {
     this.validateAndSetDataProcessing(
       this.options.dataProcessingOptions || [['LDU'], 0, 0]
     );
+  } else {
+    // explicitly not enable Limited Data Use (LDU) mode
+    window.fbq('dataProcessingOptions', []);
   }
   if (this.options.initWithExistingTraits) {
     var traits = this.formatTraits(this.analytics);

--- a/integrations/facebook-pixel/package.json
+++ b/integrations/facebook-pixel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-facebook-pixel",
   "description": "The Facebook Pixel analytics.js integration.",
-  "version": "2.11.1",
+  "version": "2.11.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",


### PR DESCRIPTION
**What does this PR do?**
- Adds an `else` block to handle the case when the Limited Data Use Segment setting is disabled. For more information see: https://developers.facebook.com/docs/marketing-apis/data-processing-options#pixel 

**Are there breaking changes in this PR?**
Nah

**Any background context you want to provide?**


**Is there parity with the server-side/android/iOS integration components (if applicable)?**
server-side and iOS will be updated to support preset options

**Does this require a new integration setting? If so, please explain how the new setting works**


**Links to helpful docs and other external resources**

## Test Plan
- [x] Unit tests
- [x] Testing completed successfully end-to-end in staging

# Rollback Procedure
- Revert this PR