### PR TITLE
Fix/moengage id reset handle

### DIFF
--- a/integrations/moengage/lib/index.js
+++ b/integrations/moengage/lib/index.js
@@ -104,12 +104,6 @@ MoEngage.prototype.loaded = function() {
 
 MoEngage.prototype.identify = function(identify) {
   var self = this;
-  // Important: MoEngage require you to manually call reset to wipe the unique id for the session
-  // if you don't do this and call add_unique_user_id w/ a different userId, it will overwrite the previous user's
-  // unique id and all their traits so we need to manually check if it's a new user since `analytics.reset()` is not
-  // mapped for ajs integrations
-  // analytics.js regenerates anonymousId if you call `.identify()` with a unique userId value different from the cache
-  if (this.initializedAnonymousId !== identify.anonymousId()) this.reset();
   if (identify.userId()) this._client.add_unique_user_id(identify.userId());
 
   // send common traits
@@ -160,22 +154,9 @@ MoEngage.prototype.identify = function(identify) {
  */
 
 MoEngage.prototype.track = function(track) {
-  // Important: MoEngage require you to manually call reset to wipe the unique id for the session
-  // if you don't do this and call add_unique_user_id w/ a different userId, it will overwrite the previous user's
-  // unique id and all their traits so we need to manually check if it's a new user since `analytics.reset()` is not
-  // mapped for ajs integrations
-  // analytics.js regenerates anonymousId if you call `.identify()` with a unique userId value different from the cache
-  if (this.initializedAnonymousId !== track.anonymousId()) this.reset();
   this._client.track_event(track.event(), track.properties());
 };
 
-/**
- * Reset
- *
- * @api public
- */
-
-MoEngage.prototype.reset = function() {
-  this.initializedAnonymousId = this.analytics.user().anonymousId();
-  this._client.destroy_session();
+MoEngage.prototype.alias = function(alias) {
+  if (alias.to()) this._client.update_unique_user_id(alias.to());
 };

--- a/integrations/moengage/test/index.test.js
+++ b/integrations/moengage/test/index.test.js
@@ -150,13 +150,7 @@ describe('MoEngage', function() {
             'The anonymous ID should be different after an identify call'
           );
         }
-        // analytics.called(moengage._client.destroy_session);
         analytics.called(moengage._client.add_unique_user_id, 'night king');
-        // if (moengage.initializedAnonymousId !== nightKingAnonId) {
-        //   throw new Error(
-        //     'MoEngange anonymous ID should be equal after an identify call'
-        //   );
-        // }
       });
 
       it('should not call destroy session if identify is called for a existing user', function() {
@@ -197,14 +191,6 @@ describe('MoEngage', function() {
         // Logout
         analytics.reset();
         analytics.track('The Song', properties);
-        // if (
-        //   moengage.initializedAnonymousId !== analytics.user().anonymousId()
-        // ) {
-        //   throw new Error(
-        //     'MoEngange anonymous ID should be equal after an identify call'
-        //   );
-        // }
-        // analytics.called(moengage._client.destroy_session);
       });
 
       it('should not call destroy session if track is called for a existing user', function() {
@@ -244,16 +230,5 @@ describe('MoEngage', function() {
       });
     });
 
-    // describe('#reset', function() {
-    //   beforeEach(function() {
-    //     analytics.stub(moengage._client, 'destroy_session');
-    //   });
-
-    //   it('should destroy session upon reset', function() {
-    //     analytics.identify('justin');
-    //     moengage.reset();
-    //     analytics.called(moengage._client.destroy_session);
-    //   });
-    // });
   });
 });

--- a/integrations/moengage/test/index.test.js
+++ b/integrations/moengage/test/index.test.js
@@ -150,13 +150,13 @@ describe('MoEngage', function() {
             'The anonymous ID should be different after an identify call'
           );
         }
-        analytics.called(moengage._client.destroy_session);
+        // analytics.called(moengage._client.destroy_session);
         analytics.called(moengage._client.add_unique_user_id, 'night king');
