### PR TITLE
add isOuterScript to fullstory configs

### DIFF
--- a/integrations/fullstory/lib/index.js
+++ b/integrations/fullstory/lib/index.js
@@ -21,6 +21,7 @@ var FullStory = (module.exports = integration('FullStory')
   .option('trackNamedPages', false)
   .option('trackCategorizedPages', false)
   .option('trackPagesWithEvents', true)
+  .option('isOuterScript', false)
   .tag(
     '<script async src="https://edge.fullstory.com/s/fs.js" crossorigin="anonymous"></script>'
   ));
@@ -36,6 +37,7 @@ var apiSource = 'segment';
  * Initialize.
  */
 FullStory.prototype.initialize = function() {
+  window._fs_is_outer_script = this.options.isOuterScript;
   window._fs_debug = this.options.debug;
   window._fs_host = 'fullstory.com';
   window._fs_script = 'edge.fullstory.com/s/fs.js';


### PR DESCRIPTION
**What does this PR do?**


**Are there breaking changes in this PR?**


**Testing**
<!---

All PRs must follow the process for change control as outlined in:
https://segment.atlassian.net/wiki/spaces/GRC/pages/453935287/Reinforcing+Change+Control

- Testing completed successfully using <how did you test, environment>; or
- Testing not required because <explain why you think testing isn't needed>

--->


**Any background context you want to provide?**

We have had to set this variable outside of segment for a while now, and it makes my devs lose trust in why we are using segment. You can read more about the config here: https://help.fullstory.com/hc/en-us/articles/360020622514-Can-FullStory-capture-content-that-is-presented-in-iframes-#h_01F1G33B40Q2TPQA8MA7SF8Y5P


**Is there parity with the server-side/android/iOS integration components (if applicable)?**

Not applicable. 


**Does this require a new integration setting? If so, please explain how the new setting works**

Yes, it should mimic the debug setting only setting `window['_fs_is_outer_script'] = true;`


**Links to helpful docs and other external resources**

https://help.fullstory.com/hc/en-us/articles/360020622514-Can-FullStory-capture-content-that-is-presented-in-iframes-#h_01F1G33B40Q2TPQA8MA7SF8Y5P

