### PR TITLE
Specify charset in Segment content-type header

### DIFF
--- a/integrations/segmentio/lib/index.js
+++ b/integrations/segmentio/lib/index.js
@@ -347,7 +347,7 @@ Segment.prototype.ampId = function(ctx) {
 
 Segment.prototype.enqueue = function(path, message, fn) {
   var url = 'https://' + this.options.apiHost + path;
-  var headers = { 'Content-Type': 'text/plain' };
+  var headers = { 'Content-Type': 'text/plain; charset=utf-8' };
   var msg = this.normalize(message);
 
   // Print a log statement when messages exceed the maximum size. In the future,

--- a/integrations/segmentio/package.json
+++ b/integrations/segmentio/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-segmentio",
   "description": "The Segmentio analytics.js integration.",
-  "version": "4.2.5",
+  "version": "4.2.6",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",


### PR DESCRIPTION
**What does this PR do?**

Explicitly specifies a charset in the content-type header for the Segment integration.

**Are there breaking changes in this PR?**

No

**Any background context you want to provide?**

The Segment integration is sending a JSON payload with a content-type of `text/plain`. According to the HTTP spec, when no explicit charset is provided for `text/plain` payloads, a default charset value of ISO-8859-1 is assumed. However, the JSON payload is being encoded via `XMLHttpRequest.send()`, which uses UTF-8. Therefore, the charset should be explicitly specified as UTF-8.

**Is there parity with the server-side/android/iOS integration components (if applicable)?**

Unsure if applicable

**Does this require a new integration setting? If so, please explain how the new setting works**

No

**Links to helpful docs and other external resources**

* XMLHttpRequest spec: "If body is a Document, then set request body to body, serialized, converted, and UTF-8 encoded." (https://xhr.spec.whatwg.org/#the-send()-method)
* HTTP spec: "When no explicit charset parameter is provided by the sender, media subtypes of the "text" type are defined to have a default charset value of "ISO-8859-1" when received via HTTP." (https://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html)