### PR TITLE
typo: mixpanel token set twice to the same value

### DIFF
--- a/integrations/mixpanel/test/index.test.js
+++ b/integrations/mixpanel/test/index.test.js
@@ -48,7 +48,6 @@ describe('Mixpanel', function() {
         .option('nameTag', true)
         .option('pageview', false)
         .option('people', false)
-        .option('token', '')
         .option('trackAllPages', false)
         .option('persistence', 'cookie')
         .option('trackNamedPages', false)


### PR DESCRIPTION
which, in this case, is an empty string both times.  See line 45 where it's initially set.


**What does this PR do?**
fix a bug

**Are there breaking changes in this PR?**
no

**Any background context you want to provide?**
no

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
no

**Does this require a new integration setting? If so, please explain how the new setting works**
no

**Links to helpful docs and other external resources**
n/a