### PR TITLE
[DEST-2724] Update adobe-analytics facade to 3.2.7 to mitigate ReDos in trim dep

### DIFF
--- a/integrations/adobe-analytics/HISTORY.md
+++ b/integrations/adobe-analytics/HISTORY.md
@@ -1,3 +1,7 @@
+1.16.3 / 2020-12-14
+===================
+* Bump segmentio-facade to ^3.2.7
+
 1.16.2 / 2020-07-13
 ===================
 * Reads session playhead values from `window._segHBPlayheads` if it exists. This solves an issue where the playhead is only updated when 'Video Content Playing' (+ various others) events are tracked. To get around this, we allow video implementations to set the playhead value as often as possible without the need to trigger an event.

--- a/integrations/adobe-analytics/package.json
+++ b/integrations/adobe-analytics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-adobe-analytics",
   "description": "The Adobe Analytics analytics.js integration.",
-  "version": "1.16.2",
+  "version": "1.16.3",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",
@@ -33,7 +33,7 @@
     "@segment/to-iso-string": "^1.0.1",
     "@segment/trample": "^0.2.0",
     "obj-case": "^0.2.0",
-    "segmentio-facade": "^3.0.3",
+    "segmentio-facade": "^3.2.7",
     "type-of": "^2.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
**What does this PR do?**

https://segment.atlassian.net/browse/DEST-2724

Bump facade to 3.2.7. This patches a ReDos vuln in an underlying dependency, trim. Trim was patched in https://github.com/Trott/trim/commit/52b0acc7587eed7380344fd767847dbd4854e4f2 with no breaking changes. And a new 3.2.x branch was pushed and published in https://github.com/segmentio/facade/commits/v3.2.x, also with no breaking changes. We avoided updating via 3.3.x+ releases since they're far larger to validate (rewrite as of https://github.com/segmentio/facade/commit/a2963c20a407a091bf3f6a5576bf4b0c3c38276b)

<img width="1110" alt="Screen Shot 2020-12-14 at 9 35 02 AM" src="https://user-images.githubusercontent.com/817212/102114964-b5b5ca00-3def-11eb-9d4c-a2db099b87dc.png">

**Are there breaking changes in this PR?**

There are no breaking changes. Upgrade path from 3.0.2 to 3.2.7 is safe. 

**Testing**

Testing completed successfully via CI