### PR TITLE
Support a better debugging mode for unit tests

### DIFF
--- a/integrations/optimizely/package.json
+++ b/integrations/optimizely/package.json
@@ -11,6 +11,7 @@
   "main": "lib/index.js",
   "scripts": {
     "test": "karma start",
+    "test:debug": "HEADLESS=false karma start",
     "test:ci": "karma start karma.conf-ci.js"
   },
   "author": "Segment <friends@segment.com>",

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -15,7 +15,7 @@ module.exports = function(config) {
 
     reporters: ['spec'],
 
-    browsers: ['ChromeHeadless'],
+    browsers: [process.env.HEADLESS === 'false' ? 'Chrome' : 'ChromeHeadless'],
 
     middleware: ['server'],
 


### PR DESCRIPTION
**What does this PR do?**

* Use a visible Chrome browser instead of headless Chrome when running unit tests with `HEADLESS=false`.
* For the Optimizely integration, facilitate this via a new `yarn test:debug` command.

**Are there breaking changes in this PR?**

No. I've confirmed `yarn test` command continues to run in headless mode.

**Any background context you want to provide?**

I was having trouble debugging some of the tests in #481. This tweak made debugging much easier because it allowed me to step through my code line-by-line using the Chrome inspector. I'll admit there may be a built-in debugging flow that I'm just not aware of.

**Is there parity with the server-side/android/iOS integration components (if applicable)?**

N/A

**Does this require a new integration setting? If so, please explain how the new setting works**

No

**Links to helpful docs and other external resources**

N/A