### PR TITLE
[QF-9389] updated variable name for track only AB experiments setting

### DIFF
--- a/integrations/visual-website-optimizer/lib/index.js
+++ b/integrations/visual-website-optimizer/lib/index.js
@@ -29,7 +29,7 @@ var VWO = (module.exports = integration('Visual Website Optimizer')
   .option('listen', false)
   .option('experimentNonInteraction', false)
   .option('isSpa', false)
-  .option('trackOnlyABExperiments', false));
+  .option('trackOnlyAbExperiments', false));
 
 /**
  * The context for this integration.
@@ -135,7 +135,7 @@ VWO.prototype.roots = function() {
         context: { integration: integrationContext }
       });
     });
-  }, this.options.trackOnlyABExperiments);
+  }, this.options.trackOnlyAbExperiments);
 };
 
 /**
@@ -147,13 +147,13 @@ VWO.prototype.roots = function() {
  * @return {Object}
  */
 
-function rootExperiments(fn, trackOnlyABExperiments) {
+function rootExperiments(fn, trackOnlyAbExperiments) {
   enqueue(function() {
     var data = {};
     var experimentIds = window._vwo_exp_ids;
     if (!experimentIds) return fn();
     each(experimentIds, function(experimentId) {
-      var variationName = variation(experimentId, trackOnlyABExperiments);
+      var variationName = variation(experimentId, trackOnlyAbExperiments);
       if (variationName) data[experimentId] = variationName;
     });
     fn(null, data);
@@ -215,7 +215,7 @@ function isValidExperimentType(experiment) {
  * @return {String}
  */
 
-function variation(id, trackOnlyABExperiments) {
+function variation(id, trackOnlyAbExperiments) {
   var experiments = window._vwo_exp;
   if (!experiments) return null;
   var experiment = experiments[id];
@@ -227,8 +227,8 @@ function variation(id, trackOnlyABExperiments) {
   }
 
   if (
-    trackOnlyABExperiments &&
-    !isValidExperimentType(experiment, trackOnlyABExperiments)
+    trackOnlyAbExperiments &&
+    !isValidExperimentType(experiment, trackOnlyAbExperiments)
   ) {
     return null;
   }

--- a/integrations/visual-website-optimizer/package.json
+++ b/integrations/visual-website-optimizer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-visual-website-optimizer",
   "description": "The Visual Website Optimizer analytics.js integration.",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/visual-website-optimizer/package.json
+++ b/integrations/visual-website-optimizer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-visual-website-optimizer",
   "description": "The Visual Website Optimizer analytics.js integration.",
-  "version": "2.4.4",
+  "version": "2.4.3",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/visual-website-optimizer/test/index.test.js
+++ b/integrations/visual-website-optimizer/test/index.test.js
@@ -262,9 +262,9 @@ describe('Visual Website Optimizer', function() {
       });
     });
 
-    it('should not send experiments if experiment type is not of type A/B with trackOnlyABExperiments enabled', function(done) {
+    it('should not send experiments if experiment type is not of type A/B with trackOnlyAbExperiments enabled', function(done) {
       vwo.options.listen = true;
-      vwo.options.trackOnlyABExperiments = true;
+      vwo.options.trackOnlyAbExperiments = true;
       window._vwo_exp[1].type = 'testType';
       analytics.initialize();
       analytics.page();
@@ -292,7 +292,7 @@ describe('Visual Website Optimizer', function() {
       });
     });
 
-    it('should send experiments if experiment type is not of type A/B with trackOnlyABExperiments disabled', function(done) {
+    it('should send experiments if experiment type is not of type A/B with trackOnlyAbExperiments disabled', function(done) {
       vwo.options.listen = true;
       window._vwo_exp[1].type = 'testType';
       analytics.initialize();


### PR DESCRIPTION
**What does this PR do?**
The PR fixes a typo in the variable name for the Track only AB experiments setting.


**Are there breaking changes in this PR?**
No. Only a variable name is corrected, which was causing a setting to not work as expected.

**Testing**
<!---

All PRs must follow the process for change control as outlined in:
https://segment.atlassian.net/wiki/spaces/GRC/pages/453935287/Reinforcing+Change+Control

- Testing completed successfully using <how did you test, environment>; or
- Testing not required because <explain why you think testing isn't needed>
- CC-9389

--->
- Testing completed successfully using local file mapping to the Segment analytics.js file.

**Any background context you want to provide?**
NA

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
NA

**Does this require a new integration setting? If so, please explain how the new setting works**
No.

**Links to helpful docs and other external resources**
NA
