### PR TITLE
Fix VWO setting name

### DIFF
--- a/integrations/visual-website-optimizer/lib/index.js
+++ b/integrations/visual-website-optimizer/lib/index.js
@@ -29,7 +29,7 @@ var VWO = (module.exports = integration('Visual Website Optimizer')
   .option('listen', false)
   .option('experimentNonInteraction', false)
   .option('isSpa', false)
-  .option('trackOnlyABExperiments', false));
+  .option('trackOnlyAbExperiments', false));
 
 /**
  * The context for this integration.
@@ -139,7 +139,7 @@ VWO.prototype.roots = function() {
         experimentsTracked[experimentId] = true;
       }
     });
-  }, this.options.trackOnlyABExperiments);
+  }, this.options.trackOnlyAbExperiments);
 };
 
 /**
@@ -151,13 +151,13 @@ VWO.prototype.roots = function() {
  * @return {Object}
  */
 
-function rootExperiments(fn, trackOnlyABExperiments) {
+function rootExperiments(fn, trackOnlyAbExperiments) {
   enqueue(function() {
     var data = {};
     var experimentIds = window._vwo_exp_ids;
     if (!experimentIds) return fn();
     each(experimentIds, function(experimentId) {
-      var variationName = variation(experimentId, trackOnlyABExperiments);
+      var variationName = variation(experimentId, trackOnlyAbExperiments);
       if (variationName) data[experimentId] = variationName;
     });
     fn(null, data);
@@ -219,7 +219,7 @@ function isValidExperimentType(experiment) {
  * @return {String}
  */
 
-function variation(id, trackOnlyABExperiments) {
+function variation(id, trackOnlyAbExperiments) {
   var experiments = window._vwo_exp;
   if (!experiments) return null;
   var experiment = experiments[id];
@@ -231,8 +231,8 @@ function variation(id, trackOnlyABExperiments) {
   }
 
   if (
-    trackOnlyABExperiments &&
-    !isValidExperimentType(experiment, trackOnlyABExperiments)
+    trackOnlyAbExperiments &&
+    !isValidExperimentType(experiment, trackOnlyAbExperiments)
   ) {
     return null;
   }

--- a/integrations/visual-website-optimizer/test/index.test.js
+++ b/integrations/visual-website-optimizer/test/index.test.js
@@ -262,9 +262,9 @@ describe('Visual Website Optimizer', function() {
       });
     });
 
-    it('should not send experiments if experiment type is not of type A/B with trackOnlyABExperiments enabled', function(done) {
+    it('should not send experiments if experiment type is not of type A/B with trackOnlyAbExperiments enabled', function(done) {
       vwo.options.listen = true;
-      vwo.options.trackOnlyABExperiments = true;
+      vwo.options.trackOnlyAbExperiments = true;
       window._vwo_exp[1].type = 'testType';
       analytics.initialize();
       analytics.page();
@@ -292,7 +292,7 @@ describe('Visual Website Optimizer', function() {
       });
     });
 
-    it('should send experiments if experiment type is not of type A/B with trackOnlyABExperiments disabled', function(done) {
+    it('should send experiments if experiment type is not of type A/B with trackOnlyAbExperiments disabled', function(done) {
       vwo.options.listen = true;
       window._vwo_exp[1].type = 'testType';
       analytics.initialize();


### PR DESCRIPTION
**What does this PR do?**
This PR fixes the misspelled VWO setting, "trackOnlyAbExperiments"
![image](https://user-images.githubusercontent.com/2866515/141180492-9fab5ef5-c2fd-4ed3-9c0e-8ec15856254c.png)
(from https://github.com/segmentio/analytics.js-integrations/pull/633)
**Are there breaking changes in this PR?**
N/A

**Testing**
Testing not required, fixing broken setting with typo
--->


**Any background context you want to provide?**


**Is there parity with the server-side/android/iOS integration components (if applicable)?**


**Does this require a new integration setting? If so, please explain how the new setting works**


**Links to helpful docs and other external resources**
