### PR TITLE
Don't fail CI builds on lint warnings

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,7 +5,7 @@ steps:
     command:
       - npm config set "//registry.npmjs.org/:_authToken" $${NPM_TOKEN}
       - yarn install --frozen-lockfile
-      - yarn lint
+      - yarn lint || true
       - yarn test
       - yarn test:ci
     plugins:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
           command: yarn install --frozen-lockfile
       - run:
           name: Run Linter (not enforcing for now)
-          command: yarn lint
+          command: yarn lint || true
       - run:
           name: Run Tests
           command: yarn test

--- a/.eslintrc
+++ b/.eslintrc
@@ -17,7 +17,10 @@
     "no-shadow": "warn",
     "no-plusplus": "off",
     "no-template-curly-in-string": "warn",
-    "no-useless-escape": "warn"
+    "no-useless-escape": "warn",
+    "no-return-assign": "warn",
+    "no-unused-vars": "warn",
+    "no-param-reassign": "warn"
   },
   "overrides": [
     {


### PR DESCRIPTION
**What does this PR do?**

ESLint warns currently fail the build, and there's many of such warnings in integrations that haven't been touched in the last couple years, blocking our ability to publish new versions or bump dependencies.

**Are there breaking changes in this PR?**

There are no breaking changes

**Testing**

Testing not required because we're only relaxing some CI validation that's enforced as part of a commit hook.
