### PR TITLE
[PD-378] Remove google_cm param from DCF match tag

### DIFF
--- a/integrations/doubleclick-floodlight/lib/index.js
+++ b/integrations/doubleclick-floodlight/lib/index.js
@@ -31,7 +31,7 @@ var Floodlight = (module.exports = integration('DoubleClick Floodlight')
   )
   .tag(
     'doubleclick id',
-    '<img src="//cm.g.doubleclick.net/pixel?google_nid={{ googleNetworkId }}&segment_write_key={{ segmentWriteKey }}&user_id={{ userId }}&anonymous_id={{ anonymousId }}&google_hm={{ partnerProvidedId }}"/>'
+    '<img src="//cm.g.doubleclick.net/pixel?google_nid={{ googleNetworkId }}&segment_write_key={{ segmentWriteKey }}&google_hm={{ partnerProvidedId }}"/>'
   ));
 
 /**
@@ -49,9 +49,6 @@ Floodlight.prototype.initialize = function() {
     this.load('doubleclick id', {
       googleNetworkId: this.options.googleNetworkId,
       segmentWriteKey: this.options.segmentWriteKey,
-      // TODO: handle userId being nulls/undefined.
-      userId: this.analytics.user().id(),
-      anonymousId: this.analytics.user().anonymousId(),
       // Hosted match table id https://developers.google.com/authorized-buyers/rtb/cookie-guide#match-table
       partnerProvidedId: btoa(this.analytics.user().anonymousId())
     });

--- a/integrations/doubleclick-floodlight/lib/index.js
+++ b/integrations/doubleclick-floodlight/lib/index.js
@@ -31,7 +31,7 @@ var Floodlight = (module.exports = integration('DoubleClick Floodlight')
   )
   .tag(
     'doubleclick id',
-    '<img src="//cm.g.doubleclick.net/pixel?google_cm&google_nid={{ googleNetworkId }}&segment_write_key={{ segmentWriteKey }}&user_id={{ userId }}&anonymous_id={{ anonymousId }}&google_hm={{ partnerProvidedId }}"/>'
+    '<img src="//cm.g.doubleclick.net/pixel?google_nid={{ googleNetworkId }}&segment_write_key={{ segmentWriteKey }}&user_id={{ userId }}&anonymous_id={{ anonymousId }}&google_hm={{ partnerProvidedId }}"/>'
   ));
 
 /**


### PR DESCRIPTION
**What does this PR do?**
This PR prevents the triggering of Google's cookie matching process, and instead relies on Google hosted match tables. It does so by removing the `google_cm` parameter from the match tag. Further context provided in the [retrospective SDD for our DV360 integration](https://paper.dropbox.com/doc/Google-Retrospective-SDD-DV360--A7qLO0MpSDwjtifxRgK5TBG9Ag-gAWKYnAc53JlwhUUFEjOY). 

Note these responses to our questions sent to Google:
> **1. Will the Hosted Match service not be triggered if we include google_cm parameter in the match tag?**
The Hosted Match service will be triggered if google_hm parameter is included however, including google_cm will also invoke the Cookie Matching service and for such requests, google_gid will be passed in the redirect. Simultaneously, the match will be stored in the Hosted Match table since google_hm is also included so there wouldn't be a problem with that. This is the actual workflow before June's update over Cookie Matching.
Considering the recent change wherein, google_gid is no longer passed for users in California, the parameter google_cm is no longer supported in this new workflow. Passing google_cm for a user in California will result in an error and the match will not be saved. Since this update is not applicable for the users outside of California, including google_cm will work like usual and there will be no change as mentioned in the above point.
Since you're using google_hm for all users regardless of where they are located and save those matches in Google's Hosted Match table, including google_cm isn't required unless you're looking for a redirect with google_gid value. In such a case, google_cm should only be included for the users outside of California and this parameter should be removed for users in California.
Note: When google_cm is included, Cookie Matching service will treat it as the old workflow that was being used before the June's announcement, as mentioned in the 1st bullet point above.
**2. You mentioned that currently Segment has a configuration which means that we will only receive a 302 redirect if there is an error. If the match is successful, we do not receive the redirect and Google responds with the pixel. I'm a little unclear on this. We currently send the google_cm parameter as well as the google_hm parameter in the match tag. I would think this means that we always receive the 302. Can you elaborate? Did you mean to say that, should we stop sending the google_cm parameter, then we would only receive 302s when there is an error?**
Yes, that's correct. 
As mentioned above, including google_cm in the match tag will invoke Cookie Matching service as per the old workflow wherein, we issue a redirect with google_gid value. However, if you don't include google_cm and send just google_hm, then there won't be a redirect back to you unless there is an error. 
I hope this clarifies. Please do not hesitate to let me know if you've any further questions. Have a great week ahead and stay safe.

**Are there breaking changes in this PR?**
Nothing will break, but the workflow for cookie syncing will change. After this change, we will no longer receive a redirect for the pixel to our `idsync-service`; instead, Google will only respond with the 302 when there is an error in the matching process. Otherwise, Google responds with the pixel content. 

**Any background context you want to provide?**
This is a follow up to [previous work](https://github.com/segmentio/analytics.js-integrations/pull/476) to migrate toward Google hosted match tables in June 2020.

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
N/A

**Does this require a new integration setting? If so, please explain how the new setting works**
N/A

**Links to helpful docs and other external resources**
[Retro DV360 SDD](https://paper.dropbox.com/doc/Google-Retrospective-SDD-DV360--A7qLO0MpSDwjtifxRgK5TBG9Ag-gAWKYnAc53JlwhUUFEjOY)
[Google Cookie Matching Docs](https://developers.google.com/authorized-buyers/rtb/cookie-guide)