### PR TITLE
Pin analytics.js-integration for Analytics 2.0 integrations

### DIFF
--- a/integrations/adlearn-open-platform/package.json
+++ b/integrations/adlearn-open-platform/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-adlearn-open-platform",
   "description": "The Adlearn Open Platform analytics.js integration.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/adobe-analytics/package.json
+++ b/integrations/adobe-analytics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-adobe-analytics",
   "description": "The Adobe Analytics analytics.js integration.",
-  "version": "1.16.3",
+  "version": "1.16.4",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/adobe-target/package.json
+++ b/integrations/adobe-target/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-adobe-target",
   "description": "The Adobe Target analytics.js integration.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/adometry/package.json
+++ b/integrations/adometry/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-adometry",
   "description": "The Adometry analytics.js integration.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/adroll/package.json
+++ b/integrations/adroll/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-adroll",
   "description": "The Adroll analytics.js integration.",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/adwords/package.json
+++ b/integrations/adwords/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-adwords",
   "description": "The Adwords analytics.js integration.",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/alexa/package.json
+++ b/integrations/alexa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-alexa",
   "description": "The Alexa analytics.js integration.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/ambassador/package.json
+++ b/integrations/ambassador/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-ambassador",
   "description": "The Ambassador analytics.js integration.",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/amplitude/package.json
+++ b/integrations/amplitude/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-amplitude",
   "description": "The Amplitude analytics.js integration.",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/appboy/package.json
+++ b/integrations/appboy/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-appboy",
   "description": "The Appboy analytics.js integration.",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/appcues/package.json
+++ b/integrations/appcues/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-appcues",
   "description": "The Appcues analytics.js integration.",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/appnexus/package.json
+++ b/integrations/appnexus/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-appnexus",
   "description": "The Appnexus analytics.js integration.",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/aptrinsic/package.json
+++ b/integrations/aptrinsic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-aptrinsic",
   "description": "The Aptrinsic analytics.js integration.",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/asayer/package.json
+++ b/integrations/asayer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@asayerio/analytics.js-integration-asayer",
   "description": "The Asayer analytics.js integration.",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/atatus/package.json
+++ b/integrations/atatus/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-atatus",
   "description": "The Atatus analytics.js integration.",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/auryc/package.json
+++ b/integrations/auryc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auryc/analytics.js-integration-auryc",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "",
   "main": "lib/index.js",
   "scripts": {
@@ -20,11 +20,11 @@
   "author": "auryc(npm@auryc.com)",
   "license": "MIT",
   "dependencies": {
-    "@segment/analytics.js-integration": "^2.1.0",
-    "is": "^3.1.0",
     "@ndhoule/extend": "^2.0.0",
     "@segment/analytics.js-core": "^3.0.0",
-    "@segment/to-iso-string": "^1.0.1"
+    "@segment/analytics.js-integration": "^2.1.0",
+    "@segment/to-iso-string": "^1.0.1",
+    "is": "^3.1.0"
   },
   "devDependencies": {
     "@segment/analytics.js-integration-tester": "^3.1.0",

--- a/integrations/autosend/package.json
+++ b/integrations/autosend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-autosend",
   "description": "The Autosend analytics.js integration.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/awesm/package.json
+++ b/integrations/awesm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-awesm",
   "description": "The Awesm analytics.js integration.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/bing-ads/package.json
+++ b/integrations/bing-ads/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-bing-ads",
   "description": "The Bing Ads analytics.js integration.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/blueshift/package.json
+++ b/integrations/blueshift/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-blueshift",
   "description": "The Blueshift analytics.js integration.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/boomtrain/package.json
+++ b/integrations/boomtrain/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-boomtrain",
   "description": "The Boomtrain analytics.js integration.",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/bronto/package.json
+++ b/integrations/bronto/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-bronto",
   "description": "The Bronto analytics.js integration.",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/bugherd/package.json
+++ b/integrations/bugherd/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-bugherd",
   "description": "The Bugherd analytics.js integration.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/bugsnag/package.json
+++ b/integrations/bugsnag/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-bugsnag",
   "description": "The Bugsnag analytics.js integration.",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/castle/package.json
+++ b/integrations/castle/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-castle",
   "description": "The Castle analytics.js integration.",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/chameleon/package.json
+++ b/integrations/chameleon/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-chameleon",
   "description": "The Chameleon analytics.js integration.",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/chartbeat/package.json
+++ b/integrations/chartbeat/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-chartbeat",
   "description": "The Chartbeat analytics.js integration.",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/clevertap/package.json
+++ b/integrations/clevertap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-clevertap",
   "description": "The CleverTap analytics.js integration.",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/clicky/package.json
+++ b/integrations/clicky/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-clicky",
   "description": "The Clicky analytics.js integration.",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/comscore/package.json
+++ b/integrations/comscore/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-comscore",
   "description": "The Comscore analytics.js integration.",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/convertflow/package.json
+++ b/integrations/convertflow/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@convertflow/analytics.js-integration-convertflow",
   "description": "The ConvertFlow analytics.js integration.",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/convertro/package.json
+++ b/integrations/convertro/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-convertro",
   "description": "The Convertro analytics.js integration.",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/crazy-egg/package.json
+++ b/integrations/crazy-egg/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-crazy-egg",
   "description": "The Crazy Egg analytics.js integration.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/criteo/package.json
+++ b/integrations/criteo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-criteo",
   "description": "The Criteo analytics.js integration.",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/curebit/package.json
+++ b/integrations/curebit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-curebit",
   "description": "The Curebit analytics.js integration.",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/customerio/package.json
+++ b/integrations/customerio/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-customerio",
   "description": "The Customerio analytics.js integration.",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/cxense/package.json
+++ b/integrations/cxense/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-cxense",
   "description": "The Cxense analytics.js integration.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/doubleclick-floodlight/package.json
+++ b/integrations/doubleclick-floodlight/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-doubleclick-floodlight",
   "description": "The DoubleClick Floodlight analytics.js integration.",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",
@@ -48,7 +48,7 @@
     "karma-spec-reporter": "^0.0.32",
     "karma-summary-reporter": "^1.6.0",
     "mocha": "^6.1.4",
-    "watchify": "^3.11.1",
-    "sinon": "^1.17.6"
+    "sinon": "^1.17.6",
+    "watchify": "^3.11.1"
   }
 }

