### PR TITLE
[STRATCONN-973] Add presence checks for marketo global objects for V2 integration

### DIFF
--- a/integrations/marketo-v2/HISTORY.md
+++ b/integrations/marketo-v2/HISTORY.md
@@ -1,3 +1,8 @@
+4.0.2 / 2021-10-26
+=================
+
+  * Add better error handling for when Marketo scripts are blocked
+
 4.0.0 / 2021-09-09
 =================
 

--- a/integrations/marketo-v2/lib/index.js
+++ b/integrations/marketo-v2/lib/index.js
@@ -133,6 +133,10 @@ Marketo.prototype.initialize = function() {
 
   var self = this;
   this.load(function() {
+    if (window.Munchkin === undefined) {
+      return;
+    }
+
     window.Munchkin.init(munchkinId, {
       asyncOnly: true
     });
@@ -146,6 +150,10 @@ Marketo.prototype.initialize = function() {
   });
 
   this.load('forms', { marketoHostUrl: marketoHostUrl }, function() {
+    if (window.MktoForms2 === undefined) {
+      return;
+    }
+
     var marketoForm = document.createElement('form');
     marketoForm.setAttribute('id', 'mktoForm_' + marketoFormId);
     marketoForm.setAttribute('style', 'display:none');
@@ -185,6 +193,11 @@ Marketo.prototype.page = function(page) {
 
   var properties = page.properties();
   var parsed = url.parse(properties.url);
+
+  if (window.mktoMunchkinFunction === undefined) {
+    return;
+  }
+
   window.mktoMunchkinFunction('visitWebPage', {
     url: properties.url,
     params: parsed.query
@@ -272,6 +285,10 @@ Marketo.prototype.identify = function(identify) {
       traitsToSendMarketo[marketoField] = traits[segmentTrait];
     }
   }, settings.traits);
+
+  if (window.MktoForms2 === undefined) {
+    return;
+  }
 
   window.MktoForms2.whenReady(function(form) {
     var marketoFormId = parseInt(settings.marketoFormId, 10);

--- a/integrations/marketo-v2/package.json
+++ b/integrations/marketo-v2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-marketo-v2",
   "description": "The Marketo analytics.js integration.",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",


### PR DESCRIPTION
**What does this PR do?**

Checks if the Marketo global objects are defined and gracefully ends execution of the Segment calls if the objects are not defined.

**Are there breaking changes in this PR?**

No.

**Testing**

- Testing completed successfully using localhost using the sources compiler pointing to a Stage source.

![Screen Shot 2021-11-01 at 3 51 00 PM](https://user-images.githubusercontent.com/316711/139752817-3cb1c068-bc15-4d71-be1e-9b33200ec177.png)

![Screen Shot 2021-11-01 at 3 57 27 PM](https://user-images.githubusercontent.com/316711/139752877-95f26cf4-50db-4ec3-ac6a-b3dc20b8b8cd.png)



**Any background context you want to provide?**

https://segment.atlassian.net/jira/software/c/projects/STRATCONN/boards/310?modal=detail&selectedIssue=STRATCONN-973
