### PR TITLE
Proposal: allow passing a callback to Amplitude integration

### DIFF
--- a/integrations/amplitude/lib/index.js
+++ b/integrations/amplitude/lib/index.js
@@ -238,7 +238,7 @@ Amplitude.prototype.setTraits = function(traits) {
 
 Amplitude.prototype.track = logEvent;
 
-function logEvent(track, dontSetRevenue) {
+function logEvent(track, dontSetRevenue, callback) {
   this.setDeviceIdFromAnonymousId(track);
 
   var props = track.properties();
@@ -277,7 +277,7 @@ function logEvent(track, dontSetRevenue) {
       .getInstance()
       .logEventWithGroups(event, props, options.groups);
   } else {
-    window.amplitude.getInstance().logEvent(event, props);
+    window.amplitude.getInstance().logEvent(event, props, callback);
   }
 
   // Ideally, user's will track revenue using an Order Completed event.


### PR DESCRIPTION
Hi there - I'm opening this PR just to start a discussion on whether you'd want to take a change like this.

## The problem
We'd like to log an analytics event immediately before navigating a page. Analytics.js' `trackLink()` is insufficient because it merely waits for a 300ms time. We're finding that 300ms isn't long enough for 20% of our analytics events are dropped. Our underlying analytics integration is Amplitude, and Amplitude supports passing a callback.

## The solution (proposed in this incomplete PR)
When using Amplitude specifically, we'd like to be able to pass a callback. This PR shows a very incomplete solution and only exists to start a conversation about this feature request.