### PR TITLE
Set max age for latest manifest

### DIFF
--- a/scripts/upload-assets.js
+++ b/scripts/upload-assets.js
@@ -138,6 +138,7 @@ async function uploadAssets() {
       Key: key('/manifest-latest.json'),
       Body: zlib.gzipSync(JSON.stringify(manifest)),
       ContentEncoding: process.env.CONTENT_ENCODING,
+      CacheControl: 'public, max-age=120',
       GrantRead: cfCanonicalUserIdsParsed,
       GrantFullControl: `id=${platformCanonicalUserId}`,
       ContentType: 'application/json'


### PR DESCRIPTION
**What does this PR do?**
This PR updates the caching settings of the manifest-latest file for destinations.

**Are there breaking changes in this PR?**
N/A

**Testing**
Testing completed successfully on stage:
Updated a version in the manifest and made sure the change was showing on the cdn in <2 minutes:
![image](https://user-images.githubusercontent.com/2866515/118539335-2a28c800-b704-11eb-8555-4fa09ea7fa90.png)


**Any background context you want to provide?**


**Is there parity with the server-side/android/iOS integration components (if applicable)?**


**Does this require a new integration setting? If so, please explain how the new setting works**


**Links to helpful docs and other external resources**
