### PR TITLE
[DEST-2724] Update amplitude facade to 3.2.7 to mitigate ReDos in trim dep

### DIFF
--- a/integrations/amplitude/HISTORY.md
+++ b/integrations/amplitude/HISTORY.md
@@ -1,3 +1,8 @@
+
+# 3.3.1 / 2020-12-14
+
+- Bump segmentio-facade to ^3.2.7
+
 # 3.3.0 / 2019-10-09
 
 - Add support for versionName setting, this will allow user to specify version.

--- a/integrations/amplitude/package.json
+++ b/integrations/amplitude/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-amplitude",
   "description": "The Amplitude analytics.js integration.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",
@@ -30,7 +30,7 @@
     "component-bind": "^1.0.0",
     "do-when": "^1.0.0",
     "is": "^3.2.1",
-    "segmentio-facade": "^3.2.1"
+    "segmentio-facade": "^3.2.7"
   },
   "devDependencies": {
     "@segment/analytics.js-core": "^3.8.2",


### PR DESCRIPTION
**What does this PR do?**

https://segment.atlassian.net/browse/DEST-2724

Bump facade to 3.2.7. This patches a ReDos vuln in an underlying dependency, trim. Trim was patched in https://github.com/Trott/trim/commit/52b0acc7587eed7380344fd767847dbd4854e4f2 with no breaking changes. And a new 3.2.x branch was pushed and published in https://github.com/segmentio/facade/commits/v3.2.x, also with no breaking changes. We avoided updating via 3.3.x+ releases since they're far larger to validate (rewrite as of https://github.com/segmentio/facade/commit/a2963c20a407a091bf3f6a5576bf4b0c3c38276b)

<img width="1110" alt="Screen Shot 2020-12-14 at 9 35 02 AM" src="https://user-images.githubusercontent.com/817212/102114964-b5b5ca00-3def-11eb-9d4c-a2db099b87dc.png">

**Are there breaking changes in this PR?**

There are no breaking changes. Upgrade path from 3.0.2 to 3.2.7 is safe. 

**Testing**

Testing completed successfully via CI