### PR TITLE
Added support of the consent flag parameter cs_ucfr, updated beacon.j…

### DIFF
--- a/integrations/comscore/lib/index.js
+++ b/integrations/comscore/lib/index.js
@@ -5,6 +5,7 @@
  */
 
 var integration = require('@segment/analytics.js-integration');
+const { option } = require('@segment/analytics.js-integration/lib/statics');
 var useHttps = require('use-https');
 
 /**
@@ -17,8 +18,9 @@ var Comscore = (module.exports = integration('comScore')
   .option('c1', '2')
   .option('c2', '')
   .option('comscorekw', '')
-  .tag('http', '<script src="http://b.scorecardresearch.com/beacon.js">')
-  .tag('https', '<script src="https://sb.scorecardresearch.com/beacon.js">'));
+  .option('consentFlag', '')
+  .tag('https', '<script src="https://sb.scorecardresearch.com/cs/{{ c2 }}/beacon.js">')
+  .tag('http', '<script src="https://sb.scorecardresearch.com/cs/{{ c2 }}/beacon.js">'));
 
 /**
  * Initialize.
@@ -78,6 +80,7 @@ Comscore.prototype._initialize = function() {
 Comscore.prototype.mapComscoreParams = function(page) {
   var beaconParamMap = this.options.beaconParamMap;
   var properties = page.properties();
+  var consentValue;
 
   var comScoreParams = {};
 
@@ -88,6 +91,23 @@ Comscore.prototype.mapComscoreParams = function(page) {
       comScoreParams[key] = value;
     }
   });
+
+  if (this.options.consentFlag) {
+    consentValue = page.proxy('properties.' + this.options.consentFlag);
+    if (this.options.consentFlag in properties) {
+      if (String(consentValue) === 'true' || String(consentValue) === '1') {
+        consentValue = '1';
+      } else if (
+        String(consentValue) === 'false' ||
+        String(consentValue) === '0'
+      ) {
+        consentValue = '0';
+      } else {
+        consentValue = '';
+      }
+      comScoreParams.cs_ucfr = consentValue;
+    }
+  }
 
   comScoreParams.c1 = this.options.c1;
   comScoreParams.c2 = this.options.c2;

--- a/integrations/comscore/test/index.test.js
+++ b/integrations/comscore/test/index.test.js
@@ -16,7 +16,8 @@ describe('comScore', function() {
     beaconParamMap: {
       exampleParam: 'c5',
       anotherParam: 'c6'
-    }
+    },
+    consentFlag: ''
   };
 
   beforeEach(function() {
@@ -42,6 +43,7 @@ describe('comScore', function() {
         .option('c1', '2')
         .option('c2', '')
         .option('comscorekw', '')
+        .option('consentFlag', '')
     );
   });
 
@@ -73,12 +75,14 @@ describe('comScore', function() {
 
   describe('loading', function() {
     it('should load', function(done) {
+      comscore.options.c2 = '24186693';
       analytics.load(comscore, done);
     });
   });
 
   describe('after loading', function() {
     beforeEach(function(done) {
+      comscore.options.c2 = '24186693';
       analytics.once('ready', done);
       analytics.initialize();
       analytics.page();
@@ -92,13 +96,13 @@ describe('comScore', function() {
       it('should call only on 2nd page', function() {
         analytics.didNotCall(window.COMSCORE.beacon, {
           c1: '2',
-          c2: 'x',
+          c2: '24186693',
           comscorekw: 'test'
         });
         analytics.page();
         analytics.called(window.COMSCORE.beacon, {
           c1: '2',
-          c2: 'x',
+          c2: '24186693',
           comscorekw: 'test'
         });
       });
@@ -106,16 +110,204 @@ describe('comScore', function() {
       it('should map properties in beaconParamMap', function() {
         analytics.didNotCall(window.COMSCORE.beacon, {
           c1: '2',
-          c2: 'x',
+          c2: '24186693',
           comscorekw: 'test'
         });
         analytics.page({ exampleParam: 'foo', anotherParam: 'bar' });
         analytics.called(window.COMSCORE.beacon, {
           c1: '2',
-          c2: 'x',
+          c2: '24186693',
           c5: 'foo',
           c6: 'bar',
           comscorekw: 'test'
+        });
+      });
+      it('should not pass cs_ucfr flag when consentFlag option is not mapped in the settings', function() {
+        analytics.page({
+          exampleParam: 'foo',
+          anotherParam: 'bar',
+          flagParam: 'value'
+        });
+        analytics.called(window.COMSCORE.beacon, {
+          c1: '2',
+          c2: '24186693',
+          c5: 'foo',
+          c6: 'bar',
+          comscorekw: 'test'
+        });
+      });
+      it('should not pass cs_ucfr when mapped property is not in the payload', function() {
+        comscore.options.consentFlag = 'flagParam';
+        analytics.page({
+          exampleParam: 'foo',
+          anotherParam: 'bar'
+        });
+        analytics.called(window.COMSCORE.beacon, {
+          c1: '2',
+          c2: '24186693',
+          c5: 'foo',
+          c6: 'bar',
+          comscorekw: 'test'
+        });
+      });
+      it('should set cs_ucfr to "" (empty string) when mapped property is not 1/0, true/false', function() {
+        comscore.options.consentFlag = 'flagParam';
+        analytics.page({
+          exampleParam: 'foo',
+          anotherParam: 'bar',
+          flagParam: 'some value'
+        });
+        analytics.called(window.COMSCORE.beacon, {
+          c1: '2',
+          c2: '24186693',
+          c5: 'foo',
+          c6: 'bar',
+          comscorekw: 'test',
+          cs_ucfr: ''
+        });
+      });
+      it('should set cs_ucfr to "" (empty string) when mapped property is null', function() {
+        comscore.options.consentFlag = 'flagParam';
+        analytics.page({
+          exampleParam: 'foo',
+          anotherParam: 'bar',
+          flagParam: null
+        });
+        analytics.called(window.COMSCORE.beacon, {
+          c1: '2',
+          c2: '24186693',
+          c5: 'foo',
+          c6: 'bar',
+          comscorekw: 'test',
+          cs_ucfr: ''
+        });
+      });
+      it('should set cs_ucfr to "1" string when mapped property is true (bool)', function() {
+        comscore.options.consentFlag = 'flagParam';
+        analytics.page({
+          exampleParam: 'foo',
+          anotherParam: 'bar',
+          flagParam: true
+        });
+        analytics.called(window.COMSCORE.beacon, {
+          c1: '2',
+          c2: '24186693',
+          c5: 'foo',
+          c6: 'bar',
+          comscorekw: 'test',
+          cs_ucfr: '1'
+        });
+      });
+      it('should set cs_ucfr to "1" string when mapped property is true (string)', function() {
+        comscore.options.consentFlag = 'flagParam';
+        analytics.page({
+          exampleParam: 'foo',
+          anotherParam: 'bar',
+          flagParam: 'true'
+        });
+        analytics.called(window.COMSCORE.beacon, {
+          c1: '2',
+          c2: '24186693',
+          c5: 'foo',
+          c6: 'bar',
+          comscorekw: 'test',
+          cs_ucfr: '1'
+        });
+      });
+      it('should set cs_ucfr to "1" string when mapped property is 1 (int)', function() {
+        comscore.options.consentFlag = 'flagParam';
+        analytics.page({
+          exampleParam: 'foo',
+          anotherParam: 'bar',
+          flagParam: true
+        });
+        analytics.called(window.COMSCORE.beacon, {
+          c1: '2',
+          c2: '24186693',
+          c5: 'foo',
+          c6: 'bar',
+          comscorekw: 'test',
+          cs_ucfr: '1'
+        });
+      });
+      it('should set cs_ucfr to "1" string when mapped property is "1" (string)', function() {
+        comscore.options.consentFlag = 'flagParam';
+        analytics.page({
+          exampleParam: 'foo',
+          anotherParam: 'bar',
+          flagParam: true
+        });
+        analytics.called(window.COMSCORE.beacon, {
+          c1: '2',
+          c2: '24186693',
+          c5: 'foo',
+          c6: 'bar',
+          comscorekw: 'test',
+          cs_ucfr: '1'
+        });
+      });
+      it('should set cs_ucfr to "0" string when mapped property is false (bool)', function() {
+        comscore.options.consentFlag = 'flagParam';
+        analytics.page({
+          exampleParam: 'foo',
+          anotherParam: 'bar',
+          flagParam: false
+        });
+        analytics.called(window.COMSCORE.beacon, {
+          c1: '2',
+          c2: '24186693',
+          c5: 'foo',
+          c6: 'bar',
+          comscorekw: 'test',
+          cs_ucfr: '0'
+        });
+      });
+      it('should set cs_ucfr to "0" string when mapped property is "false" (string)', function() {
+        comscore.options.consentFlag = 'flagParam';
+        analytics.page({
+          exampleParam: 'foo',
+          anotherParam: 'bar',
+          flagParam: 'false'
+        });
+        analytics.called(window.COMSCORE.beacon, {
+          c1: '2',
+          c2: '24186693',
+          c5: 'foo',
+          c6: 'bar',
+          comscorekw: 'test',
+          cs_ucfr: '0'
+        });
+      });
+      it('should set cs_ucfr to "0" string when mapped property is 0 (int)', function() {
+        comscore.options.consentFlag = 'flagParam';
+        analytics.page({
+          exampleParam: 'foo',
+          anotherParam: 'bar',
+          flagParam: 0
+        });
+        analytics.called(window.COMSCORE.beacon, {
+          c1: '2',
+          c2: '24186693',
+          c5: 'foo',
+          c6: 'bar',
+          comscorekw: 'test',
+          cs_ucfr: '0'
+        });
+      });
+      it('should set cs_ucfr to "0" string when mapped property is "0" (string)', function() {
+        comscore.options.consentFlag = 'flagParam';
+        analytics.page({
+          exampleParam: 'foo',
+          anotherParam: 'bar',
+          flagParam: '0'
+        });
+        analytics.called(window.COMSCORE.beacon, {
+          c1: '2',
+          c2: '24186693',
+          c5: 'foo',
+          c6: 'bar',
+          comscorekw: 'test',
+          cs_ucfr: '0'
         });
       });
     });


### PR DESCRIPTION
**What does this PR do?**

This PR does the following:
1. Updates beacon.js HTTP and HTTPS links to https://sb.scorecardresearch.com/cs/<c2 client Id value>/beacon.js
2. Adds support of the consent label `_cs_ucfr_`: allows a customer to map page() event property to the `_cs_ucfr_` label (comScore user consent flag) in the Destination Settings; converts property value into "1"/"0" as expected by comScore.

**Are there breaking changes in this PR?**
No.

**Testing**

1. Unit tests

Unit tests completed successfully including new (highlighted in orange) and changed (highlighted in red).

![image](https://user-images.githubusercontent.com/27460815/129117396-3fc20140-9771-4b7c-8896-ddea0075079a.png)

2. Local testing

2.1 **Consent flag** is not mapped in the Destination Settings
![image](https://user-images.githubusercontent.com/27460815/129117900-854e8290-fcff-4abb-8560-6ac45bc98a4d.png)

Result: `_cs_ucfr_` is not passed with beacon.js
![image](https://user-images.githubusercontent.com/27460815/129118073-77195a70-c70b-4bb1-8424-796dd0299cb7.png)

2.2 **Consent flag** is mapped in the Destination Settings, page() event does not contain specified property
![image](https://user-images.githubusercontent.com/27460815/129118320-cc87f47b-4c70-42d6-8984-23bb79eb41e1.png)

Result: `_cs_ucfr_` is not passed with beacon.js
![image](https://user-images.githubusercontent.com/27460815/129118383-50b589bc-b0ce-4c62-a149-2be220179e8b.png)

2.3 **Consent flag** is mapped in the Destination Settings, page() event property is other then 1/0, true/false

Result: `_cs_ucfr_` is passed with beacon.js, `_cs_ucfr=""_`
![image](https://user-images.githubusercontent.com/27460815/129118723-e623bbf0-14b7-4d6d-862a-91427590d2ad.png)

2.4 **Consent flag** is mapped in the Destination Settings, page() event property is Null

Result: `_cs_ucfr_` is passed with beacon.js, `_cs_ucfr=""_`
![image](https://user-images.githubusercontent.com/27460815/129118816-6b60128e-242a-48a9-8579-e0857aa16e72.png)

2.5 **Consent flag** is mapped in the Destination Settings, page() event property is true (bool)

Result: `_cs_ucfr_` is passed with beacon.js, `_cs_ucfr="1"_`
![image](https://user-images.githubusercontent.com/27460815/129118900-2ebeaa89-f679-4bfd-8d69-3ec846df49de.png)

2.6 **Consent flag** is mapped in the Destination Settings, page() event property is "true" (string)

Result: `_cs_ucfr_` is passed with beacon.js, `_cs_ucfr="1"_`
![image](https://user-images.githubusercontent.com/27460815/129118967-60859672-61a9-4acb-abbf-067cb0a42fdc.png)

2.7 **Consent flag** is mapped in the Destination Settings, page() event property is 1 (int)

Result: `_cs_ucfr_` is passed with beacon.js, `_cs_ucfr="1"_`
![image](https://user-images.githubusercontent.com/27460815/129119016-68dc9ff9-a126-4dcf-8de8-df340828c563.png)

2.8 **Consent flag** is mapped in the Destination Settings, page() event property is "1" (string)

Result: `_cs_ucfr_` is passed with beacon.js, `_cs_ucfr="1"_`
![image](https://user-images.githubusercontent.com/27460815/129119054-8a8ef959-8a0e-461e-a506-48787d33df82.png)

2.9 **Consent flag** is mapped in the Destination Settings, page() event property is false (bool)

Result: `_cs_ucfr_` is passed with beacon.js, `_cs_ucfr="0"_`
![image](https://user-images.githubusercontent.com/27460815/129119130-74497eec-4b07-4026-92a6-ecc7f2a5d0c5.png)

2.10 **Consent flag** is mapped in the Destination Settings, page() event property is "false" (string)

Result: `_cs_ucfr_` is passed with beacon.js, `_cs_ucfr="0"_`
![image](https://user-images.githubusercontent.com/27460815/129119178-121b65fa-a47f-41ff-9750-50b6b517bcfb.png)

2.11 **Consent flag** is mapped in the Destination Settings, page() event property is 0 (int)

Result: `_cs_ucfr_` is passed with beacon.js, `_cs_ucfr="0"_`
![image](https://user-images.githubusercontent.com/27460815/129119249-b7ba7252-982f-4eb4-b1d8-7250ec5f9577.png)

2.12 **Consent flag** is mapped in the Destination Settings, page() event property is "0" (string)

Result: `_cs_ucfr_` is passed with beacon.js, `_cs_ucfr="0"_`
![image](https://user-images.githubusercontent.com/27460815/129119318-93f1841a-0458-44a6-9ad0-ee165ce1b336.png)

**Any background context you want to provide?**
Both changes requested by Fox.
- comScore representative confirmed we should be loading beacon.js via HTTPS only.
- cs_ucfr flag was introduced by comScore last year and required for tracking user consent. This implementation follows PRD document [here](https://paper.dropbox.com/doc/PRD-Support-for-Comscore-Consent-Flag--BQRikRsLcTv5CRxHHq0XVJE0Ag-5Co2TbDeaj0HWqo6rdKra).

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
Planned, but not ready yet. 
iOS and Android implementation of the `_cs_ucfr_` flag is planned in the upcoming weeks.

**Does this require a new integration setting? If so, please explain how the new setting works**
Yes.
This change requires a new setting `consentFlag`. The setting is a string field, not required. The setting is live in the Staging environment.
The setting allows a customer to specify page() event property name which should be mapped to the `cs_ucfr` beacon.js label.
If the setting is not populated, or mapped property is missing in the page() call - the integration omits `cs_ucfr` label. If mapped property value is 1 or true - the integration sets `cs_ucfr="1"`. If mapped property value is 0 or false - the integration sets `cs_ucfr="0"`.  If mapped property value is any value other than 1/0/true/false, or if it is Null - the integration sets `cs_ucfr=""`.


**Links to helpful docs and other external resources**
PRD document: [link](https://paper.dropbox.com/doc/PRD-Support-for-Comscore-Consent-Flag--BQRikRsLcTv5CRxHHq0XVJE0Ag-5Co2TbDeaj0HWqo6rdKra)
