### PR TITLE
[Customer.io] Allow for a separate script to be loaded for EU

### DIFF
--- a/integrations/customerio/lib/index.js
+++ b/integrations/customerio/lib/index.js
@@ -17,7 +17,13 @@ var MAX_YEAR_SUPPORTED_AS_UNIX = 1970;
 var Customerio = (module.exports = integration('Customer.io')
   .global('_cio')
   .option('siteId', '')
+  .option('datacenter', '')
   .tag(
+    'eu-tag',
+    '<script id="cio-tracker" src="https://assets.customer.io/assets/track-eu.js" data-site-id="{{ siteId }}">'
+  )
+  .tag(
+    'global-tag',
     '<script id="cio-tracker" src="https://assets.customer.io/assets/track.js" data-site-id="{{ siteId }}">'
   ));
 
@@ -34,7 +40,12 @@ Customerio.prototype.initialize = function() {
   /* eslint-disable */
   (function(){var a,b,c; a = function(f){return function(){window._cio.push([f].concat(Array.prototype.slice.call(arguments,0))); }; }; b = ['identify', 'track']; for (c = 0; c < b.length; c++) {window._cio[b[c]] = a(b[c]); } })();
   /* eslint-enable */
-  this.load(this.ready);
+
+  if (this.options.datacenter === 'eu' && this.templates['eu-tag']) {
+    this.load('eu-tag', this.ready)
+  } else {
+    this.load('global-tag', this.ready);
+  }
 };
 
 /**

--- a/integrations/customerio/package.json
+++ b/integrations/customerio/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-customerio",
   "description": "The Customerio analytics.js integration.",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/customerio/test/index.test.js
+++ b/integrations/customerio/test/index.test.js
@@ -10,7 +10,8 @@ describe('Customer.io', function() {
   var analytics;
   var customerIO;
   var options = {
-    siteId: '1e5932b3d9de5078ccf9'
+    siteId: '1e5932b3d9de5078ccf9',
+    datacenter: 'eu'
   };
 
   beforeEach(function() {
@@ -35,11 +36,22 @@ describe('Customer.io', function() {
         .global('_cio')
         .option('siteId', '')
     );
+
+    analytics.assert(customerIO.templates['eu-tag'])
+    analytics.assert(customerIO.templates['global-tag'])
+    analytics.assert.equal(customerIO.options.datacenter, 'eu')
   });
 
   describe('before loading', function() {
     beforeEach(function() {
       analytics.stub(customerIO, 'load');
+    });
+
+    afterEach(function() {
+      analytics.restore();
+      analytics.reset();
+      customerIO.reset();
+      sandbox();
     });
 
     describe('#initialize', function() {
@@ -53,6 +65,47 @@ describe('Customer.io', function() {
         analytics.initialize();
         analytics.called(customerIO.load);
       });
+
+      it('initializes with global tag', function() {
+        var customerIO;
+        var options = {
+          siteId: '1e5932b3d9de5078ccf9',
+        };
+
+        analytics = new Analytics();
+        customerIO = new CustomerIO(options);
+        analytics.use(CustomerIO);
+        analytics.use(tester);
+        analytics.add(customerIO);
+
+        analytics.assert.equal(customerIO.options.datacenter, '')
+
+        analytics.stub(customerIO, 'load');
+
+        analytics.initialize();
+        analytics.called(customerIO.load, 'global-tag');
+      })
+
+      it('initializes with eu tag', function() {
+        var customerIO;
+        var options = {
+          siteId: '1e5932b3d9de5078ccf9',
+          datacenter: 'eu'
+        };
+
+        analytics = new Analytics();
+        customerIO = new CustomerIO(options);
+        analytics.use(CustomerIO);
+        analytics.use(tester);
+        analytics.add(customerIO);
+
+        analytics.assert.equal(customerIO.options.datacenter, 'eu')
+
+        analytics.stub(customerIO, 'load');
+
+        analytics.initialize();
+        analytics.called(customerIO.load, 'eu-tag');
+      })
     });
   });
 


### PR DESCRIPTION
**What does this PR do?**
This PR adds the ability to choose between the global or EU datacenters for Customer.io.
Segment's app's UI will be updated to reflect such option once this PR lands - the option has been implemented on the backend, but it's invisible given it doesn't work on the library side yet.

**Testing**
- Testing completed successfully using Analytics 2.0 locally and a bundled version of Customer.io, uploaded to stage's CDN
![image](https://user-images.githubusercontent.com/484013/120256413-e6c17400-c242-11eb-9c5e-fe4745b883b6.png)