--- a/integrations/drift/package.json
+++ b/integrations/drift/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-drift",
   "description": "The Drift analytics.js integration.",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/drip/package.json
+++ b/integrations/drip/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-drip",
   "description": "The Drip analytics.js integration.",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/elevio/package.json
+++ b/integrations/elevio/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-elevio",
   "description": "The Elevio analytics.js integration.",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/eloqua/package.json
+++ b/integrations/eloqua/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-eloqua",
   "description": "The Eloqua analytics.js integration.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/email-aptitude/package.json
+++ b/integrations/email-aptitude/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-email-aptitude",
   "description": "The Email Aptitude analytics.js integration.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/errorception/package.json
+++ b/integrations/errorception/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-errorception",
   "description": "The Errorception analytics.js integration.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/evergage/package.json
+++ b/integrations/evergage/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-evergage",
   "description": "The Evergage analytics.js integration.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/extole/package.json
+++ b/integrations/extole/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-extole",
   "description": "The Extole analytics.js integration.",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/facebook-conversion-tracking/package.json
+++ b/integrations/facebook-conversion-tracking/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-facebook-conversion-tracking",
   "description": "The Facebook Conversion Tracking analytics.js integration.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/facebook-custom-audiences/package.json
+++ b/integrations/facebook-custom-audiences/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-facebook-custom-audiences",
   "description": "The Facebook Custom Audiences analytics.js integration.",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/facebook-pixel/package.json
+++ b/integrations/facebook-pixel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-facebook-pixel",
   "description": "The Facebook Pixel analytics.js integration.",
-  "version": "2.11.3",
+  "version": "2.11.4",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/foxmetrics/package.json
+++ b/integrations/foxmetrics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-foxmetrics",
   "description": "The Foxmetrics analytics.js integration.",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/friendbuy/package.json
+++ b/integrations/friendbuy/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-friendbuy",
   "description": "The FriendBuy analytics.js integration.",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/fullstory/package.json
+++ b/integrations/fullstory/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-fullstory",
   "description": "The Fullstory analytics.js integration.",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/gauges/package.json
+++ b/integrations/gauges/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-gauges",
   "description": "The Gauges analytics.js integration.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/get-satisfaction/package.json
+++ b/integrations/get-satisfaction/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-get-satisfaction",
   "description": "The Get Satisfaction analytics.js integration.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/google-adwords-new/package.json
