### PR TITLE
Revert the json3 changes for segmentio integration

### DIFF
--- a/integrations/segmentio/lib/index.js
+++ b/integrations/segmentio/lib/index.js
@@ -9,16 +9,15 @@ var clone = require('component-clone');
 var cookie = require('component-cookie');
 var extend = require('@ndhoule/extend');
 var integration = require('@segment/analytics.js-integration');
+var json = require('json3');
 var keys = require('@ndhoule/keys');
 var localstorage = require('yields-store');
 var protocol = require('@segment/protocol');
 var send = require('@segment/send-json');
 var topDomain = require('@segment/top-domain');
 var utm = require('@segment/utm-params');
-var uuid = require('@lukeed/uuid').v4;
+var uuid = require('uuid').v4;
 var Queue = require('@segment/localstorage-retry');
-
-var json = JSON;
 
 /**
  * Cookie options

--- a/integrations/segmentio/package.json
+++ b/integrations/segmentio/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-segmentio",
   "description": "The Segmentio analytics.js integration.",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",
@@ -28,15 +28,16 @@
     "@ndhoule/keys": "^2.0.0",
     "@segment/ad-params": "^1.0.0",
     "@segment/analytics.js-integration": "^2.1.0",
-    "@segment/localstorage-retry": "^1.2.5",
+    "@segment/localstorage-retry": "^1.2.2",
     "@segment/protocol": "^1.0.0",
-    "@segment/send-json": "^4.0.2",
+    "@segment/send-json": "^3.0.0",
     "@segment/top-domain": "^3.0.0",
     "@segment/utm-params": "^2.0.0",
     "component-clone": "^0.2.2",
     "component-cookie": "^1.1.2",
     "component-type": "^1.2.1",
-    "@lukeed/uuid": "^2.0.0",
+    "json3": "^3.3.2",
+    "uuid": "^2.0.2",
     "yields-store": "^1.0.2"
   },
   "devDependencies": {
@@ -44,6 +45,7 @@
     "@segment/analytics.js-integration-tester": "^2.0.0",
     "@segment/clear-env": "^2.0.0",
     "browserify": "^16.2.3",
+    "eslint": "^5.16.0",
     "karma": "^4.1.0",
     "karma-browserify": "^6.0.0",
     "karma-chrome-launcher": "^2.2.0",
@@ -53,8 +55,8 @@
     "karma-spec-reporter": "^0.0.32",
     "karma-summary-reporter": "^1.6.0",
     "mocha": "^6.1.4",
+    "watchify": "^3.11.1",
     "proclaim": "^3.4.1",
-    "sinon": "^1.17.4",
-    "watchify": "^3.11.1"
+    "sinon": "^1.17.4"
   }
 }

--- a/integrations/segmentio/test/index.test.js
+++ b/integrations/segmentio/test/index.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var Analytics = require('@segment/analytics.js-core').constructor;
+var JSON = require('json3');
 var Segment = require('../lib/');
 var assert = require('proclaim');
 var cookie = require('component-cookie');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1601,18 +1601,6 @@
     npmlog "^4.1.2"
     write-file-atomic "^2.3.0"
 
-"@lukeed/csprng@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@lukeed/csprng/-/csprng-1.0.0.tgz#733a122382749d27e2e46ec38f8c71c9d53a9636"
-  integrity sha512-ruuGHsnabmObBdeMg3vKdGRmh06Oog3eFpf/Tk6X0kDSJDpJTDCj2dqdp1+0VjzIUgHlFF9GBm7uFqfYhhdX9g==
-
-"@lukeed/uuid@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@lukeed/uuid/-/uuid-2.0.0.tgz#1c0f33c071cb6902bc3b9e475782ada7314ef9bd"
-  integrity sha512-dUz8OmYvlY5A9wXaroHIMSPASpSYRLCqbPvxGSyHguhtTQIy24lC+EGxQlwv71AhRCO55WOtgwhzQLpw27JaJQ==
-  dependencies:
-    "@lukeed/csprng" "^1.0.0"
-
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
@@ -2210,16 +2198,17 @@
     next-tick "^0.2.2"
     script-onload "^1.0.2"
 
-"@segment/localstorage-retry@^1.2.5":
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/@segment/localstorage-retry/-/localstorage-retry-1.2.5.tgz#6e378160d0c9d02d4e0d17cea9cb200f36e26f19"
-  integrity sha512-wQ9HxNsEcWNotrBImO7fHTPThWg7lnymmdMqhnT2z6jCiNqHmDeK0ivnh+klomXI8AwAX4OpI0BO5cfNIS5nCw==
+"@segment/localstorage-retry@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@segment/localstorage-retry/-/localstorage-retry-1.2.2.tgz#d141fab7212fd3efb0ee19bf7eb16b1e38930af3"
+  integrity sha1-0UH6tyEv0++w7hm/frFrHjiTCvM=
   dependencies:
-    "@lukeed/uuid" "^2.0.0"
     "@ndhoule/each" "^2.0.1"
     "@ndhoule/keys" "^2.0.0"
     component-emitter "^1.2.1"
     debug "^0.7.4"
+    json3 "^3.3.2"
+    uuid "^3.0.1"
 
 "@segment/prevent-default@^1.0.0":
   version "1.0.0"
@@ -2239,15 +2228,6 @@
     "@segment/base64-encode" "^2.0.2"
     has-cors "^1.1.0"
     json3 "^3.3.2"
-    jsonp "^0.2.0"
-
-"@segment/send-json@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@segment/send-json/-/send-json-4.0.2.tgz#69dc4d320be6a6c7c904b44568b33b79ab293620"
-  integrity sha512-HFNr6FB+mvBDC+ZcQCMblOuaLE+b0D7mk5hgkIhcun2+S0AucL0HsD50P6PnncZrinc7AXHIoAcfWLn8FEPtlg==
-  dependencies:
-    "@segment/base64-encode" "^2.0.2"
-    has-cors "^1.1.0"
     jsonp "^0.2.0"
 
 "@segment/spy@^1.0.0":


### PR DESCRIPTION
**What does this PR do?**
This PR reverts back the changes in the https://github.com/segmentio/analytics.js-integrations/pull/553 that touch the Segmentio integration. I didn't revert back the changes to the other destinations as the destination version are pinned in the AJS-Private anyways. 

**Are there breaking changes in this PR?**
No breaking change

**Testing**
- [x] Testing not required because it will be tested in an a.js-private release to stage


**Any background context you want to provide?**


**Is there parity with the server-side/android/iOS integration components (if applicable)?**


**Does this require a new integration setting? If so, please explain how the new setting works**


**Links to helpful docs and other external resources**
