### PR TITLE
Better source maps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,3 +36,9 @@ build-and-upload: build
 build-and-publish: build
 	make publish-assets
 .PHONY: build-and-publish
+
+local-server:
+	yarn build
+	node ./scripts/build-shells.js
+	npx serve
+.PHONY: local-server

--- a/scripts/build-shells.js
+++ b/scripts/build-shells.js
@@ -22,13 +22,14 @@ files.forEach(file => {
   const libraryName = last(libraryPath.split('/')).replace('.js', '');
   const vendorPath = last(vendor[0].split('build'));
 
-  const dynamic = `
-window['${libraryName}Deps'] = ["${vendorPath}"]
+  // We need this to remain a single line in order to not break source maps,
+  // as well as put the bracket at the very end, this is so we don't change the line numbers
+  // for the dynamic file
 
-window['${libraryName}Loader'] = function() {
-  return ${fs.readFileSync(file).toString()}
-}
-`.trim();
+  // prettier-ignore
+  const dynamic = `
+  window['${libraryName}Deps'] = ["${vendorPath}"];window['${libraryName}Loader'] = function() { return ${fs.readFileSync(file).toString()}
+};`.trim();
 
   const filename = file.replace(/\.js$/, '.dynamic.js');
   fs.writeFileSync(filename + '.gz', zlib.gzipSync(dynamic));


### PR DESCRIPTION
**What does this PR do?**
Change the dynamic template scripts so that Source Maps are no longer shifted.
The previous implementation altered the number of lines in the original file, shifting every line by 2~3.
We no longer prepend lines to the file now though, which makes browsers happy again.


**Are there breaking changes in this PR?**
N/A

**Testing**
Testing completed successfully using local via:
- using the new `make local-server` command and loading all destinations into ajs-next