+++ b/integrations/google-adwords-new/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-google-adwords-new",
   "description": "The google-adwords-new analytics.js integration.",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/google-analytics-4/package.json
+++ b/integrations/google-analytics-4/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/analytics.js-integration-google-analytics-4",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "",
   "main": "lib/index.js",
   "directories": {

--- a/integrations/google-analytics/package.json
+++ b/integrations/google-analytics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-google-analytics",
   "description": "The Google Analytics analytics.js integration.",
-  "version": "2.18.4",
+  "version": "2.18.5",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/google-tag-manager/package.json
+++ b/integrations/google-tag-manager/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-google-tag-manager",
   "description": "The Google Tag Manager analytics.js integration.",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/gosquared/package.json
+++ b/integrations/gosquared/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-gosquared",
   "description": "The Gosquared analytics.js integration.",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/gtag/package.json
+++ b/integrations/gtag/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-gtag",
   "description": "The Gtag analytics.js integration.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/heap/package.json
+++ b/integrations/heap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-heap",
   "description": "The Heap analytics.js integration.",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/hello-bar/package.json
+++ b/integrations/hello-bar/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-hellobar",
   "description": "The Hellobar analytics.js integration.",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/hindsight/package.json
+++ b/integrations/hindsight/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-hindsight",
   "description": "The Hindsight analytics.js integration.",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/hittail/package.json
+++ b/integrations/hittail/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-hittail",
   "description": "The Hittail analytics.js integration.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/hotjar/package.json
+++ b/integrations/hotjar/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-hotjar",
   "description": "The Hotjar analytics.js integration.",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "keywords": null,
   "main": "lib/index.js",
   "scripts": {

--- a/integrations/hubspot/package.json
+++ b/integrations/hubspot/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-hubspot",
   "description": "The Hubspot analytics.js integration.",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/improvely/package.json
+++ b/integrations/improvely/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-improvely",
   "description": "The Improvely analytics.js integration.",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/inspectlet/package.json
+++ b/integrations/inspectlet/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-inspectlet",
   "description": "The Inspectlet analytics.js integration.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/intercom/package.json
+++ b/integrations/intercom/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-intercom",
   "description": "The Intercom analytics.js integration.",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/keen-io/package.json
+++ b/integrations/keen-io/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-keen-io",
   "description": "The Keen Io analytics.js integration.",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/kenshoo-infinity/package.json
+++ b/integrations/kenshoo-infinity/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-kenshoo-infinity",
   "description": "The Kenshoo Infinity analytics.js integration.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/kenshoo/package.json
+++ b/integrations/kenshoo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-kenshoo",
   "description": "The Kenshoo analytics.js integration.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/kissmetrics/package.json
+++ b/integrations/kissmetrics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-kissmetrics",
   "description": "The Kissmetrics analytics.js integration.",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/klaviyo/package.json
+++ b/integrations/klaviyo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-klaviyo",
   "description": "The Klaviyo analytics.js integration.",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/linkedin-insight-tag/package.json
+++ b/integrations/linkedin-insight-tag/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-linkedin-insight-tag",
   "description": "The LinkedIn Insight Tag analytics.js integration.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/livechat/package.json
+++ b/integrations/livechat/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-livechat",
   "description": "The Livechat analytics.js integration.",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",
@@ -13,7 +13,7 @@
     "test": "karma start",
     "test:ci": "karma start karma.conf-ci.js"
   },
-  "author": "Segment \u003cfriends@segment.com\u003e",
+  "author": "Segment <friends@segment.com>",
   "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://github.com/segmentio/analytics.js-integrations/blob/master/integrations/livechat#readme",
   "bugs": {

--- a/integrations/localytics/package.json
+++ b/integrations/localytics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-localytics",
   "description": "The Localytics analytics.js integration.",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/lucky-orange/package.json
+++ b/integrations/lucky-orange/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-lucky-orange",
   "description": "The Lucky Orange analytics.js integration.",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/lytics/package.json
+++ b/integrations/lytics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-lytics",
   "description": "The Lytics analytics.js integration.",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/madkudu/package.json
+++ b/integrations/madkudu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-madkudu",
   "description": "The Madkudu analytics.js integration.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/marketo-v2/package.json
+++ b/integrations/marketo-v2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-marketo-v2",
   "description": "The Marketo analytics.js integration.",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/marketo/package.json
+++ b/integrations/marketo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-marketo",
   "description": "The Marketo analytics.js integration.",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/mediamath/package.json
+++ b/integrations/mediamath/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-mediamath",
   "description": "The Mediamath analytics.js integration.",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/mixpanel/package.json
+++ b/integrations/mixpanel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-mixpanel",
   "description": "The Mixpanel analytics.js integration.",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/moengage/package.json
+++ b/integrations/moengage/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-moengage",
   "description": "The MoEngage analytics.js integration.",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/mojn/package.json
+++ b/integrations/mojn/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-mojn",
   "description": "The Mojn analytics.js integration.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/monetate/package.json
+++ b/integrations/monetate/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-monetate",
   "description": "The Monetate analytics.js integration.",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/mouseflow/package.json
+++ b/integrations/mouseflow/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-mouseflow",
   "description": "The Mouseflow analytics.js integration.",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/mousestats/package.json
+++ b/integrations/mousestats/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-mousestats",
   "description": "The Mousestats analytics.js integration.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/nanigans/package.json
+++ b/integrations/nanigans/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-nanigans",
   "description": "The Nanigans analytics.js integration.",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/navilytics/package.json
+++ b/integrations/navilytics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-navilytics",
   "description": "The Navilytics analytics.js integration.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/nielsen-dcr/package.json
+++ b/integrations/nielsen-dcr/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-nielsen-dcr",
   "description": "The Nielsen DCR analytics.js integration.",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/nielsen-dtvr/package.json
+++ b/integrations/nielsen-dtvr/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-nielsen-dtvr",
   "description": "The Nielsen DTVR analytics.js integration.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/nudgespot/package.json
+++ b/integrations/nudgespot/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-nudgespot",
   "description": "The Nudgespot analytics.js integration.",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/olark/package.json
+++ b/integrations/olark/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-olark",
   "description": "The Olark analytics.js integration.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/olark/package.json
+++ b/integrations/olark/package.json
@@ -10,8 +10,8 @@
   ],
   "main": "lib/index.js",
   "scripts": {
-    "test": "karma start",
-    "test:ci": "karma start karma.conf-ci.js"
+    "test": "echo 'test'",
+    "test:ci": "echo 'test'"
   },
   "author": "Segment <friends@segment.com>",
   "license": "SEE LICENSE IN LICENSE",

--- a/integrations/omniture/package.json
+++ b/integrations/omniture/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-omniture",
   "description": "The Omniture analytics.js integration.",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/onespot/package.json
+++ b/integrations/onespot/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-onespot",
   "description": "The Onespot analytics.js integration.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/optimizely/package.json
+++ b/integrations/optimizely/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-optimizely",
   "description": "The Optimizely analytics.js integration.",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/outbound/package.json
+++ b/integrations/outbound/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-outbound",
   "description": "The Outbound analytics.js integration.",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/owneriq/package.json
+++ b/integrations/owneriq/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@owneriq/analytics.js-integration-owneriq-pixel",
   "description": "The OwnerIQ analytics.js integration.",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/pardot/package.json
+++ b/integrations/pardot/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-pardot",
   "description": "The Pardot analytics.js integration.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/parsely/package.json
+++ b/integrations/parsely/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-parsely",
   "description": "The Parsely analytics.js integration.",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/pendo/package.json
+++ b/integrations/pendo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-pendo",
   "description": "The Pendo analytics.js integration.",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/perfect-audience/package.json
+++ b/integrations/perfect-audience/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-perfect-audience",
   "description": "The Perfect Audience analytics.js integration.",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/perimeterx/package.json
+++ b/integrations/perimeterx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-perimeterx",
   "description": "The Perimeterx analytics.js integration.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/pingdom/package.json
+++ b/integrations/pingdom/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-pingdom",
   "description": "The Pingdom analytics.js integration.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/pinterest-tag/package.json
+++ b/integrations/pinterest-tag/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-pinterest-tag",
   "description": "The Pinterest Tag analytics.js integration.",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/piwik/package.json
+++ b/integrations/piwik/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-piwik",
   "description": "The Piwik analytics.js integration.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/qualaroo/package.json
+++ b/integrations/qualaroo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-qualaroo",
   "description": "The Qualaroo analytics.js integration.",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/quantcast/package.json
+++ b/integrations/quantcast/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-quantcast",
   "description": "The Quantcast analytics.js integration.",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/quanticmind/package.json
+++ b/integrations/quanticmind/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-quanticmind",
   "description": "The QuanticMind analytics.js integration.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/quora-conversion-pixel/package.json
+++ b/integrations/quora-conversion-pixel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-quora-conversion-pixel",
   "description": "The Quora Conversion Pixel analytics.js integration.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/ramen/package.json
+++ b/integrations/ramen/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-ramen",
   "description": "The Ramen analytics.js integration.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/rockerbox/package.json
+++ b/integrations/rockerbox/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-rockerbox",
   "description": "The Rockerbox analytics.js integration.",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/rocket-fuel/package.json
+++ b/integrations/rocket-fuel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-rocket-fuel",
   "description": "The Rocket Fuel analytics.js integration.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/rollbar/package.json
+++ b/integrations/rollbar/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-rollbar",
   "description": "The Rollbar analytics.js integration.",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/route/package.json
+++ b/integrations/route/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-route",
   "description": "The Route analytics.js integration.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/saasquatch/package.json
+++ b/integrations/saasquatch/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-saasquatch",
   "description": "The Saasquatch analytics.js integration.",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/salesforce-dmp/package.json
+++ b/integrations/salesforce-dmp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-salesforce-dmp",
   "description": "The Salesforce DMP analytics.js integration.",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/salesforce-live-agent/package.json
+++ b/integrations/salesforce-live-agent/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-salesforce-live-agent",
   "description": "The Salesforce Live Agent analytics.js integration.",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/satismeter/package.json
+++ b/integrations/satismeter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-satismeter",
   "description": "The Satismeter analytics.js integration.",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/segmentio/package.json
+++ b/integrations/segmentio/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-segmentio",
   "description": "The Segmentio analytics.js integration.",
-  "version": "4.4.6",
+  "version": "4.4.7",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",
@@ -53,8 +53,8 @@
     "karma-spec-reporter": "^0.0.32",
     "karma-summary-reporter": "^1.6.0",
     "mocha": "^6.1.4",
-    "watchify": "^3.11.1",
     "proclaim": "^3.4.1",
-    "sinon": "^1.17.4"
+    "sinon": "^1.17.4",
+    "watchify": "^3.11.1"
   }
 }

