### PR TITLE
Skip SauceLabs tests when releasing

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,6 +4,7 @@ env:
 
 steps:
   - label: ':hammer: Build and Test'
+    key: 'build'
     agents:
       queue: v1
     command:
@@ -24,6 +25,7 @@ steps:
             - CHROME-BIN=google-chrome
 
   - label: 'SauceLabs'
+    key: 'sauce_labs'
     soft_fail: true
     command:
       - npm config set "//registry.npmjs.org/:_authToken" $${NPM_TOKEN}
@@ -43,6 +45,7 @@ steps:
             - SAUCE_ACCESS_KEY
 
   - label: '🔒 Snyk Security Check'
+    key: 'snyk'
     agents:
       queue: v1
     plugins:
@@ -51,6 +54,7 @@ steps:
           fail-on: upgradable
 
   - wait: ~
+    depends_on: ['snyk', 'build']
 
   - label: ':cloud: Upload Assets to stage bucket'
     branches: master staging


### PR DESCRIPTION
**What does this PR do?**
Change CI configuration to only block on unit tests and snyk.

Sauce Labs test already run in soft_fail mode, which means they're not release blockers. This change makes them truly non-blocking, helping improve our lead time for changes.


**Are there breaking changes in this PR?**
N/A

**Testing**
- Testing not required because this is a CI only change.