-        if (moengage.initializedAnonymousId !== nightKingAnonId) {
-          throw new Error(
-            'MoEngange anonymous ID should be equal after an identify call'
-          );
-        }
+        // if (moengage.initializedAnonymousId !== nightKingAnonId) {
+        //   throw new Error(
+        //     'MoEngange anonymous ID should be equal after an identify call'
+        //   );
+        // }
       });
 
       it('should not call destroy session if identify is called for a existing user', function() {
@@ -197,15 +197,14 @@ describe('MoEngage', function() {
         // Logout
         analytics.reset();
         analytics.track('The Song', properties);
-        if (
-          moengage.initializedAnonymousId !== analytics.user().anonymousId()
-        ) {
-          throw new Error(
-            'MoEngange anonymous ID should be equal after an identify call'
-          );
-        }
-        1;
-        analytics.called(moengage._client.destroy_session);
+        // if (
+        //   moengage.initializedAnonymousId !== analytics.user().anonymousId()
+        // ) {
+        //   throw new Error(
+        //     'MoEngange anonymous ID should be equal after an identify call'
+        //   );
+        // }
+        // analytics.called(moengage._client.destroy_session);
       });
 
       it('should not call destroy session if track is called for a existing user', function() {
@@ -223,16 +222,38 @@ describe('MoEngage', function() {
       });
     });
 
-    describe('#reset', function() {
+    describe('#alias', function() {
       beforeEach(function() {
-        analytics.stub(moengage._client, 'destroy_session');
+        analytics.stub(moengage._client, 'update_unique_user_id');
       });
-
-      it('should destroy session upon reset', function() {
-        analytics.identify('justin');
-        moengage.reset();
-        analytics.called(moengage._client.destroy_session);
+      it('should called update_unique_user_id on calling alias', function() {
+        analytics.alias(123);
+        analytics.called(moengage._client.update_unique_user_id);
+      });
+      it('should not called update_unique_user_id on calling alias without new ID', function() {
+        analytics.alias();
+        analytics.didNotCall(moengage._client.update_unique_user_id);
+      });
+      it('should called update_unique_user_id on calling alias with ID', function() {
+        analytics.alias(123);
+        analytics.called(moengage._client.update_unique_user_id, 123);
+      });
+      it('should not called update_unique_user_id on calling alias with wrong ID', function() {
+        analytics.alias(123);
+        analytics.didNotCall(moengage._client.update_unique_user_id, 1234);
       });
     });
+
+    // describe('#reset', function() {
+    //   beforeEach(function() {
+    //     analytics.stub(moengage._client, 'destroy_session');
+    //   });
+
+    //   it('should destroy session upon reset', function() {
+    //     analytics.identify('justin');
+    //     moengage.reset();
+    //     analytics.called(moengage._client.destroy_session);
+    //   });
+    // });
   });
 });


### PR DESCRIPTION
What does this PR do?
- it has bug fixes where reset was getting called when userID is passed
- alias method implemented

Are there breaking changes in this PR?
- No

Any background context you want to provide?
- We were expecting the `reset()` method to be available in integration and wrote the code accordingly. Now its causing unnecessary logout from our SDK on adding user IDs.

Is there parity with the server-side/android/iOS integration components (if applicable)?
- Not applicable

Does this require a new integration setting? If so, please explain how the new setting works - 
- No

Links to helpful docs and other external resources
- https://docs.moengage.com/docs/segment-websdk-integration

Why is this PR raised?
- There was an issue raised by a customer which was causing unnecessary logouts on MoEngage side and thus bloating the user counts in MoEngage

Are there any docs surrounding the change?
- https://docs.moengage.com/docs/segment-websdk-integration

What will the customer impact be as a result of the change?
- The customer experience will improve when integrating MoEngage and Segment as we will no longer create multiple users on login.

What will the customer impact be if the change is not implemented?
- The user count in MoEngage will bloat up when using Segment <> MoEngage integration and setting the user ID on identify.

Testing
- Testing completed successfully