### PR TITLE
[Criteo] Upgrade `is-email` to version 1.0.1 to fix a potential ReDoS vuln

### DIFF
--- a/integrations/criteo/package.json
+++ b/integrations/criteo/package.json
@@ -29,7 +29,7 @@
     "@ndhoule/values": "^2.0.1",
     "@segment/analytics.js-integration": "^3.2.0",
     "is": "^3.2.1",
-    "is-email": "^1.0.0",
+    "is-email": "^1.0.1",
     "md5": "^2.2.1",
     "obj-case": "^0.2.0",
     "use-https": "^0.1.1"

--- a/integrations/criteo/package.json
+++ b/integrations/criteo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-criteo",
   "description": "The Criteo analytics.js integration.",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8336,10 +8336,10 @@ is-email@0.1.0:
   resolved "https://registry.yarnpkg.com/is-email/-/is-email-0.1.0.tgz#e7eb1aefe8d4a3183980a7172b851272ebd04a95"
   integrity sha1-5+sa7+jUoxg5gKcXK4UScuvQSpU=
 
-is-email@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-email/-/is-email-1.0.0.tgz#6e02d4145dd6246fa05eea16bfe0b2b843ac2802"
-  integrity sha1-bgLUFF3WJG+gXuoWv+CyuEOsKAI=
+is-email@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-email/-/is-email-1.0.1.tgz#6f98c0ab6a0e3936dc4da7f2ab334f7faebbaa56"
+  integrity sha512-/+OIyLQ3Vg37svRz0sbw2UIxC0jdVKnIlBJ2BMzDf/xi4wThTel1plETP/+KSyarKgxluljIzJCYjzuvSnANfA==
 
 is-es2016-keyword@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
**What does this PR do?**
This PR upgrades `is-email` to version 1.0.1 that includes a fix for a potential ReDoS vulnerability.

**Testing**
- Testing completed successfully using Analytics 2.0 and a built version of Criteo uploaded to stage.
Criteo checks if `userId` is not a valid e-mail (as it doesn't want emails to be set to user id):
![image](https://user-images.githubusercontent.com/484013/120399304-9274cd80-c2f0-11eb-9362-0966b096c2e7.png)
