### PR TITLE
[AJS 2.0] Resolve domify 1.4.1 for every integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,5 +39,7 @@
     "webpack-cli": "^3.3.12",
     "webpack-dev-server": "^3.11.0"
   },
-  "dependencies": {}
+  "dependencies": {
+    "domify": "1.4.1"
+  }
 }

--- a/webpack.config.integrations.js
+++ b/webpack.config.integrations.js
@@ -67,7 +67,10 @@ module.exports = {
     ]
   },
   resolve: {
-    extensions: ['.ts', '.js']
+    extensions: ['.ts', '.js'],
+    alias: {
+      domify: '/node_modules/domify/index.js'
+    }
   },
   devServer: {
     contentBase: path.resolve(__dirname, 'build')

--- a/yarn.lock
+++ b/yarn.lock
@@ -5447,6 +5447,11 @@ domain-browser@~1.1.0:
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.1.7.tgz#867aa4b093faa05f1de08c06f4d7b21fdf8698bc"
   integrity sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw=
 
+domify@1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/domify/-/domify-1.4.1.tgz#2e1e813019646715deeb8d3c5de4d3ef7bddd07e"
+  integrity sha512-x18nuiDHMCZGXr4KJSRMf/TWYtiaRo6RX8KN9fEbW54mvbQ6pieUuerC2ahBg+kEp1wycFj8MPUI0WkIOw5E9w==
+
 domify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/domify/-/domify-1.4.0.tgz#11483617f764f8695975b4bdc79b14f0803b629b"


### PR DESCRIPTION
**What does this PR do?**

This PR fixes a potential XSS vulnerability present in every single destination library *for AJS 2.0 only*.
We do this by telling webpack to always resolve `domify` on version `1.4.1` when building the destination libraries.


**Testing**
- Testing completed successfully by uploading the final bundles to S3 and testing it end to end with analytics 2.0 locally. See the code changes reflected here:
![Screen Shot 2021-04-29 at 12 44 24 PM](https://user-images.githubusercontent.com/484013/116609427-3847ad80-a8e9-11eb-8ce5-b82848995296.png)



**Any background context you want to provide?**
Domify is used by `analytics.js-integration`, the base code for every destination library we have.
Ideally, we should have `analytics.js-integration` updated for every destination, but that would require updating 180+ libraries and running a release train for all of them. In addition, not all libraries use the latest version of `analytics.js-integration`, increasing the amount of changes deployed.

https://github.com/component/domify/pull/48