### PR TITLE
Fix utm params

### DIFF
--- a/integrations/segmentio/lib/utm.js
+++ b/integrations/segmentio/lib/utm.js
@@ -5,9 +5,12 @@ function utm(query) {
 
   query = query.replace(/\?/g, '&')
 
-  return query.split('&').reduce(function(acc, str) {
-    var k = str.split('=')[0]
-    var v = str.split('=')[1]
+  var split = query.split('&')
+
+  var acc = {}
+  for (var i = 0; i < split.length; i++) {
+    var k = split[i].split('=')[0]
+    var v = split[i].split('=')[1]
 
     if (k.indexOf('utm_') !== -1) {
       var utmParam = k.substr(4)
@@ -16,8 +19,9 @@ function utm(query) {
       }
       acc[utmParam] = v
     }
-    return acc
-  })
+  }
+
+  return acc
 }
 
 module.exports = utm

--- a/integrations/segmentio/package.json
+++ b/integrations/segmentio/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-segmentio",
   "description": "The Segmentio analytics.js integration.",
-  "version": "4.4.3",
+  "version": "4.4.4-beta.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/segmentio/package.json
+++ b/integrations/segmentio/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-segmentio",
   "description": "The Segmentio analytics.js integration.",
-  "version": "4.4.4-beta.0",
+  "version": "4.4.4",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",


### PR DESCRIPTION
**What does this PR do?**
This PR fixes our custom logic of `utm_params`, introduced on version 4.4.2 of `Segment.io`.
The custom logic introduced a bug where parameters were not parsed correctly.

Expected behavior present on `Segment.io` v 4.4.1, is that `utm_` params were parsed as parsed as
```
// query = localhost:3000/?utm_type=classic
context: {
    campaign: {
       type: "classic"
    }
}
```
![](https://paper-attachments.dropbox.com/s_3FC21801CD7A77E2B0F2F99DDB12E8A28D91D5639F5A9D2B8051D25D9EF195BB_1618509365483_image.png)

The custom logic, present on `Segment.io` 4.4.2 and 4.4.3, did not parse `utm_params`, resulting on:
```
context: {
    campaign: "utm_type=classic"
}
```
![](https://paper-attachments.dropbox.com/s_3FC21801CD7A77E2B0F2F99DDB12E8A28D91D5639F5A9D2B8051D25D9EF195BB_1618509552779_image.png)


**Are there breaking changes in this PR?**
No

**Testing**
- Testing completed successfully using a local React App, loading the library built locally.
![image](https://user-images.githubusercontent.com/484013/114945693-a2972300-9dfe-11eb-8a30-a5aff9c4820f.png)


more details here: https://paper.dropbox.com/doc/ajs-4.1.9-segment.io-4.4.2--BI4r4REDg5ueMuotE~TKfchIAg-an6FjL7utxfU3u7znQmij#:uid=892052783410079145578277&h2=Tests: