### PR TITLE
[SatisMeter] Add support for track and group calls

### DIFF
--- a/integrations/satismeter/HISTORY.md
+++ b/integrations/satismeter/HISTORY.md
@@ -1,3 +1,12 @@
+2.0.2 / 2020-07-30
+==================
+
+  * Send anonymousId in all calls
+  * Support for `track` calls
+  * Support for `group` calls
+  * Support page related properties
+  * Send `source` parameter to identify analytics.js as the caller
+
 2.0.1 / 2017-04-11
 ==================
 

--- a/integrations/satismeter/lib/index.js
+++ b/integrations/satismeter/lib/index.js
@@ -25,10 +25,20 @@ var SatisMeter = (module.exports = integration('SatisMeter')
 
 SatisMeter.prototype.initialize = function() {
   var self = this;
+  var options = this.options;
   this.load(function() {
-    when(function() {
-      return self.loaded();
-    }, self.ready);
+    when(
+      function() {
+        return self.loaded();
+      },
+      function() {
+        window.satismeter('load', {
+          writeKey: options.apiKey || options.token,
+          source: 'analytics.js'
+        });
+        self.ready();
+      }
+    );
   });
 };
 
@@ -51,11 +61,10 @@ SatisMeter.prototype.loaded = function() {
  */
 
 SatisMeter.prototype.identify = function(identify) {
-  window.satismeter({
-    writeKey: this.options.apiKey || this.options.token,
+  window.satismeter('identify', {
     userId: identify.userId(),
-    traits: this.analytics.user().traits(),
-    type: 'identify'
+    anonymousId: identify.anonymousId(),
+    traits: this.analytics.user().traits()
   });
 };
 
@@ -66,10 +75,44 @@ SatisMeter.prototype.identify = function(identify) {
  * @param {Page} page
  */
 
-SatisMeter.prototype.page = function() {
-  window.satismeter({
-    writeKey: this.options.apiKey || this.options.token,
+SatisMeter.prototype.page = function(page) {
+  window.satismeter('page', {
     userId: this.analytics.user().id(),
-    type: 'page'
+    anonymousId: this.analytics.user().anonymousId(),
+    name: page.name(),
+    category: page.category(),
+    properties: page.properties()
+  });
+};
+
+/**
+ * Track.
+ *
+ * @api public
+ * @param {Track} track
+ */
+
+SatisMeter.prototype.track = function(track) {
+  window.satismeter('track', {
+    userId: this.analytics.user().id(),
+    anonymousId: this.analytics.user().anonymousId(),
+    event: track.event(),
+    properties: track.properties()
+  });
+};
+
+/**
+ * group.
+ *
+ * @api public
+ * @param {group} group
+ */
+
+SatisMeter.prototype.group = function(group) {
+  window.satismeter('group', {
+    userId: this.analytics.user().id(),
+    anonymousId: this.analytics.user().anonymousId(),
+    groupId: group.groupId(),
+    traits: group.properties()
   });
 };

--- a/integrations/satismeter/package.json
+++ b/integrations/satismeter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-satismeter",
   "description": "The Satismeter analytics.js integration.",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/satismeter/test/index.test.js
+++ b/integrations/satismeter/test/index.test.js
@@ -45,6 +45,7 @@ describe('SatisMeter', function() {
     describe('#initialize', function() {
       it('should call #load', function() {
         analytics.initialize();
+
         analytics.called(satismeter.load);
       });
     });
@@ -69,48 +70,52 @@ describe('SatisMeter', function() {
 
       it('should send apiKey and user id', function() {
         analytics.identify('id');
-        analytics.called(window.satismeter, {
-          writeKey: options.apiKey,
+        var anonymousId = analytics.user().anonymousId();
+
+        analytics.called(window.satismeter, 'identify', {
           userId: 'id',
-          traits: {},
-          type: 'identify'
+          anonymousId: anonymousId,
+          traits: {}
         });
       });
 
       it('should send email', function() {
         analytics.identify('id', { email: 'email@example.com' });
-        analytics.called(window.satismeter, {
-          writeKey: options.apiKey,
+        var anonymousId = analytics.user().anonymousId();
+
+        analytics.called(window.satismeter, 'identify', {
           userId: 'id',
+          anonymousId: anonymousId,
           traits: {
             email: 'email@example.com'
-          },
-          type: 'identify'
+          }
         });
       });
 
       it('should send user name', function() {
         analytics.identify('id', { name: 'john doe' });
-        analytics.called(window.satismeter, {
-          writeKey: options.apiKey,
+        var anonymousId = analytics.user().anonymousId();
+
+        analytics.called(window.satismeter, 'identify', {
           userId: 'id',
+          anonymousId: anonymousId,
           traits: {
             name: 'john doe'
-          },
-          type: 'identify'
+          }
         });
       });
 
       it('should send signUpDate', function() {
         var now = new Date();
         analytics.identify('id', { createdAt: now });
-        analytics.called(window.satismeter, {
-          writeKey: options.apiKey,
+        var anonymousId = analytics.user().anonymousId();
+
+        analytics.called(window.satismeter, 'identify', {
           userId: 'id',
+          anonymousId: anonymousId,
           traits: {
             createdAt: now
-          },
-          type: 'identify'
+          }
         });
       });
 
@@ -121,16 +126,42 @@ describe('SatisMeter', function() {
           },
           language: 'en'
         });
-        analytics.called(window.satismeter, {
-          writeKey: options.apiKey,
+        var anonymousId = analytics.user().anonymousId();
+
+        analytics.called(window.satismeter, 'identify', {
           userId: 'id',
+          anonymousId: anonymousId,
           traits: {
             translation: {
               FOLLOWUP: 'What can we improve'
             },
             language: 'en'
-          },
-          type: 'identify'
+          }
+        });
+      });
+    });
+
+    describe('#track', function() {
+      beforeEach(function() {
+        analytics.stub(window, 'satismeter');
+      });
+
+      it('should send event name and properties', function() {
+        analytics.user().id('id');
+        analytics.user().anonymousId('anonymousId');
+        analytics.track('User Subscribed', {
+          planId: 'Example Plan',
+          planPrice: 2000
+        });
+
+        analytics.called(window.satismeter, 'track', {
+          userId: 'id',
+          anonymousId: 'anonymousId',
+          event: 'User Subscribed',
+          properties: {
+            planId: 'Example Plan',
+            planPrice: 2000
+          }
         });
       });
     });
@@ -140,13 +171,53 @@ describe('SatisMeter', function() {
         analytics.stub(window, 'satismeter');
       });
 
-      it('should send apiKey and user id', function() {
+      it('should send page name, category and properties', function() {
         analytics.user().id('id');
-        analytics.page('Pricing');
-        analytics.called(window.satismeter, {
-          writeKey: options.apiKey,
+        analytics.user().anonymousId('anonymousId');
+        analytics.page('Product', 'Pricing', {
+          customProperty: 'Example'
+        });
+
+        analytics.called(window.satismeter, 'page', {
           userId: 'id',
-          type: 'page'
+          anonymousId: 'anonymousId',
+          name: 'Pricing',
+          category: 'Product',
+          properties: {
+            name: 'Pricing',
+            category: 'Product',
+            path: window.location.pathname,
+            referrer: window.document.referrer,
+            search: window.location.search,
+            title: window.document.title,
+            url: window.location.href,
+            customProperty: 'Example'
+          }
+        });
+      });
+    });
+
+    describe('#group', function() {
+      beforeEach(function() {
+        analytics.stub(window, 'satismeter');
+      });
+
+      it('should send group id and traits', function() {
+        analytics.user().id('id');
+        analytics.user().anonymousId('anonymousId');
+        analytics.group('groupId', {
+          industry: 'Technology',
+          employees: 2000
+        });
+
+        analytics.called(window.satismeter, 'group', {
+          userId: 'id',
+          anonymousId: 'anonymousId',
+          groupId: 'groupId',
+          traits: {
+            industry: 'Technology',
+            employees: 2000
+          }
         });
       });
     });
@@ -193,6 +264,7 @@ describe('SatisMeter - legacy setup', function() {
     describe('#initialize', function() {
       it('should call #load', function() {
         analytics.initialize();
+
         analytics.called(satismeter.load);
       });
     });
@@ -217,48 +289,52 @@ describe('SatisMeter - legacy setup', function() {
 
       it('should send token and user id', function() {
         analytics.identify('id');
-        analytics.called(window.satismeter, {
-          writeKey: options.token,
+        var anonymousId = analytics.user().anonymousId();
+
+        analytics.called(window.satismeter, 'identify', {
           userId: 'id',
-          traits: {},
-          type: 'identify'
+          anonymousId: anonymousId,
+          traits: {}
         });
       });
 
       it('should send email', function() {
         analytics.identify('id', { email: 'email@example.com' });
-        analytics.called(window.satismeter, {
-          writeKey: options.token,
+        var anonymousId = analytics.user().anonymousId();
+
+        analytics.called(window.satismeter, 'identify', {
           userId: 'id',
+          anonymousId: anonymousId,
           traits: {
             email: 'email@example.com'
-          },
-          type: 'identify'
+          }
         });
       });
 
       it('should send user name', function() {
         analytics.identify('id', { name: 'john doe' });
-        analytics.called(window.satismeter, {
-          writeKey: options.token,
+        var anonymousId = analytics.user().anonymousId();
+
+        analytics.called(window.satismeter, 'identify', {
           userId: 'id',
+          anonymousId: anonymousId,
           traits: {
             name: 'john doe'
-          },
-          type: 'identify'
+          }
         });
       });
 
       it('should send signUpDate', function() {
         var now = new Date();
         analytics.identify('id', { createdAt: now });
-        analytics.called(window.satismeter, {
-          writeKey: options.token,
+        var anonymousId = analytics.user().anonymousId();
+
+        analytics.called(window.satismeter, 'identify', {
           userId: 'id',
+          anonymousId: anonymousId,
           traits: {
             createdAt: now
-          },
-          type: 'identify'
+          }
         });
       });
 
@@ -269,16 +345,42 @@ describe('SatisMeter - legacy setup', function() {
           },
           language: 'en'
         });
-        analytics.called(window.satismeter, {
-          writeKey: options.token,
+        var anonymousId = analytics.user().anonymousId();
+
+        analytics.called(window.satismeter, 'identify', {
           userId: 'id',
+          anonymousId: anonymousId,
           traits: {
             translation: {
               FOLLOWUP: 'What can we improve'
             },
             language: 'en'
-          },
-          type: 'identify'
+          }
+        });
+      });
+    });
+
+    describe('#track', function() {
+      beforeEach(function() {
+        analytics.stub(window, 'satismeter');
+      });
+
+      it('should send event name and properties', function() {
+        analytics.user().id('id');
+        analytics.user().anonymousId('anonymousId');
+        analytics.track('User Subscribed', {
+          planId: 'Example Plan',
+          planPrice: 2000
+        });
+
+        analytics.called(window.satismeter, 'track', {
+          userId: 'id',
+          anonymousId: 'anonymousId',
+          event: 'User Subscribed',
+          properties: {
+            planId: 'Example Plan',
+            planPrice: 2000
+          }
         });
       });
     });
@@ -288,13 +390,53 @@ describe('SatisMeter - legacy setup', function() {
         analytics.stub(window, 'satismeter');
       });
 
-      it('should send token and user id', function() {
+      it('should send page name, category and properties', function() {
         analytics.user().id('id');
-        analytics.page('Pricing');
-        analytics.called(window.satismeter, {
-          writeKey: options.token,
+        analytics.user().anonymousId('anonymousId');
+        analytics.page('Product', 'Pricing', {
+          customProperty: 'Example'
+        });
+
+        analytics.called(window.satismeter, 'page', {
           userId: 'id',
-          type: 'page'
+          anonymousId: 'anonymousId',
+          name: 'Pricing',
+          category: 'Product',
+          properties: {
+            name: 'Pricing',
+            category: 'Product',
+            path: window.location.pathname,
+            referrer: window.document.referrer,
+            search: window.location.search,
+            title: window.document.title,
+            url: window.location.href,
+            customProperty: 'Example'
+          }
+        });
+      });
+    });
+
+    describe('#group', function() {
+      beforeEach(function() {
+        analytics.stub(window, 'satismeter');
+      });
+
+      it('should send group id and traits', function() {
+        analytics.user().id('id');
+        analytics.user().anonymousId('anonymousId');
+        analytics.group('groupId', {
+          industry: 'Technology',
+          employees: 2000
+        });
+
+        analytics.called(window.satismeter, 'group', {
+          userId: 'id',
+          anonymousId: 'anonymousId',
+          groupId: 'groupId',
+          traits: {
+            industry: 'Technology',
+            employees: 2000
+          }
         });
       });
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1457,10 +1457,10 @@
     component-cookie "^1.1.2"
     component-url "^0.2.1"
 
-"@segment/tracktor@0.12.0":
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/@segment/tracktor/-/tracktor-0.12.0.tgz#2df0a1f8dad87e13ca4afac51655d6bac7c0c95f"
-  integrity sha512-yOGcYD33y0Wo1qHIA+IFIHcxk0GoRrQwCjpuaKZf2rnz0puZoseSGPdbIX47BgMLSSgEYnBoW3s5aUpCRdkEkw==
+"@segment/tracktor@0.12.1":
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/@segment/tracktor/-/tracktor-0.12.1.tgz#ca3e868f8b51c7da585764a482874addc31ea3e1"
+  integrity sha512-M9/XhBOHzerK1ZoiL/wOaM4gmzBOV6e2Z/xeic85qjKtiFSqNOBthlpyEGfEDKo6niEVBQm6wn86HgcAEkMDAg==
   dependencies:
     element-matches-polyfill "^1.0.0"
     whatwg-fetch "^3.0.0"


### PR DESCRIPTION
**What does this PR do?**
  - Adds anonymousId in all calls
  - Adds support for `track` and `group` calls
  - Adds page related properties to `page` calls
  - Adds `source` parameter on `load` to identify analytics.js as the caller

**Are there breaking changes in this PR?**
No

**Any background context you want to provide?**
No

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
- SatisMeter browser widget is already updated to support `source` and `anonymousId`.
- SatisMeter server and browser widget will be updated to support the other new calls and parameters.

**Does this require a new integration setting? If so, please explain how the new setting works**
No

**Links to helpful docs and other external resources**
N/A