### PR TITLE
[segmentio] Drop event on message size limit exceeded

### DIFF
--- a/integrations/segmentio/lib/index.js
+++ b/integrations/segmentio/lib/index.js
@@ -316,26 +316,25 @@ Segment.prototype.normalize = function(message) {
   }
   if (this.options.addBundledMetadata) {
     var bundled = keys(this.analytics.Integrations);
-    var maybeBundledConfigIds = this.options.maybeBundledConfigIds
+    var maybeBundledConfigIds = this.options.maybeBundledConfigIds;
 
     // Generate a list of bundled config IDs using the intersection of
     // bundled destination names and maybe bundled config IDs.
-    var bundledConfigIds = []
+    var bundledConfigIds = [];
     for (var i = 0; i < bundled.length; i++) {
-      var name = bundled[i]
+      var name = bundled[i];
       if (!maybeBundledConfigIds) {
-        break
+        break;
       }
       if (!maybeBundledConfigIds[name]) {
-        continue
+        continue;
       }
 
       for (var j = 0; j < maybeBundledConfigIds[name].length; j++) {
-        var id = maybeBundledConfigIds[name][j]
-        bundledConfigIds.push(id)
+        var id = maybeBundledConfigIds[name][j];
+        bundledConfigIds.push(id);
       }
     }
-
 
     msg._metadata = msg._metadata || {};
     msg._metadata.bundled = bundled;
@@ -374,10 +373,10 @@ Segment.prototype.enqueue = function(path, message, fn) {
   var headers = { 'Content-Type': 'text/plain' };
   var msg = this.normalize(message);
 
-  // Print a log statement when messages exceed the maximum size. In the future,
-  // we may consider dropping this event on the client entirely.
+  // Drop the event when message exceeds the maximum size
   if (json.stringify(msg).length > MAX_SIZE) {
     this.debug('message must be less than 32kb %O', msg);
+    return;
   }
 
   this.debug('enqueueing %O', msg);

--- a/integrations/segmentio/test/index.test.js
+++ b/integrations/segmentio/test/index.test.js
@@ -243,8 +243,7 @@ describe('Segment.io', function() {
 
       it('should decode .campaign', function() {
         Segment.global = { navigator: {}, location: {} };
-        Segment.global.location.search =
-          '?utm_source=%5BFoo%5D';
+        Segment.global.location.search = '?utm_source=%5BFoo%5D';
         segment.normalize(object);
         analytics.assert(object);
         analytics.assert(object.context);
@@ -473,7 +472,11 @@ describe('Segment.io', function() {
 
           assert(object);
           assert(object._metadata);
-          assert.deepEqual(object._metadata.bundled, ['Segment.io', 'other', 'another']);
+          assert.deepEqual(object._metadata.bundled, [
+            'Segment.io',
+            'other',
+            'another'
+          ]);
         });
 
         it('should add a list of unbundled integrations when `addBundledMetadata` and `unbundledIntegrations` are set', function() {
@@ -496,8 +499,8 @@ describe('Segment.io', function() {
         it('should generate and add a list of bundled destination config ids when `addBundledMetadata` is set', function() {
           segment.options.addBundledMetadata = true;
           segment.options.maybeBundledConfigIds = {
-            'other': ['config21'],
-            'slack': ['slack99'] // should be ignored
+            other: ['config21'],
+            slack: ['slack99'] // should be ignored
           };
           segment.normalize(object);
 
@@ -509,15 +512,18 @@ describe('Segment.io', function() {
         it('should generate a list of multiple bundled destination config ids when `addBundledMetadata` is set', function() {
           segment.options.addBundledMetadata = true;
           segment.options.maybeBundledConfigIds = {
-            'other': ['config21'],
-            'another': ['anotherConfig99'],
-            'slack': ['slack99'] // should be ignored
+            other: ['config21'],
+            another: ['anotherConfig99'],
+            slack: ['slack99'] // should be ignored
           };
           segment.normalize(object);
 
           assert(object);
           assert(object._metadata);
-          assert.deepEqual(object._metadata.bundledIds, ['config21', 'anotherConfig99']);
+          assert.deepEqual(object._metadata.bundledIds, [
+            'config21',
+            'anotherConfig99'
+          ]);
         });
       });
 
@@ -845,7 +851,7 @@ describe('Segment.io', function() {
           );
 
           it(
-            'should enqueue an oversized payload',
+            'should not enqueue an oversized payload',
             sinon.test(function() {
               var spy = sinon.spy();
               xhr.onCreate = spy;
@@ -867,12 +873,7 @@ describe('Segment.io', function() {
                 payload
               );
 
-              assert(spy.calledOnce);
-              var req = spy.getCall(0).args[0];
-              assert.strictEqual(
-                JSON.parse(req.requestBody).key1749,
-                'value1749'
-              );
+              assert(spy.notCalled);
             })
           );
         });


### PR DESCRIPTION
**What does this PR do?**
Drops the event when the message exceeds the maximum size of `32KB`

**Are there breaking changes in this PR?**
No

**Testing**
Testing completed successfully using the [a.js compiler](https://github.com/segmentio/analytics.js-integrations/tree/master/compiler)

**Any background context you want to provide?**
Issue from https://github.com/segmentio/analytics.js-integrations/issues/598

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
Yes

**Links to helpful docs and other external resources**
https://segment.com/docs/connections/sources/catalog/libraries/server/http-api/#max-request-size
