### PR TITLE
Update Nielsen integration mappings and add new setting to Nielsen DCR

### DIFF
--- a/integrations/nielsen-dcr/lib/index.js
+++ b/integrations/nielsen-dcr/lib/index.js
@@ -22,6 +22,7 @@ var NielsenDCR = (module.exports = integration('Nielsen DCR')
   .option('adAssetIdPropertyName', '')
   .option('subbrandPropertyName', '')
   .option('clientIdPropertyName', '')
+  .option('customSectionProperty', '')
   .option('sendCurrentTimeLivestream', false)
   .option('contentLengthPropertyName', 'total_length')
   .option('optout', false)
@@ -100,10 +101,21 @@ NielsenDCR.prototype.loaded = function() {
 
 NielsenDCR.prototype.page = function(page) {
   var integrationOpts = page.options(this.name);
+  var customSectionName;
+
+  //Allow customer to pick property to source section from otherwise fallback on page name
+  if (this.options.customSectionProperty) {
+    customSectionName = page.proxy(
+      'properties.' + this.options.customSectionProperty
+    );
+  }
+  var defaultSectionName = page.fullName() || page.name() || page.event();
+  var sectionName = customSectionName || defaultSectionName;
+
   var staticMetadata = reject({
     type: 'static',
     assetid: page.url(), // *DYNAMIC METADATA*: unique ID for each article **REQUIRED**
-    section: page.fullName() || page.name() || page.event(), // *DYNAMIC METADATA*: section of site **REQUIRED**
+    section: sectionName, // *DYNAMIC METADATA*: section of site **REQUIRED**
     segA: integrationOpts.segA, // *DYNAMIC METADATA*: custom segment
     segB: integrationOpts.segB, // *DYNAMIC METADATA*: custom segment
     segC: integrationOpts.segC // *DYNAMIC METADATA*: custom segment
@@ -394,11 +406,13 @@ NielsenDCR.prototype.videoAdCompleted = function(track) {
  * Video Playback Paused
  * Video Playback Seek Started
  * Video Playback Buffer Started
+ * Video Playback Interrupted
+ * Video Playback Exited
  *
  * @api public
  */
 
-NielsenDCR.prototype.videoPlaybackPaused = NielsenDCR.prototype.videoPlaybackSeekStarted = NielsenDCR.prototype.videoPlaybackBufferStarted = function(
+NielsenDCR.prototype.videoPlaybackPaused = NielsenDCR.prototype.videoPlaybackSeekStarted = NielsenDCR.prototype.videoPlaybackBufferStarted = NielsenDCR.prototype.videoPlaybackInterrupted = NielsenDCR.prototype.videoPlaybackExited = function(
   track
 ) {
   var self = this;
@@ -460,13 +474,12 @@ NielsenDCR.prototype.videoPlaybackResumed = NielsenDCR.prototype.videoPlaybackSe
 
 /**
  * Video Playback Completed
- * Video Playback Interrupted
  *
  *
  * @api public
  */
 
-NielsenDCR.prototype.videoPlaybackCompleted = NielsenDCR.prototype.videoPlaybackInterrupted = function(
+NielsenDCR.prototype.videoPlaybackCompleted = function(
   track
 ) {
   var self = this;
@@ -481,7 +494,7 @@ NielsenDCR.prototype.videoPlaybackCompleted = NielsenDCR.prototype.videoPlayback
   this._client.ggPM('setPlayheadPosition', position);
   this._client.ggPM('end', position);
 
-  // reset state because "Video Playback Completed/Interrupted" are "non-recoverable events"
+  // reset state because "Video Playback Completed" are "non-recoverable events"
   // e.g. they should always be followed by the start of a new video session with either
   // "Video Content Started" or "Video Ad Started" events
   this.currentPosition = 0;

--- a/integrations/nielsen-dcr/test/index.test.js
+++ b/integrations/nielsen-dcr/test/index.test.js
@@ -41,6 +41,7 @@ describe('NielsenDCR', function() {
         .option('adAssetIdPropertyName', '')
         .option('subbrandPropertyName', '')
         .option('clientIdPropertyName', '')
+        .option('customSectionProperty', '')
         .option('contentLengthPropertyName', 'total_length')
         .option('optout', false)
         .option('sendCurrentTimeLivestream', false)
@@ -92,6 +93,29 @@ describe('NielsenDCR', function() {
           type: 'static',
           assetid: window.location.href,
           section: 'Loaded a Page'
+        };
+        analytics.called(
+          nielsenDCR._client.ggPM,
+          'staticstart',
+          staticMetadata
+        );
+      });
+
+      it('should send static metadata with custom section name', function() {
+        var props;
+        props = {
+          custom_section_name_prop: 'Custom Page Name'
+        }
+
+        nielsenDCR.options.customSectionProperty =
+        'custom_section_name_prop';
+
+        analytics.page('Homepage', props);
+
+        var staticMetadata = {
+          type: 'static',
+          assetid: window.location.href,
+          section: 'Custom Page Name'
         };
         analytics.called(
           nielsenDCR._client.ggPM,
@@ -183,13 +207,19 @@ describe('NielsenDCR', function() {
         it('video playback interrupted during content', function() {
           analytics.track('Video Playback Interrupted', props);
           analytics.called(window.clearInterval);
-          analytics.called(nielsenDCR._client.ggPM, 'end', props.position);
+          analytics.called(nielsenDCR._client.ggPM, 'stop', props.position);
         });
 
         it('video playback interrupted during ad', function() {
           analytics.track('Video Playback Interrupted', props);
           analytics.called(window.clearInterval);
-          analytics.called(nielsenDCR._client.ggPM, 'end', props.position);
+          analytics.called(nielsenDCR._client.ggPM, 'stop', props.position);
+        });
+
+        it('video playback exited', function() {
+          analytics.track('Video Playback Exited', props);
+          analytics.called(window.clearInterval);
+          analytics.called(nielsenDCR._client.ggPM, 'stop', props.position);
         });
 
         it('video playback completed', function() {


### PR DESCRIPTION
**What does this PR do?**
This PR updates our Nielsen DCR and Nielsen DTVR (to be added) integrations to meet Nielsen requirements. Changes requested by Nielsen are outlined in [this spreadsheet](https://docs.google.com/spreadsheets/d/192EYcjqiPBdTEKDCKQ0iJB6gjJH3CDQDeyenYmuAe-k/edit#gid=0).

- [JIRA](https://segment.atlassian.net/browse/LIBMOBILE-369)

**Are there breaking changes in this PR?**
No.

**Testing**
Testing in progress

<!---
All PRs must follow the process for change control as outlined in:
https://segment.atlassian.net/wiki/spaces/GRC/pages/453935287/Reinforcing+Change+Control

- Testing completed successfully using <how did you test, environment>; or
- Testing not required because <explain why you think testing isn't needed>
--->

**Any background context you want to provide?**
Fox has been trying to get certified by Nielsen for a year+ now. In order to get certified using the Segment-Nielsen integrations, our integrations to meet Nielsen's requirements. This should be the last set of changes blocking certification.

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
Yes. The same changes have already been made to iOS (published new versions) and Android (being tested by customer before publishing new versions):
- iOS DCR: https://github.com/segment-integrations/analytics-ios-integration-nielsen-dcr/commit/010dc9779bbcbfdb6199e93f3fd1fff0321d9b91
- iOS DTVR: https://github.com/segment-integrations/analytics-ios-integration-nielsen-dtvr/commit/06eb3a23d2c781d8eeb311d3e220bcefc7c1270a
- Android DCR: https://github.com/segment-integrations/analytics-android-integration-nielsen-dcr/commit/f059bfb5259b7acaa2df3b1a98927a3fb86d7ff5
- Android DTVR: https://github.com/segment-integrations/analytics-ios-integration-nielsen-dtvr/commit/06eb3a23d2c781d8eeb311d3e220bcefc7c1270a

**Does this require a new integration setting? If so, please explain how the new setting works**
Yes. The Nielsen DCR integration requires a new setting for `customSectionProperty`. This setting is already live in prod (Partner Portal) as it is used in iOS and Android too. The setting allows a customer to choose which property on their page calls maps to the Nielsen `section` field. If nothing is set, we will fallback on the page name which is the existing behavior.

**Links to helpful docs and other external resources**
See spreadsheet linked above.