### PR TITLE
Braze - upgrade to v3.3

### DIFF
--- a/integrations/appboy/HISTORY.md
+++ b/integrations/appboy/HISTORY.md
@@ -1,3 +1,9 @@
+1.17.0 / 2021-05-25
+===================
+
+* Adds support for SDK Authentication feature
+* Upgrades from v3.1 to v3.3
+
 1.16.0 / 2020-12-16
 ===================
 

--- a/integrations/appboy/lib/appboyUtil.js
+++ b/integrations/appboy/lib/appboyUtil.js
@@ -52,7 +52,8 @@ var appboyUtil = {
         requireExplicitInAppMessageDismissal:
           options.requireExplicitInAppMessageDismissal,
         serviceWorkerLocation: options.serviceWorkerLocation,
-        sessionTimeoutInSeconds: Number(options.sessionTimeoutInSeconds) || 30
+        sessionTimeoutInSeconds: Number(options.sessionTimeoutInSeconds) || 30,
+        enableSdkAuthentication: options.enableSdkAuthentication || false,
       };
     } else {
       var datacenterMappings = {

--- a/integrations/appboy/lib/index.js
+++ b/integrations/appboy/lib/index.js
@@ -36,6 +36,7 @@ var Appboy = (module.exports = integration('Appboy')
   .option('version', 1)
   .option('logPurchaseWhenRevenuePresent', false)
   .option('onlyTrackKnownUsersOnWeb', false)
+  .option('enableSdkAuthentication', false)
   .tag(
     'v1',
     '<script src="https://js.appboycdn.com/web-sdk/1.6/appboy.min.js">'
@@ -51,6 +52,10 @@ var Appboy = (module.exports = integration('Appboy')
   .tag(
     'v3.1',
     '<script src="https://js.appboycdn.com/web-sdk/3.1/appboy.min.js">'
+  )
+  .tag(
+    'v3.3',
+    '<script src="https://js.appboycdn.com/web-sdk/3.3/appboy.min.js">'
   ));
 
 Appboy.prototype.appboyInitialize = function(userId, options, config) {
@@ -182,7 +187,7 @@ Appboy.prototype.initializeV3 = function() {
   +function(a,p,P,b,y){
     a.appboy={};
     a.appboyQueue=[];
-    for(var s="DeviceProperties Card Card.prototype.dismissCard Card.prototype.removeAllSubscriptions Card.prototype.removeSubscription Card.prototype.subscribeToClickedEvent Card.prototype.subscribeToDismissedEvent Banner CaptionedImage ClassicCard ControlCard ContentCards ContentCards.prototype.getUnviewedCardCount Feed Feed.prototype.getUnreadCardCount ControlMessage InAppMessage InAppMessage.SlideFrom InAppMessage.ClickAction InAppMessage.DismissType InAppMessage.OpenTarget InAppMessage.ImageStyle InAppMessage.Orientation InAppMessage.TextAlignment InAppMessage.CropType InAppMessage.prototype.closeMessage InAppMessage.prototype.removeAllSubscriptions InAppMessage.prototype.removeSubscription InAppMessage.prototype.subscribeToClickedEvent InAppMessage.prototype.subscribeToDismissedEvent FullScreenMessage ModalMessage HtmlMessage SlideUpMessage User User.Genders User.NotificationSubscriptionTypes User.prototype.addAlias User.prototype.addToCustomAttributeArray User.prototype.getUserId User.prototype.incrementCustomUserAttribute User.prototype.removeFromCustomAttributeArray User.prototype.setAvatarImageUrl User.prototype.setCountry User.prototype.setCustomLocationAttribute User.prototype.setCustomUserAttribute User.prototype.setDateOfBirth User.prototype.setEmail User.prototype.setEmailNotificationSubscriptionType User.prototype.setFirstName User.prototype.setGender User.prototype.setHomeCity User.prototype.setLanguage User.prototype.setLastKnownLocation User.prototype.setLastName User.prototype.setPhoneNumber User.prototype.setPushNotificationSubscriptionType InAppMessageButton InAppMessageButton.prototype.removeAllSubscriptions InAppMessageButton.prototype.removeSubscription InAppMessageButton.prototype.subscribeToClickedEvent display display.automaticallyShowNewInAppMessages display.destroyFeed display.hideContentCards display.showContentCards display.showFeed display.showInAppMessage display.toggleContentCards display.toggleFeed changeUser destroy getDeviceId initialize isPushBlocked isPushGranted isPushPermissionGranted isPushSupported logCardClick logCardDismissal logCardImpressions logContentCardsDisplayed logCustomEvent logFeedDisplayed logInAppMessageButtonClick logInAppMessageClick logInAppMessageHtmlClick logInAppMessageImpression logPurchase openSession registerAppboyPushMessages removeAllSubscriptions removeSubscription requestContentCardsRefresh requestFeedRefresh requestImmediateDataFlush resumeWebTracking setLogger stopWebTracking subscribeToContentCardsUpdates subscribeToFeedUpdates subscribeToInAppMessage subscribeToNewInAppMessages toggleAppboyLogging trackLocation unregisterAppboyPushMessages wipeData".split(" "),i=0;i<s.length;i++){for(var m=s[i],k=a.appboy,l=m.split("."),j=0;j<l.length-1;j++)k=k[l[j]];k[l[j]]=(new Function("return function "+m.replace(/\./g,"_")+"(){window.appboyQueue.push(arguments); return true}"))()}
+    for(var s="DeviceProperties Card Card.prototype.dismissCard Card.prototype.removeAllSubscriptions Card.prototype.removeSubscription Card.prototype.subscribeToClickedEvent Card.prototype.subscribeToDismissedEvent Banner CaptionedImage ClassicCard ControlCard ContentCards ContentCards.prototype.getUnviewedCardCount Feed Feed.prototype.getUnreadCardCount ControlMessage InAppMessage InAppMessage.SlideFrom InAppMessage.ClickAction InAppMessage.DismissType InAppMessage.OpenTarget InAppMessage.ImageStyle InAppMessage.Orientation InAppMessage.TextAlignment InAppMessage.CropType InAppMessage.prototype.closeMessage InAppMessage.prototype.removeAllSubscriptions InAppMessage.prototype.removeSubscription InAppMessage.prototype.subscribeToClickedEvent InAppMessage.prototype.subscribeToDismissedEvent FullScreenMessage ModalMessage HtmlMessage SlideUpMessage User User.Genders User.NotificationSubscriptionTypes User.prototype.addAlias User.prototype.addToCustomAttributeArray User.prototype.getUserId User.prototype.incrementCustomUserAttribute User.prototype.removeFromCustomAttributeArray User.prototype.setAvatarImageUrl User.prototype.setCountry User.prototype.setCustomLocationAttribute User.prototype.setCustomUserAttribute User.prototype.setDateOfBirth User.prototype.setEmail User.prototype.setEmailNotificationSubscriptionType User.prototype.setFirstName User.prototype.setGender User.prototype.setHomeCity User.prototype.setLanguage User.prototype.setLastKnownLocation User.prototype.setLastName User.prototype.setPhoneNumber User.prototype.setPushNotificationSubscriptionType InAppMessageButton InAppMessageButton.prototype.removeAllSubscriptions InAppMessageButton.prototype.removeSubscription InAppMessageButton.prototype.subscribeToClickedEvent display display.automaticallyShowNewInAppMessages display.destroyFeed display.hideContentCards display.showContentCards display.showFeed display.showInAppMessage display.toggleContentCards display.toggleFeed changeUser destroy getDeviceId initialize isPushBlocked isPushGranted isPushPermissionGranted isPushSupported logCardClick logCardDismissal logCardImpressions logContentCardsDisplayed logCustomEvent logFeedDisplayed logInAppMessageButtonClick logInAppMessageClick logInAppMessageHtmlClick logInAppMessageImpression logPurchase openSession registerAppboyPushMessages removeAllSubscriptions removeSubscription requestContentCardsRefresh requestFeedRefresh requestImmediateDataFlush resumeWebTracking setLogger setSdkAuthenticationSignature stopWebTracking subscribeToContentCardsUpdates subscribeToFeedUpdates subscribeToInAppMessage subscribeToNewInAppMessages subscribeToSdkAuthenticationFailures toggleAppboyLogging trackLocation unregisterAppboyPushMessages wipeData".split(" "),i=0;i<s.length;i++){for(var m=s[i],k=a.appboy,l=m.split("."),j=0;j<l.length-1;j++)k=k[l[j]];k[l[j]]=(new Function("return function "+m.replace(/\./g,"_")+"(){window.appboyQueue.push(arguments); return true}"))()}
     window.appboy.getCachedContentCards=function(){return new window.appboy.ContentCards};
     window.appboy.getCachedFeed=function(){return new window.appboy.Feed};
     window.appboy.getUser=function(){return new window.appboy.User};
@@ -196,7 +201,7 @@ Appboy.prototype.initializeV3 = function() {
     this.appboyInitialize(userId, options, config);
   }
 
-  this.load('v3.1', this.ready);
+  this.load('v3.3', this.ready);
 };
 
 /**

--- a/integrations/appboy/lib/index.js
+++ b/integrations/appboy/lib/index.js
@@ -201,7 +201,8 @@ Appboy.prototype.initializeV3 = function() {
     this.appboyInitialize(userId, options, config);
   }
 
-  this.load('v3.3', this.ready);
+  var versionTag = Number(options.version) === 3.1 ? 'v3.1' : 'v3.3';
+  this.load(versionTag, this.ready);
 };
 
 /**

--- a/integrations/appboy/test/onlyTrackKnownUsersOnWeb.test.js
+++ b/integrations/appboy/test/onlyTrackKnownUsersOnWeb.test.js
@@ -175,7 +175,8 @@ describe('Appboy with onlyTrackKnownUsersOnWeb enabled', function() {
           sessionTimeoutInSeconds: 30,
           serviceWorkerLocation: undefined,
           requireExplicitInAppMessageDismissal: false,
-          enableHtmlInAppMessages: false
+          enableHtmlInAppMessages: false,
+          enableSdkAuthentication: false,
         };
         analytics.once('ready', function() {
           try {


### PR DESCRIPTION
**What does this PR do?**

* Adds support for Braze SDK v3.3
* Adds support for SDK Authentication feature

**Are there breaking changes in this PR?**

No

**Testing**
<!---

All PRs must follow the process for change control as outlined in:
https://segment.atlassian.net/wiki/spaces/GRC/pages/453935287/Reinforcing+Change+Control



--->

- Testing completed successfully using `yarn test`

```
   appboyUtil
    shouldOpenSession
      ✓ should open if option is disabled regardless of userId
      ✓ should conditionally open if option is enabled and userId is valid

  Appboy
    ✓ should have the right settings
    before loading
      #initialize
        ✓ should call #load
    loading
      ✓ should load
      ✓ should set the sdk endpoint to the correct datacenter
      ✓ should use initializeV1 if version is set to 1
      ✓ should use initializeV2 if version is set to 2
      ✓ should use initializeV3 if version is set to 3.1
      ✓ should use initializeV3 if version is set to 3.3
      ✓ should set the sdk endpoint to a custom URI if one is provided
      ✓ should prefix the customEndpoint with https:// if it was not by the user
      ✓ should send Safari Website Push ID if provided in the settings
      ✓ should set `enableSdkAuthentication` provided in the settings and use the updated integration snippet
      initializeV1
        ✓ should call changeUser if userID is present
      initializeV2
        ✓ should call changeUser if userID is present
        ✓ should initialize the appboy sdk with default options if none are provided
    after loading
      #identify
        ✓ should call each Appboy method for standard traits
        ✓ should set gender to male when passed male gender
        ✓ should set gender to other when passed other gender
        ✓ should handle custom traits of valid types and exclude nested objects
        ✓ should handle custom traits of valid types and including date object
        ✓ should not let you set reserved keys as custom attributes
      #group
        ✓ should send group calls with group ID as a custom field
      #track
        ✓ should send an event
        ✓ should send all properties
        ✓ should send all properties including date object
        ✓ should call logPurchase if revenue propery is present in a Completed Order event
        ✓ should call logPurchase for each product in a Completed Order event
        ✓ should not fail if currency, quantity, and purchaseProperties are undefined
      #page
        ✓ should send a page view if trackAllPages is enabled
        ✓ should send a page view if trackNamedPages is enabled
        ✓ should not send a page view if trackAllPages and trackNamedPages are disabled
        ✓ should not send a page view if trackNamedPages is enabled and name is null
        ✓ should send all properties

  Appboy with onlyTrackKnownUsersOnWeb enabled
    before loading
      #initialize
        ✓ should call #load
    loading
      ✓ should load
      ✓ should use initializeV1 if version is set to 1
      ✓ should use initializeV2 if version is set to 2
      ✓ should use initializeV2 if version is set to 2.7
      initializeV1
        ✓ should call changeUser if userID is present
      initializeV2
        ✓ should call changeUser if userID is present
        ✓ should not initialize appboy sdk as user is not initialized
        ✓ should not initialize appboy sdk even if anonymous user is set
        ✓ should initialize appboy sdk if user is identified with defaults
    after loading
      #identify
        ✓ should call each Appboy method for standard traits
      #group
        ✓ should send group calls with group ID as a custom field after initialized
      #track
        ✓ should send an event once initialized
      #page
        ✓ should send event once initialized

HeadlessChrome 90.0.4430 (Mac OS X 10.15.5): Executed 49 of 49 SUCCESS (0.57 secs / 0.255 secs)
TOTAL: 49 SUCCESS
```

**Any background context you want to provide?**

n/a

**Is there parity with the server-side/android/iOS integration components (if applicable)?**

n/a

**Does this require a new integration setting? If so, please explain how the new setting works**

Yes - we need to replace the `3.1` setting with `3.3`

**Links to helpful docs and other external resources**