--- a/integrations/sentry/package.json
+++ b/integrations/sentry/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-sentry",
   "description": "The Sentry analytics.js integration.",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/shareasale/package.json
+++ b/integrations/shareasale/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-shareasale",
   "description": "The Shareasale analytics.js integration.",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/simplereach/package.json
+++ b/integrations/simplereach/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-simplereach",
   "description": "The Simplereach analytics.js integration.",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/simplifi/package.json
+++ b/integrations/simplifi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-simplifi",
   "description": "The Simplifi analytics.js integration.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/smartlook/package.json
+++ b/integrations/smartlook/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@smartlook/analytics.js-integration-smartlook",
   "description": "The Smartlook analytics.js integration.",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/snapengage/package.json
+++ b/integrations/snapengage/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-snapengage",
   "description": "The Snapengage analytics.js integration.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/spinnakr/package.json
+++ b/integrations/spinnakr/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-spinnakr",
   "description": "The Spinnakr analytics.js integration.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/steelhouse/package.json
+++ b/integrations/steelhouse/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-steelhouse",
   "description": "The Steelhouse analytics.js integration.",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/stripe-radar/package.json
+++ b/integrations/stripe-radar/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-stripe-radar",
   "description": "The Stripe Radar analytics.js integration.",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/supporthero/package.json
