### PR TITLE
Add option to use amplitude referral behaviour

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "@segment/analytics.js-integration": "^3.3.3",
-    "domify": "1.4.1"
+    "domify": "1.4.1",
+    "is-email": "1.0.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8923,6 +8923,11 @@ is-email@0.1.0:
   resolved "https://registry.yarnpkg.com/is-email/-/is-email-0.1.0.tgz#e7eb1aefe8d4a3183980a7172b851272ebd04a95"
   integrity sha1-5+sa7+jUoxg5gKcXK4UScuvQSpU=
 
+is-email@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-email/-/is-email-1.0.2.tgz#51a618e2ddc895988ceb550df9f587b3607560e5"
+  integrity sha512-UojUgD2EhDTBQ2SGKwrK9edce5phRzgLsP+V5+Uu2Swi+uvjVXgH3zduM3HhT9iaC/9Kq19/TYUbP0jPoi6ioA==
+
 is-email@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-email/-/is-email-1.0.1.tgz#6f98c0ab6a0e3936dc4da7f2ab334f7faebbaa56"


### PR DESCRIPTION
**What does this PR do?**

In this PR https://github.com/segmentio/analytics.js-integrations/pull/73, we stopped using Amplitudes includeReferrer setting in order to avoid a bug with anonymousIds. However, this broke the option to only set a referrer once per session, as our integration has no concept of amplitudes sessions. Referrers are being set with every page even when the option to only set referrer once per session is enabled.

This PR adds an option to revert to the old behaviour, where we let Amplitude handle setting referrer once per session. The default of the option will be a non-breaking change for existing users.

**Are there breaking changes in this PR?**
No

**Testing**
<!---

All PRs must follow the process for change control as outlined in:
https://segment.atlassian.net/wiki/spaces/GRC/pages/453935287/Reinforcing+Change+Control

- Testing completed successfully using <how did you test, environment>; or
- Testing not required because <explain why you think testing isn't needed>

--->

Testing completed successfully locally (referrer not being overwritten):
![image](https://user-images.githubusercontent.com/2866515/137424481-43c0dc10-b58d-4d98-9230-11146bedba3b.png)
![image](https://user-images.githubusercontent.com/2866515/137424579-b2169d0c-0b05-45d1-a281-7eca2c353fd3.png)

**Any background context you want to provide?**


**Is there parity with the server-side/android/iOS integration components (if applicable)?**


**Does this require a new integration setting? If so, please explain how the new setting works**
Yes, explained above

**Links to helpful docs and other external resources**
