### PR TITLE
Update Olark to count automated events as nonInteraction

### DIFF
--- a/integrations/olark/HISTORY.md
+++ b/integrations/olark/HISTORY.md
@@ -1,3 +1,8 @@
+2.1.0 / 2020-12-16
+==================
+
+  * Updated the `Live Chat Message Received` event to add `nonInteraction: 1` prop for automated olark messages. This will prevent automated pop-ups counting as interactive events in GA massively skewing the bounce rate calculation.
+
 2.0.0 / 2016-06-21
 ==================
 

--- a/integrations/olark/lib/index.js
+++ b/integrations/olark/lib/index.js
@@ -181,10 +181,10 @@ Olark.prototype.attachListeners = function() {
 
   // Callback accepts `event`
   // TODO: We might eventually send information about the event through Segment
-  api('chat.onMessageToVisitor', function() {
+  api('chat.onMessageToVisitor', function(opts) {
     self.analytics.track(
       'Live Chat Message Received',
-      {},
+      (opts.automated === true ? { nonInteraction: 1 } : {}),
       {
         context: { integration: integrationContext },
         integrations: { Olark: false }

--- a/integrations/olark/lib/index.js
+++ b/integrations/olark/lib/index.js
@@ -184,7 +184,7 @@ Olark.prototype.attachListeners = function() {
   api('chat.onMessageToVisitor', function(opts) {
     self.analytics.track(
       'Live Chat Message Received',
-      (opts.automated === true ? { nonInteraction: 1 } : {}),
+      ((opts.message && opts.message.automated === true) ? { nonInteraction: 1 } : {}),
       {
         context: { integration: integrationContext },
         integrations: { Olark: false }

--- a/integrations/olark/package.json
+++ b/integrations/olark/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-olark",
   "description": "The Olark analytics.js integration.",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",


### PR DESCRIPTION
**What does this PR do?**
Updated the `Live Chat Message Received` event to add `nonInteraction: 1` prop for automated olark messages. This will prevent automated pop-ups counting as interactive events in GA massively skewing the bounce rate calculation.

In our specific situation, we have Olark on our website along with Google Analytics. We have Olark configured to pop-up and offer to start a chat session when agents are online and they have been on the site for more than 15 or so seconds. This triggers the `chat.onMessageToVisitor` Olark event to be triggered, causing an event `Live Chat Message Received` to be triggered throughout Segment. GA then sees this event and doesn't count the session as bounced, even if it is actually should be counted as a bounced session ([info here about bounces](https://support.google.com/analytics/answer/1033068?hl=en#NonInteractionEvents)).

**Are there breaking changes in this PR?**
This may cause issues with people who are used to the existing behaviour and an incorrect (much lower) bounce rate. Other than that, the change is quite minimal.

**Testing**
<!---

All PRs must follow the process for change control as outlined in:
https://segment.atlassian.net/wiki/spaces/GRC/pages/453935287/Reinforcing+Change+Control

- Testing completed successfully using <how did you test, environment>; or
- Testing not required because <explain why you think testing isn't needed>

--->
We've been running this change in production for a month now to test it, and wanted to contribute it upstream now.


**Is there parity with the server-side/android/iOS integration components (if applicable)?**
N/A


**Does this require a new integration setting? If so, please explain how the new setting works**
Nope


**Links to helpful docs and other external resources**
https://support.google.com/analytics/answer/1033068?hl=en#NonInteractionEvents
