### PR TITLE
[Heap] Add a blacklist to prevent sending traits

### DIFF
--- a/integrations/heap/HISTORY.md
+++ b/integrations/heap/HISTORY.md
@@ -1,3 +1,7 @@
+2.1.2 / 2020-09-04
+==================
+
+  * Add a blacklist to prevent sending the configured traits in the addUserProperties call
 
 2.1.1 / 2018-07-06
 ==================

--- a/integrations/heap/package.json
+++ b/integrations/heap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-heap",
   "description": "The Heap analytics.js integration.",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/heap/test/index.test.js
+++ b/integrations/heap/test/index.test.js
@@ -11,7 +11,8 @@ describe('Heap', function() {
   var heap;
   var analytics;
   var options = {
-    appId: '1535634150'
+    appId: '1535634150',
+    blacklistedTraits: ['forbidden_field', 'do_not_send']
   };
 
   beforeEach(function() {
@@ -124,6 +125,19 @@ describe('Heap', function() {
 
       it('should send id as handle and traits', function() {
         analytics.identify('id', { trait: 'trait' });
+        analytics.called(window.heap.identify, 'id');
+        analytics.called(window.heap.addUserProperties, {
+          id: 'id',
+          trait: 'trait'
+        });
+      });
+
+      it('should filter out blacklisted traits', function() {
+        analytics.identify('id', {
+          trait: 'trait',
+          forbidden_field: 'shouldnt send this',
+          do_not_send: 'nor this'
+        });
         analytics.called(window.heap.identify, 'id');
         analytics.called(window.heap.addUserProperties, {
           id: 'id',


### PR DESCRIPTION
Add a blacklist to prevent sending the configured traits in the addUserProperties call

**What does this PR do?**

Adds a config entry in the Heap plugin. It is a list of fields that should be excluded from calls to the addUserProperties method.

**Are there breaking changes in this PR?**

No

**Any background context you want to provide?**

Some data compliance policies requires that no PII (Personally identifiable information) is sent to subprocessors. This change would allow that, combined with an id that's also non-identifiable.

**Is there parity with the server-side/android/iOS integration components (if applicable)?**

n/a

**Does this require a new integration setting? If so, please explain how the new setting works**

Yes. The setting is called `blacklistedTraits`, and it's an array of strings. The description might be: "List of traits (fields) that should be blacklisted from the identify calls to Heap".

**Links to helpful docs and other external resources**

https://help.heap.io/data-privacy/data-privacy-faqs/how-do-i-use-heap-to-comply-with-data-privacy-legislation/
https://en.wikipedia.org/wiki/Personal_data
