### PR TITLE
APP-44646 Added support for configurable domain to pendo integration

### DIFF
--- a/integrations/pendo/lib/index.js
+++ b/integrations/pendo/lib/index.js
@@ -17,9 +17,9 @@ var obj = require('obj-case');
 var Pendo = (module.exports = integration('Pendo')
   .global('pendo')
   .option('apiKey', '')
-  .tag(
-    '<script src="https://cdn.pendo.io/agent/static/{{ apiKey }}/pendo.js">'
-  ));
+  .option('domain', 'cdn.pendo.io')
+  .tag('<script src="https://{{ domain }}/agent/static/{{ apiKey }}/pendo.js">')
+);
 
 /**
  * Either use this as a TagLoader and all the relevant Pendo information will

--- a/integrations/pendo/package.json
+++ b/integrations/pendo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-pendo",
   "description": "The Pendo analytics.js integration.",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",


### PR DESCRIPTION
**What does this PR do?**

Add support to exist Pendo Integration to allow for a CNAME domain to be optionally provided when requesting the pendo.js resource.

No breaking changes.

This doesn't require any new settings but does look to use a new `domain` argument in addition to the already existing `apiKey` argument. This new value should be provided in the same way that `apiKey` is provided.
