### PR TITLE
Relay custom customer traits to Friendbuy destination

### DIFF
--- a/integrations/friendbuy/HISTORY.md
+++ b/integrations/friendbuy/HISTORY.md
@@ -1,3 +1,9 @@
+1.0.8 / 2020-08-24
+==================
+
+  * Relay merchant-specific customer traits to the Friendbuy destination
+  * Fix pre-existing linting errors
+
 1.0.7 / 2018-02-23
 ==================
 

--- a/integrations/friendbuy/package.json
+++ b/integrations/friendbuy/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-friendbuy",
   "description": "The FriendBuy analytics.js integration.",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/friendbuy/test/index.test.js
+++ b/integrations/friendbuy/test/index.test.js
@@ -5,7 +5,6 @@ var integrationTester = require('@segment/analytics.js-integration-tester');
 var integration = require('@segment/analytics.js-integration');
 var sandbox = require('@segment/clear-env');
 var FriendBuy = require('../lib/');
-var util = require('util');
 
 describe('FriendBuy', function() {
   var analytics;
@@ -239,6 +238,31 @@ describe('FriendBuy', function() {
             last_name: myElectrifyingTraits.lastName,
             stripe_customer_id: 'staging-billing-is-broken',
             chargebee_customer_id: 'buzz-buzz'
+          }
+        ]);
+      });
+
+      it('should track customer with custom traits', function() {
+        var myCustomElectrifyingTraits = Object.assign(
+          {},
+          myElectrifyingTraits,
+          {
+            VIP: true,
+            plan_type: 'luxury'
+          }
+        );
+
+        analytics.identify(userId, myCustomElectrifyingTraits);
+        analytics.called(window.friendbuy.push, [
+          'track',
+          'customer',
+          {
+            id: userId,
+            email: myCustomElectrifyingTraits.email,
+            first_name: myCustomElectrifyingTraits.firstName,
+            last_name: myCustomElectrifyingTraits.lastName,
+            VIP: true,
+            plan_type: 'luxury'
           }
         ]);
       });


### PR DESCRIPTION
**What does this PR do?**

This PR allows users of the Friendbuy destination to relay customized customer properties to Friendbuy, beyond the standard set that is currently accepted.

**Are there breaking changes in this PR?**

No.

**Any background context you want to provide?**

Friendbuy allows its merchants to add custom traits to their customers when integrating directly with the Friendbuy customer tracking API as part of a feature called widget targeting: http://help.friendbuy.com/en/articles/1916126-widget-targeting

We would like to allow our merchants to pass these custom parameters through the `identify` event to Friendbuy's Destination integration, so that they can use this feature via Segment. The Friendbuy Segment integration currently only accepts Customer ID, Email Address, First Name, and Last Name.  We'd like to be able to allow merchants to pass in custom parameters through the `identify` event, such as age, VIP, etc.

**Is there parity with the server-side/android/iOS integration components (if applicable)?**

n/a

**Does this require a new integration setting? If so, please explain how the new setting works**

No.

**Links to helpful docs and other external resources**

General customer tracking API: https://developers.friendbuy.com/#tracking

Widget targeting feature: http://help.friendbuy.com/en/articles/1916126-widget-targeting
