### PR TITLE
[SECOPS-1465] Bump extend 3.0.1 to 3.0.2

### DIFF
--- a/integrations/google-adwords-new/package.json
+++ b/integrations/google-adwords-new/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@ndhoule/each": "^2.0.1",
     "@segment/analytics.js-integration": "^3.2.0",
-    "extend": "^3.0.1",
+    "extend": "^3.0.2",
     "obj-case": "^0.2.0",
     "reject": "0.0.1"
   },

--- a/integrations/google-analytics/package.json
+++ b/integrations/google-analytics/package.json
@@ -27,7 +27,7 @@
     "@ndhoule/defaults": "^2.0.1",
     "@segment/analytics.js-integration": "^3.1.0",
     "component-each": "^0.2.6",
-    "extend": "^3.0.1",
+    "extend": "^3.0.2",
     "global-queue": "^1.0.1",
     "is": "^3.1.0",
     "lodash": "^4.17.4",

--- a/integrations/gtag/package.json
+++ b/integrations/gtag/package.json
@@ -33,7 +33,7 @@
     "@segment/clear-env": "^2.0.0",
     "browserify": "^16.2.3",
     "eslint": "^5.16.0",
-    "extend": "^3.0.1",
+    "extend": "^3.0.2",
     "karma": "^4.1.0",
     "karma-browserify": "^6.0.0",
     "karma-chrome-launcher": "^2.2.0",

--- a/integrations/owneriq/package.json
+++ b/integrations/owneriq/package.json
@@ -27,7 +27,7 @@
     "@ndhoule/defaults": "^2.0.1",
     "@segment/analytics.js-integration": "^3.1.0",
     "component-each": "^0.2.6",
-    "extend": "^3.0.1",
+    "extend": "^3.0.2",
     "global-queue": "^1.0.1",
     "is": "^3.1.0",
     "lodash": "^4.17.4",

--- a/integrations/youbora/package.json
+++ b/integrations/youbora/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@segment/analytics.js-integration": "^3.2.1",
-    "extend": "^3.0.1",
+    "extend": "^3.0.2",
     "reject": "^0.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
**What does this PR do?**

Bumps the extend dependency to patch a prototype pollution vuln. See https://segment.atlassian.net/browse/SECOPS-1465 This is a non-breaking change, and this version is used in core already and among some integrations.

**Are there breaking changes in this PR?**

No

**Testing**

Testing completed successfully via CI