### PR TITLE
[STRATCONN-588] Generate bundledConfigIds

### DIFF
--- a/integrations/segmentio/HISTORY.md
+++ b/integrations/segmentio/HISTORY.md
@@ -1,3 +1,12 @@
+4.4.1 / 2020-02-05
+==================
+
+  * Removes the `bundledConfigIds` _setting_ and instead generates `bundledConfigIds` using the intersection
+    of `bundled` destinations and the new `maybeBundledConfigIds` setting. `bundledConfigIds` and `unbundledConfigIds`
+    is still appended to event metadata. This change is meant to ensure that `bundledConfigIds` only includes the
+    subset of destinations that is generated at runtime for the `bundled` array.
+  * Fixes the use of `const` from a previous release.
+
 4.3.0 / 2020-01-13
 ==================
 

--- a/integrations/segmentio/HISTORY.md
+++ b/integrations/segmentio/HISTORY.md
@@ -1,4 +1,4 @@
-4.4.1 / 2020-02-05
+4.4.0 / 2020-02-05
 ==================
 
   * Removes the `bundledConfigIds` _setting_ and instead generates `bundledConfigIds` using the intersection

--- a/integrations/segmentio/lib/index.js
+++ b/integrations/segmentio/lib/index.js
@@ -341,8 +341,7 @@ Segment.prototype.normalize = function(message) {
     msg._metadata = msg._metadata || {};
     msg._metadata.bundled = bundled;
     msg._metadata.unbundled = this.options.unbundledIntegrations;
-    msg._metadata.bundledConfigIds = bundledConfigIds;
-    msg._metadata.unbundledConfigIds = this.options.unbundledConfigIds;
+    msg._metadata.bundledIds = bundledConfigIds;
   }
   this.debug('normalized %o', msg);
   this.ampId(ctx);

