### PR TITLE
Added statusCode check for NetworkErrors in Segmentio integration

### DIFF
--- a/integrations/segmentio/HISTORY.md
+++ b/integrations/segmentio/HISTORY.md
@@ -1,3 +1,7 @@
+4.4.1 / 2020-03-12
+==================
+  * Retries events that failed to send due to NetworkErrors.
+
 4.4.0 / 2020-02-05
 ==================
 

--- a/integrations/segmentio/lib/index.js
+++ b/integrations/segmentio/lib/index.js
@@ -124,8 +124,9 @@ exports.sendJsonWithTimeout = function(url, obj, headers, timeout, fn) {
 
   function done() {
     if (req.readyState === 4) {
-      // Fail on 429 and 5xx HTTP errors
-      if (req.status === 429 || (req.status >= 500 && req.status < 600)) {
+      // For XHRHttpRequests, a Network error is represented as a status code of 0.
+      // Fail on 0, 429 and 5xx HTTP errors
+      if (req.status === 0 || req.status === 429 || (req.status >= 500 && req.status < 600)) {
         fn(new Error('HTTP Error ' + req.status + ' (' + req.statusText + ')'));
       } else {
         fn(null, req);

--- a/integrations/segmentio/test/index.test.js
+++ b/integrations/segmentio/test/index.test.js
@@ -1593,7 +1593,7 @@ describe('Segment.io', function() {
         xhr.restore();
       });
 
-      [429, 500, 503].forEach(function(code) {
+      [0, 429, 500, 503].forEach(function(code) {
         it('should throw on ' + code + ' HTTP errors', function(done) {
           if (send.type !== 'xhr') return done();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6526,7 +6526,7 @@ extend@3.0.1:
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
   integrity sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=
 
-extend@3.0.2, extend@^3.0.0, extend@^3.0.1, extend@^3.0.2, extend@~3.0.2:
+extend@3.0.2, extend@^3.0.0, extend@^3.0.2, extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==


### PR DESCRIPTION
**What does this PR do?**

Changes Segment.io integration to retry events when there is a NetworkError from the browser.

**Are there breaking changes in this PR?**
 No

**Testing**
<!---

All PRs must follow the process for change control as outlined in:
https://segment.atlassian.net/wiki/spaces/GRC/pages/453935287/Reinforcing+Change+Control

- Testing completed successfully using <how did you test, environment>; or
- Testing not required because <explain why you think testing isn't needed>

--->
Added test case.

**Any background context you want to provide?**

Noticed this the other day when debugging issues in the browser (IE, turning off WiFi, or telling the tab to go into offline mode)

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
I dont believe so

**Does this require a new integration setting? If so, please explain how the new setting works**
No

**Links to helpful docs and other external resources**
https://fetch.spec.whatwg.org/#concept-network-error
Which is referenced from https://xhr.spec.whatwg.org/#response

> A network error is a response whose status is always 0, status message is always the empty byte sequence, header list is always empty, and body is always null. 