### PR TITLE
[SECOPS-2023] Link to page on segment docs site rather than public paper doc

### DIFF
--- a/integrations/parsely/lib/index.js
+++ b/integrations/parsely/lib/index.js
@@ -175,7 +175,7 @@ Parsely.prototype.parseVideoMetadata = function(track) {
   if (authors) authors = Array.isArray(authors) ? authors : [authors];
 
   // https://www.parse.ly/help/integration/video/#video-metadata
-  // https://paper.dropbox.com/doc/Segment-Video-Spec-jdrVhQdGo9aUTQ2kMsbnx
+  // https://segment.com/docs/connections/spec/video/
   return reject({
     title: track.proxy('properties.title'),
     // Fallback on null to avoid NaN trickling through reject.


### PR DESCRIPTION
https://segment.atlassian.net/browse/SECOPS-2023

No testing required, this is simply updating a comment reference.
