### PR TITLE
add timeout of one second to enqueue non-retry send call

### DIFF
--- a/integrations/segmentio/lib/index.js
+++ b/integrations/segmentio/lib/index.js
@@ -103,7 +103,7 @@ exports.sendJsonWithTimeout = function(url, obj, headers, timeout, fn) {
   // unlikely to happen in production, but we're being safe to preserve backward
   // compatibility.
   if (send.type !== 'xhr') {
-    send(url, obj, headers, fn);
+    send(url, obj, headers, timeout, fn);
     return;
   }
 
@@ -391,7 +391,7 @@ Segment.prototype.enqueue = function(path, message, fn) {
       msg: msg
     });
   } else {
-    send(url, msg, headers, function(err, res) {
+    send(url, msg, headers, 1000, function(err, res) {
       self.debug('sent %O, received %O', msg, [err, res]);
       if (fn) {
         if (err) return fn(err);


### PR DESCRIPTION
**What does this PR do?**
Fix a breaking bug from the RIP JSONv3 commit.

**Are there breaking changes in this PR?**
No, there's fixes.

**Testing**
<!---

All PRs must follow the process for change control as outlined in:
https://segment.atlassian.net/wiki/spaces/GRC/pages/453935287/Reinforcing+Change+Control

- Testing completed successfully using <how did you test, environment>; or
- Testing not required because its a simple missing arg

--->


**Any background context you want to provide?**
No

**Is there parity with the server-side/android/iOS integration components (if applicable)?**


**Does this require a new integration setting? If so, please explain how the new setting works**


**Links to helpful docs and other external resources**