--- a/integrations/segmentio/lib/index.js
+++ b/integrations/segmentio/lib/index.js
@@ -323,6 +323,9 @@ Segment.prototype.normalize = function(message) {
     var bundledConfigIds = []
     for (var i = 0; i < bundled.length; i++) {
       var name = bundled[i]
+      if (!maybeBundledConfigIds) {
+        break
+      }
       if (!maybeBundledConfigIds[name]) {
         continue
       }

--- a/integrations/segmentio/lib/index.js
+++ b/integrations/segmentio/lib/index.js
@@ -340,8 +340,8 @@ Segment.prototype.normalize = function(message) {
 
     msg._metadata = msg._metadata || {};
     msg._metadata.bundled = bundled;
-    msg._metadata.bundledConfigIds = bundledConfigIds;
     msg._metadata.unbundled = this.options.unbundledIntegrations;
+    msg._metadata.bundledConfigIds = bundledConfigIds;
     msg._metadata.unbundledConfigIds = this.options.unbundledConfigIds;
   }
   this.debug('normalized %o', msg);

--- a/integrations/segmentio/lib/index.js
+++ b/integrations/segmentio/lib/index.js
@@ -18,7 +18,7 @@ var utm = require('@segment/utm-params');
 var uuid = require('@lukeed/uuid').v4;
 var Queue = require('@segment/localstorage-retry');
 
-const json = JSON;
+var json = JSON;
 
 /**
  * Cookie options
@@ -65,8 +65,8 @@ var Segment = (exports = module.exports = integration('Segment.io')
   .option('retryQueue', true)
   .option('addBundledMetadata', false)
   .option('unbundledIntegrations', []))
-  .option('unbundledIntegrationIds', [])
-  .option('maybeBundledConfigIds', []);
+  .option('unbundledConfigIds', [])
+  .option('maybeBundledConfigIds', {});
 
 /**
  * Get the store.
@@ -317,6 +317,7 @@ Segment.prototype.normalize = function(message) {
   }
   if (this.options.addBundledMetadata) {
     var bundled = keys(this.analytics.Integrations);
+    var maybeBundledConfigIds = this.options.maybeBundledConfigIds
 
     // Generate a list of bundled config IDs using the intersection of
     // bundled destination names and maybe bundled config IDs.
@@ -330,8 +331,8 @@ Segment.prototype.normalize = function(message) {
         continue
       }
 
-      for (var i = 0; i < maybeBundledConfigIds[name].length; i++) {
-        var id = maybeBundledConfigIds[name][i]
+      for (var j = 0; j < maybeBundledConfigIds[name].length; j++) {
+        var id = maybeBundledConfigIds[name][j]
         bundledConfigIds.push(id)
       }
     }
@@ -339,8 +340,8 @@ Segment.prototype.normalize = function(message) {
 
     msg._metadata = msg._metadata || {};
     msg._metadata.bundled = bundled;
-    msg._metadata.unbundled = this.options.unbundledIntegrations;
     msg._metadata.bundledConfigIds = bundledConfigIds;
+    msg._metadata.unbundled = this.options.unbundledIntegrations;
     msg._metadata.unbundledConfigIds = this.options.unbundledConfigIds;
   }
   this.debug('normalized %o', msg);

--- a/integrations/segmentio/lib/index.js
+++ b/integrations/segmentio/lib/index.js
@@ -64,7 +64,9 @@ var Segment = (exports = module.exports = integration('Segment.io')
   .option('saveCrossDomainIdInLocalStorage', true)
   .option('retryQueue', true)
   .option('addBundledMetadata', false)
-  .option('unbundledIntegrations', []));
+  .option('unbundledIntegrations', []))
+  .option('unbundledIntegrationIds', [])
+  .option('maybeBundledConfigIds', []);
 
 /**
  * Get the store.
@@ -315,10 +317,27 @@ Segment.prototype.normalize = function(message) {
   }
   if (this.options.addBundledMetadata) {
     var bundled = keys(this.analytics.Integrations);
+
+    // Generate a list of bundled config IDs using the intersection of
+    // bundled destination names and maybe bundled config IDs.
+    var bundledConfigIds = []
+    for (var i = 0; i < bundled.length; i++) {
+      var name = bundled[i]
+      if (!maybeBundledConfigIds[name]) {
+        continue
+      }
+
+      for (var i = 0; i < maybeBundledConfigIds[name].length; i++) {
+        var id = maybeBundledConfigIds[name][i]
+        bundledConfigIds.push(id)
+      }
+    }
+
+
     msg._metadata = msg._metadata || {};
     msg._metadata.bundled = bundled;
     msg._metadata.unbundled = this.options.unbundledIntegrations;
-    msg._metadata.bundledConfigIds = this.options.bundledConfigIds;
+    msg._metadata.bundledConfigIds = bundledConfigIds;
     msg._metadata.unbundledConfigIds = this.options.unbundledConfigIds;
   }
   this.debug('normalized %o', msg);

--- a/integrations/segmentio/package.json
+++ b/integrations/segmentio/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-segmentio",
   "description": "The Segmentio analytics.js integration.",
-  "version": "4.4.1",
+  "version": "4.4.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/segmentio/package.json
+++ b/integrations/segmentio/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-segmentio",
   "description": "The Segmentio analytics.js integration.",
-  "version": "4.3.1",
+  "version": "4.4.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/segmentio/test/index.test.js
+++ b/integrations/segmentio/test/index.test.js
@@ -480,16 +480,6 @@ describe('Segment.io', function() {
           assert(!object._metadata);
         });
 
-        it('should add a list of unbundled destination config ids when `addBundledMetadata` is set', function() {
-          segment.options.addBundledMetadata = true;
-          segment.options.unbundledConfigIds = ['config1'];
-          segment.normalize(object);
-
-          assert(object);
-          assert(object._metadata);
-          assert.deepEqual(object._metadata.unbundledConfigIds, ['config1']);
-        });
-
         it('should generate and add a list of bundled destination config ids when `addBundledMetadata` is set', function() {
           segment.options.addBundledMetadata = true;
           segment.options.maybeBundledConfigIds = {
@@ -500,7 +490,7 @@ describe('Segment.io', function() {
 
           assert(object);
           assert(object._metadata);
-          assert.deepEqual(object._metadata.bundledConfigIds, ['config21']);
+          assert.deepEqual(object._metadata.bundledIds, ['config21']);
         });
 
         it('should generate a list of multiple bundled destination config ids when `addBundledMetadata` is set', function() {
@@ -514,7 +504,7 @@ describe('Segment.io', function() {
 
           assert(object);
           assert(object._metadata);
-          assert.deepEqual(object._metadata.bundledConfigIds, ['config21', 'anotherConfig99']);
+          assert.deepEqual(object._metadata.bundledIds, ['config21', 'anotherConfig99']);
         });
       });
 

--- a/integrations/segmentio/test/index.test.js
+++ b/integrations/segmentio/test/index.test.js
@@ -478,6 +478,29 @@ describe('Segment.io', function() {
           assert(object);
           assert(!object._metadata);
         });
+
+        it('should add a list of unbundled destination config ids when `addBundledMetadata` is set', function() {
+          segment.options.addBundledMetadata = true;
+          segment.options.unbundledConfigIds = ['config1'];
+          segment.normalize(object);
+
+          assert(object);
+          assert(object._metadata);
+          assert.deepEqual(object._metadata.unbundledConfigIds, ['config1']);
+        });
+
+        it('should generate and add a list of bundled destination config ids when `addBundledMetadata` is set', function() {
+          segment.options.addBundledMetadata = true;
+          segment.options.maybeBundledConfigIds = {
+            'other': ['config21'],
+            'slack': ['slack99'] // should be ignored
+          };
+          segment.normalize(object);
+
+          assert(object);
+          assert(object._metadata);
+          assert.deepEqual(object._metadata.bundledConfigIds, ['config21']);
+        });
       });
 
       it('should pick up messageId from AJS', function() {

--- a/integrations/segmentio/test/index.test.js
+++ b/integrations/segmentio/test/index.test.js
@@ -449,8 +449,9 @@ describe('Segment.io', function() {
           segment = new Segment(options);
           ajs.use(Segment);
           ajs.use(integration('other'));
+          ajs.use(integration('another'));
           ajs.add(segment);
-          ajs.initialize({ other: {} });
+          ajs.initialize({ other: {}, another: {} });
         });
 
         it('should add a list of bundled integrations when `addBundledMetadata` is set', function() {
@@ -459,7 +460,7 @@ describe('Segment.io', function() {
 
           assert(object);
           assert(object._metadata);
-          assert.deepEqual(object._metadata.bundled, ['Segment.io', 'other']);
+          assert.deepEqual(object._metadata.bundled, ['Segment.io', 'other', 'another']);
         });
 
         it('should add a list of unbundled integrations when `addBundledMetadata` and `unbundledIntegrations` are set', function() {
@@ -500,6 +501,20 @@ describe('Segment.io', function() {
           assert(object);
           assert(object._metadata);
           assert.deepEqual(object._metadata.bundledConfigIds, ['config21']);
+        });
+
+        it('should generate a list of multiple bundled destination config ids when `addBundledMetadata` is set', function() {
+          segment.options.addBundledMetadata = true;
+          segment.options.maybeBundledConfigIds = {
+            'other': ['config21'],
+            'another': ['anotherConfig99'],
+            'slack': ['slack99'] // should be ignored
+          };
+          segment.normalize(object);
+
+          assert(object);
+          assert(object._metadata);
+          assert.deepEqual(object._metadata.bundledConfigIds, ['config21', 'anotherConfig99']);
         });
       });
 


### PR DESCRIPTION
**What does this PR do?**
This pull request builds a list of `bundledds` based on the intersection between `bundled` and `maybeBundledConfigIds`. `bundledIds` is then appended to each event's metadata object.

The related ajs-renderer change can be found here: https://github.com/segmentio/ajs-renderer/pull/256.

**Example metadata object**
![image](https://user-images.githubusercontent.com/11635476/107005263-55366f80-6744-11eb-9f62-d221b8e0fb63.png)
- `601c3fef8942cb2ad5d70cdf` is the FullStory instance that is not Connection Mode configurable because there is only a browser integration.
- `601c3c238942cb7cb5d70cde` is the Google Analytics instance configured in Device Mode.
- `601c4f8164b0701d3b6b78cd` is the HubSpot instance that is not Connection Mode configurable, but defaults to Device Mode because it's an a.js source.
- `601c40c46b6df7898d069abf` is the Amplitude instance that is configured explicitly in Cloud Mode.

**Are there breaking changes in this PR?**
No. We specifically are adding new metadata fields to avoid introducing breaking changes to `bundled` and `unbundled`.

**Testing**
- [x] Testing completed successfully in stage via end-to-end tests with the related `ajs-renderer` change.
- [x] Existing and new unit tests are passing


**Any background context you want to provide?**


**Is there parity with the server-side/android/iOS integration components (if applicable)?**


**Does this require a new integration setting? If so, please explain how the new setting works**


**Links to helpful docs and other external resources**
