### PR TITLE
Next rollout

### DIFF
--- a/scripts/upload-assets.js
+++ b/scripts/upload-assets.js
@@ -40,7 +40,7 @@ async function uploadAssets() {
     .map(i => `id=${i}`)
     .join(',');
 
-  const sha = require('child_process').execSync('git rev-parse HEAD');
+  const sha = require('child_process').execSync('git rev-parse HEAD').toString().trim();
 
   if (bucket === undefined) {
     throw new Error('bucket required');

--- a/scripts/upload-assets.js
+++ b/scripts/upload-assets.js
@@ -40,7 +40,7 @@ async function uploadAssets() {
     .map(i => `id=${i}`)
     .join(',');
 
-  const sha = require('child_process').execSync('git rev-parse HEAD').toString().trim();
+  const sha = require('child_process').execSync('git rev-parse --short HEAD').toString().trim();
 
   if (bucket === undefined) {
     throw new Error('bucket required');

--- a/scripts/upload-assets.js
+++ b/scripts/upload-assets.js
@@ -132,7 +132,7 @@ async function uploadAssets() {
 
   await Promise.all(uploads);
 
-  await s3 // upload manifest file
+  await s3 // upload "latest" manifest file
     .putObject({
       Bucket: bucket,
       Key: key('/manifest-latest.json'),
@@ -144,7 +144,7 @@ async function uploadAssets() {
     })
     .promise();
 
-  await s3 // upload manifest file
+  await s3 // upload hash manifest file
     .putObject({
       Bucket: bucket,
       Key: key(`/manifest-${sha}.json`),


### PR DESCRIPTION
**What does this PR do?**
This PR uploads manifest.json as manifest-{sha}.json for ajs-renderer to consume in order to rollout changes for ajs 2.0. Non ajs 2.0 projectts will read from manifest-latest.json instead

**Are there breaking changes in this PR?**


**Testing**
Testing completed successfully on stage
<!---

All PRs must follow the process for change control as outlined in:
https://segment.atlassian.net/wiki/spaces/GRC/pages/453935287/Reinforcing+Change+Control

- Testing completed successfully using <how did you test, environment>; or
- Testing not required because <explain why you think testing isn't needed>

--->


**Any background context you want to provide?**


**Is there parity with the server-side/android/iOS integration components (if applicable)?**


**Does this require a new integration setting? If so, please explain how the new setting works**


**Links to helpful docs and other external resources**
