### PR TITLE
update klaviyo integration to support exchange ID

### DIFF
--- a/integrations/klaviyo/package.json
+++ b/integrations/klaviyo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-klaviyo",
   "description": "The Klaviyo analytics.js integration.",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/klaviyo/test/index.test.js
+++ b/integrations/klaviyo/test/index.test.js
@@ -114,6 +114,17 @@ describe('Klaviyo', function() {
         ]);
       });
 
+      it('should send an $exchange_id and traits', function() {
+        analytics.identify(undefined, {
+          $exchange_id: 'exchange-id',
+          foo: true
+        });
+        analytics.called(window._learnq.push, [
+          'identify',
+          { $exchange_id: 'exchange-id', foo: true }
+        ]);
+      });
+
       it('should alias traits', function() {
         analytics.identify('id', {
           email: 'name@example.com',


### PR DESCRIPTION
**What does this PR do?**

Klaviyo recently made an update to its web tracking. An `$exchange_id` was introduced which is an encrypted envelope containing identifiers. Segment's Klaviyo integration does not consider this identifier, and in the absence of other identifiers (like email and ID) is skipping `track` requests.

This PR allows the Segment/Klaviyo integration to recognize and pass along exchange IDs as they are encountered.

**Are there breaking changes in this PR?**

No, these changes are supplemental to existing behavior.

**Testing**
Testing completed successfully on stage via AJS 2.0
Test cases were added to existing coverage, all of which is passing.


**Any background context you want to provide?**

https://help.klaviyo.com/hc/en-us/articles/115005076767-Guide-to-Klaviyo-Web-Tracking#the-_kx-parameter5

**Is there parity with the server-side/android/iOS integration components (if applicable)?**

Unsure.

**Does this require a new integration setting? If so, please explain how the new setting works**

No.

**Links to helpful docs and other external resources**

https://help.klaviyo.com/hc/en-us/articles/115005076767-Guide-to-Klaviyo-Web-Tracking#the-_kx-parameter5
