### PR TITLE
Allow fetching Mixpanel library from a different URL

### DIFF
--- a/integrations/mixpanel/HISTORY.md
+++ b/integrations/mixpanel/HISTORY.md
@@ -1,3 +1,7 @@
+3.3.0 / 2020-09-04
+==================
+  * Added support for setting custom URL to load library from.
+
 3.1.0 / 2019-09-27
 ==================
   * Added support for groups.

--- a/integrations/mixpanel/lib/index.js
+++ b/integrations/mixpanel/lib/index.js
@@ -40,7 +40,12 @@ var Mixpanel = (module.exports = integration('Mixpanel')
   .option('groupIdentifierTraits', [])
   .option('sourceName', '')
   .option('enableEuropeanUnionEndpoint', false)
-  .tag('<script src="//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js">'));
+  .option('customLibraryUrl', '')
+  .tag(
+    'default',
+    '<script src="//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js">'
+  )
+  .tag('custom', '<script src="{{ customLibraryUrl }}">'));
 
 /**
  * Options aliases.
@@ -79,7 +84,12 @@ for(h=0;h<k.length;h++)e(d,k[h]);a._i.push([b,c,f])};a.__SV=1.2;}})(document,win
     mixpanel.register({ mp_lib: 'Segment: web' });
   };
   window.mixpanel.init(options.token, options);
-  this.load(this.ready);
+  // if custom library URL is provided, use that one
+  if (options.customLibraryUrl) {
+    this.load('custom', this.ready);
+  } else {
+    this.load('default', this.ready);
+  }
 };
 
 /**

--- a/integrations/mixpanel/package.json
+++ b/integrations/mixpanel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-mixpanel",
   "description": "The Mixpanel analytics.js integration.",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/mixpanel/test/index.test.js
+++ b/integrations/mixpanel/test/index.test.js
@@ -58,6 +58,7 @@ describe('Mixpanel', function() {
         .option('groupIdentifierTraits', [])
         .option('sourceName', '')
         .option('enableEuropeanUnionEndpoint', false)
+        .option('customLibraryUrl', '')
     );
   });
 
@@ -90,8 +91,21 @@ describe('Mixpanel', function() {
   });
 
   describe('loading', function() {
-    it('should load', function(done) {
-      analytics.load(mixpanel, done);
+    beforeEach(function() {
+      analytics.spy(mixpanel, 'load');
+    });
+
+    it('should load default script', function() {
+      analytics.load(mixpanel);
+      analytics.loaded(
+        '<script src="http://cdn.mxpnl.com/libs/mixpanel-2-latest.min.js">'
+      );
+    });
+
+    it('should load from custom library url if provided', function() {
+      mixpanel.options.customLibraryUrl = '//example.com/mixpanel.js';
+      analytics.load(mixpanel);
+      analytics.loaded('<script src="http://example.com/mixpanel.js">');
     });
   });
 


### PR DESCRIPTION
**What does this PR do?**
Allows configuring a custom URL to load Mixpanel.js from

**Are there breaking changes in this PR?**
No.

**Any background context you want to provide?**
Allows loading Mixpanel from a proxy-server

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
N/A

**Does this require a new integration setting? If so, please explain how the new setting works**
There is a new option/setting - `customLibraryUrl`, which if specified is used as the source for the script tag used to load the library.

**Links to helpful docs and other external resources**
N/A