### PR TITLE
Adding secure cookie option

### DIFF
--- a/integrations/google-analytics/HISTORY.md
+++ b/integrations/google-analytics/HISTORY.md
@@ -1,3 +1,8 @@
+2.18.6 / 2021-11-29
+===================
+
+* Adds the option to set secure cookies by using cookieFlags
+
 2.18.4 / 2020-12-14
 ===================
 

--- a/integrations/google-analytics/lib/index.js
+++ b/integrations/google-analytics/lib/index.js
@@ -63,6 +63,7 @@ var GA = (exports.Integration = integration('Google Analytics')
   .option('optimize', '')
   .option('nameTracker', false)
   .option('resetCustomDimensionsOnPage', [])
+  .option('secureCookie', false)
   .tag('library', '<script src="//www.google-analytics.com/analytics.js">')
   .tag('double click', '<script src="//stats.g.doubleclick.net/dc.js">')
   .tag('http', '<script src="http://www.google-analytics.com/ga.js">')
@@ -129,6 +130,11 @@ GA.prototype.initialize = function() {
     allowLinker: true,
     useAmpClientId: opts.useGoogleAmpClientId
   };
+
+  // set secure cookies
+  if(opts.secureCookie) {
+    config.cookieFlags = 'SameSite=None;Secure'
+  }
 
   // set tracker name to avoid collisions with unnamed third party trackers
   if (opts.nameTracker) {

--- a/integrations/google-analytics/package.json
+++ b/integrations/google-analytics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-google-analytics",
   "description": "The Google Analytics analytics.js integration.",
-  "version": "2.18.5",
+  "version": "2.18.6",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/google-analytics/test/index.test.js
+++ b/integrations/google-analytics/test/index.test.js
@@ -59,6 +59,7 @@ describe('Google Analytics', function() {
         .option('nameTracker', false)
         .option('sampleRate', 100)
         .option('resetCustomDimensionsOnPage', [])
+        .option('secureCookie', false)
     );
   });
 
@@ -650,6 +651,25 @@ describe('Google Analytics', function() {
             page: window.location.pathname,
             title: document.title
           });
+        });
+
+        it('should add cookieFlags if secureCookie is true', function() {
+          ga.options.secureCookie = true;
+          analytics.initialize();
+          analytics.assert(
+            window.ga.args[0][2].cookieFlags === 'SameSite=None;Secure'
+          );
+        });
+
+        it('should add not add cookieFlags if secureCookie is false', function() {
+          ga.options.secureCookie = false;
+          analytics.initialize();
+          analytics.assert(window.ga.args[0][2].cookieFlags === undefined);
+        });
+
+        it('should add not add cookieFlags if secureCookie is not declared', function() {
+          analytics.initialize();
+          analytics.assert(window.ga.args[0][2].cookieFlags === undefined);
         });
       });
 


### PR DESCRIPTION
**What does this PR do?**
Adds an option to set secure cookies

**Are there breaking changes in this PR?**
No

**Testing**
Tested locally and wrote some tests to make sure the option flag works. The checkmark represents a secure cookie.
<img width="1041" alt="Screen Shot 2021-11-29 at 1 35 39 PM" src="https://user-images.githubusercontent.com/95248791/143939272-be7647a9-5504-468b-8f8f-53932fd5f979.png">



**Any background context you want to provide?**
Some third-party auditing tools require to have sites only set secure cookies. This will add the option to control this setting when installing the google-analytics tag. This is already supported by the tag. 

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
NA

**Does this require a new integration setting? If so, please explain how the new setting works**
Yes, the `secureCookie` option will allow the tag to set secure google analytics cookies if set to true. 

**Links to helpful docs and other external resources**
How to setup a secure cookie in google analytics https://developers.google.com/analytics/devguides/collection/analyticsjs/cookies-user-id