### PR TITLE
Temporarily disable saucelabs tests in CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,7 +7,6 @@ steps:
       - yarn install --frozen-lockfile
       - yarn lint || true
       - yarn test
-      - yarn test:ci
     plugins:
       - ssh://git@github.com/segmentio/cache-buildkite-plugin#v1.0.0:
           key: "v1-cache-dev-{{ checksum 'yarn.lock' }}"


### PR DESCRIPTION
**What does this PR do?**
Disables saucelabs tests as we're currently unable to run them for more than 1 integration at a time before hitting connection errors. Browser tests will continue to run via karma+headless chrome in CI. We just don't run the full browser test matrix of firefox, safari, edge, etc

This will be reverted once https://segment.atlassian.net/browse/DEST-2724 is complete

**Are there breaking changes in this PR?**

Testing not required because we're disabling saucelabs in CI due to connection errors while patching deps
