### PR TITLE
Revert "Temporarily disable saucelabs tests in CI"

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,6 +7,7 @@ steps:
       - yarn install --frozen-lockfile
       - yarn lint || true
       - yarn test
+      - yarn test:ci
     plugins:
       - ssh://git@github.com/segmentio/cache-buildkite-plugin#v1.0.0:
           key: "v1-cache-dev-{{ checksum 'yarn.lock' }}"


### PR DESCRIPTION
Reverts segmentio/analytics.js-integrations#536

Testing not required because we're re-enabling saucelabs in CI due after having temporarily disabled it