+++ b/integrations/supporthero/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-supporthero",
   "description": "The Supporthero analytics.js integration.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/survicate/package.json
+++ b/integrations/survicate/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@survicate/analytics.js-integration-survicate",
   "description": "The Survicate analytics.js integration.",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",
@@ -20,10 +20,10 @@
   },
   "homepage": "https://github.com/Survicate/analytics.js-integration-survicate#readme",
   "dependencies": {
-    "@segment/analytics.js-integration": "^2.1.0",
-    "do-when": "^1.0.0",
-    "change-case": "^3.1.0",
     "@ndhoule/each": "^2.0.1",
+    "@segment/analytics.js-integration": "^2.1.0",
+    "change-case": "^3.1.0",
+    "do-when": "^1.0.0",
     "is": "^3.3.0"
   },
   "devDependencies": {

--- a/integrations/tag-injector/package.json
+++ b/integrations/tag-injector/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-tag-injector",
   "description": "The tag-injector analytics.js integration.",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/taplytics/package.json
+++ b/integrations/taplytics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-taplytics",
   "description": "The Taplytics analytics.js integration.",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/tapstream/package.json
+++ b/integrations/tapstream/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-tapstream",
   "description": "The Tapstream analytics.js integration.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/totango/package.json
+++ b/integrations/totango/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-totango",
   "description": "The Totango analytics.js integration.",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/track-js/package.json
+++ b/integrations/track-js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-trackjs",
   "description": "The Trackjs analytics.js integration.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/tv-squared/package.json
+++ b/integrations/tv-squared/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-tvsquared",
   "description": "The Tvsquared analytics.js integration.",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/twitter-ads/package.json
+++ b/integrations/twitter-ads/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-twitter-ads",
   "description": "The Twitter Ads analytics.js integration.",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/userlike/package.json
+++ b/integrations/userlike/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-userlike",
   "description": "The Userlike analytics.js integration.",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/uservoice/package.json
+++ b/integrations/uservoice/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-uservoice",
   "description": "The Uservoice analytics.js integration.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/vero/package.json
+++ b/integrations/vero/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-vero",
   "description": "The Vero analytics.js integration.",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/visual-tagger/package.json
+++ b/integrations/visual-tagger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/analytics.js-integration-visual-tagger",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "The Visual Tagger analyticsjs integration",
   "main": "lib/index.js",
   "scripts": {

--- a/integrations/visual-website-optimizer/package.json
+++ b/integrations/visual-website-optimizer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-visual-website-optimizer",
   "description": "The Visual Website Optimizer analytics.js integration.",
-  "version": "2.4.4",
+  "version": "2.4.5",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/walkme/package.json
+++ b/integrations/walkme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walkme/analytics.js-integration-walkme",
   "description": "The WalkMe analytics.js integration.",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/webengage/package.json
+++ b/integrations/webengage/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-webengage",
   "description": "The Webengage analytics.js integration.",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/wigzo/package.json
+++ b/integrations/wigzo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-wigzo",
   "description": "The wigzo analytics.js integration.",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/wishpond/package.json
+++ b/integrations/wishpond/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-wishpond",
   "description": "The Wishpond analytics.js integration.",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/woopra/package.json
+++ b/integrations/woopra/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-woopra",
   "description": "The Woopra analytics.js integration.",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/wootric/package.json
+++ b/integrations/wootric/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-wootric",
   "description": "The Wootric analytics.js integration.",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/yandex-metrica/package.json
+++ b/integrations/yandex-metrica/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-yandex-metrica",
   "description": "The Yandex Metrica analytics.js integration.",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/yellowhammer/package.json
+++ b/integrations/yellowhammer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-yellowhammer",
   "description": "The Yellowhammer analytics.js integration.",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/youbora/package.json
+++ b/integrations/youbora/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-youbora",
   "description": "The Youbora analytics.js integration.",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/zopim/package.json
+++ b/integrations/zopim/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-zopim",
   "description": "The Zopim analytics.js integration.",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   "scripts": {
     "upload-assets": "node scripts/upload-assets.js",
     "lint": "lerna exec --since master --no-bail -- npx eslint . --ext .js",
-    "test": "lerna run --concurrency 1 --since master test --stream -- --single-run --reporters summary --log-level error",
-    "test:ci": "lerna run --concurrency 1 --stream --since master test:ci -- --log-level error",
+    "test": "lerna run --since master test --stream -- --single-run --reporters summary --log-level error",
+    "test:ci": "lerna run --stream --since master test:ci -- --log-level error",
     "compile": "webpack --config webpack.config.integrations.js && webpack --config webpack.config.middleware.js",
     "build": "rm -rf build && yarn compile"
   },

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   "scripts": {
     "upload-assets": "node scripts/upload-assets.js",
     "lint": "lerna exec --since master --no-bail -- npx eslint . --ext .js",
-    "test": "lerna run --since master test --stream -- --single-run --reporters summary --log-level error",
-    "test:ci": "lerna run --stream --since master test:ci -- --log-level error",
+    "test": "lerna run --concurrency 5 --since master test --stream -- --single-run --reporters summary --log-level error",
+    "test:ci": "lerna run --concurrency 1 --stream --since master test:ci -- --log-level error",
     "compile": "webpack --config webpack.config.integrations.js && webpack --config webpack.config.middleware.js",
     "build": "rm -rf build && yarn compile"
   },

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "webpack-dev-server": "^3.11.0"
   },
   "dependencies": {
+    "@segment/analytics.js-integration": "^3.3.3",
     "domify": "1.4.1"
   }
 }

