### PR TITLE
Fix undefined utm_ params

### DIFF
--- a/integrations/segmentio/lib/utm.js
+++ b/integrations/segmentio/lib/utm.js
@@ -10,9 +10,9 @@ function utm(query) {
   var acc = {}
   for (var i = 0; i < split.length; i++) {
     var k = split[i].split('=')[0]
-    var v = split[i].split('=')[1]
+    var v = split[i].split('=')[1] || ''
 
-    if (k.indexOf('utm_') !== -1) {
+    if (k.indexOf('utm_') !== -1 && k.length > 4) {
       var utmParam = k.substr(4)
       if (utmParam === 'campaign') {
         utmParam = 'name'

--- a/integrations/segmentio/package.json
+++ b/integrations/segmentio/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-segmentio",
   "description": "The Segmentio analytics.js integration.",
-  "version": "4.4.5",
+  "version": "4.4.6",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/segmentio/test/utm.test.js
+++ b/integrations/segmentio/test/utm.test.js
@@ -1,0 +1,60 @@
+var assert = require('proclaim');
+var utm = require('../lib/utm')
+
+describe('utm', function() {
+  it('parses utm params', function() {
+    var url = 'https://localhost:3000/?utm_foo=bar'
+    var utmParams = utm(url)
+
+    assert.deepEqual(utmParams, { foo: 'bar' })
+  })
+
+  it('parses multiple utm params', function() {
+    var url = 'https://localhost:3000/?utm_foo=bar&utm_baz=bang'
+    var utmParams = utm(url)
+
+    assert.deepEqual(utmParams, { foo: 'bar', baz: 'bang' })
+  })
+
+  it('renames campaign param', function() {
+    var url = 'https://localhost:3000/?utm_campaign=bar'
+    var utmParams = utm(url)
+
+    assert.deepEqual(utmParams, { name: 'bar' })
+  })
+
+  it('only parses utm params', function() {
+    var url = 'https://localhost:3000/?utm_foo=bar&baz=bang'
+    var utmParams = utm(url)
+
+    assert.deepEqual(utmParams, { foo: 'bar' })
+  })
+
+  it('only parses params prefixed with utm_', function() {
+    var url = 'https://localhost:3000/?utm=bang'
+    var utmParams = utm(url)
+
+    assert.deepEqual(utmParams, {})
+  })
+
+  it('guards against undefined values', function() {
+    var url = 'https://localhost:3000/?utm_foo'
+    var utmParams = utm(url)
+
+    assert.deepEqual(utmParams, { foo: '' })
+  })
+
+  it('guards against empty values', function() {
+    var url = 'https://localhost:3000/?utm_foo='
+    var utmParams = utm(url)
+
+    assert.deepEqual(utmParams, { foo: '' })
+  })
+
+  it('guards against missing keys', function() {
+    var url = 'https://localhost:3000/?utm_'
+    var utmParams = utm(url)
+
+    assert.deepEqual(utmParams, {})
+  })
+})


### PR DESCRIPTION
**What does this PR do?**

This PR changes the `utm` params parsing to guard against undefined values and empty keys, preventing cases like
```
- https:/localhost:3000/?utm_
- https://niallzato.github.io/?utm_foo=
```
from messing with tracking.

https://segment.atlassian.net/browse/LIBWEB-667


**Testing**
- Testing completed successfully with unit tests and by changing the compiled code directly into the customer's website:
![image](https://user-images.githubusercontent.com/484013/118029557-21f21680-b319-11eb-9bb0-f2c03bed08ed.png)
![image](https://user-images.githubusercontent.com/484013/118029600-2c141500-b319-11eb-973e-3ed584ad9797.png)