--- a/webpack.config.integrations.js
+++ b/webpack.config.integrations.js
@@ -41,7 +41,7 @@ module.exports = {
     chunkFilename: 'vendor/[name].[contenthash].js',
     path: path.resolve(__dirname, 'build/integrations'),
     library: '[name]Integration',
-    libraryTarget: 'umd'
+    libraryTarget: 'window'
   },
   module: {
     rules: [

--- a/webpack.config.integrations.js
+++ b/webpack.config.integrations.js
@@ -69,7 +69,9 @@ module.exports = {
   resolve: {
     extensions: ['.ts', '.js'],
     alias: {
-      domify: '/node_modules/domify/index.js'
+      domify: '/node_modules/domify/index.js',
+      '@segment/analytics.js-integration':
+        '/node_modules/@segment/analytics.js-integration'
     }
   },
   devServer: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2032,6 +2032,32 @@
     slug-component "^1.1.0"
     to-no-case "^0.1.3"
 
+"@segment/analytics.js-integration@^3.3.3":
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/@segment/analytics.js-integration/-/analytics.js-integration-3.3.3.tgz#c8fb06747f0864f931c3d0a16f014d9b0e726ec2"
+  integrity sha512-RpUQBSE2wH/ovVrT1b0dTesalLZer7iX21p2TDaM+8mhi4M91HdqK4nOtE/Ny5+GAYU4v7LvTfvb9zgTC34rPA==
+  dependencies:
+    "@ndhoule/clone" "^1.0.0"
+    "@ndhoule/defaults" "^2.0.1"
+    "@ndhoule/each" "^2.0.1"
+    "@ndhoule/every" "^2.0.1"
+    "@ndhoule/extend" "^2.0.0"
+    "@ndhoule/foldl" "^2.0.1"
+    "@ndhoule/includes" "^2.0.1"
+    "@segment/fmt" "^1.0.0"
+    "@segment/load-script" "^1.0.1"
+    analytics-events "^2.0.2"
+    component-bind "^1.0.0"
+    component-emitter "^1.2.0"
+    debug "^2.2.0"
+    domify "^1.4.1"
+    extend "^3.0.2"
+    is "^3.1.0"
+    load-iframe "^1.0.0"
+    next-tick "^0.2.2"
+    slug-component "^1.1.0"
+    to-no-case "^0.1.3"
+
 "@segment/base64-encode@^2.0.2":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@segment/base64-encode/-/base64-encode-2.0.2.tgz#3ac90b9c28678dfd467e76191f7b1d063673034f"
@@ -5447,7 +5473,7 @@ domain-browser@~1.1.0:
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.1.7.tgz#867aa4b093faa05f1de08c06f4d7b21fdf8698bc"
   integrity sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw=
 
-domify@1.4.1:
+domify@1.4.1, domify@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/domify/-/domify-1.4.1.tgz#2e1e813019646715deeb8d3c5de4d3ef7bddd07e"
   integrity sha512-x18nuiDHMCZGXr4KJSRMf/TWYtiaRo6RX8KN9fEbW54mvbQ6pieUuerC2ahBg+kEp1wycFj8MPUI0WkIOw5E9w==


### PR DESCRIPTION
**What does this PR do?**
Massively reduce bundle size for Analytics.js 2.0 integrations by pinning `@segment/analytics.js-integration`.
This will 

**Are there breaking changes in this PR?**
Unsure. More testing is required.

**Testing**

Testing completed successfully using custom enviroment via:
- Loading AJS 2.0 with normalized dependency
- Running e2e QA tests 

**Demo**

Before

![image](https://user-images.githubusercontent.com/270688/120688635-e30f3680-c468-11eb-95de-d66b355a4d67.png)

After
![image](https://user-images.githubusercontent.com/270688/120688690-edc9cb80-c468-11eb-8598-bcf2f9cf4195.png)
