### PR TITLE
add support for set_once

### DIFF
--- a/integrations/mixpanel/HISTORY.md
+++ b/integrations/mixpanel/HISTORY.md
@@ -1,3 +1,8 @@
+
+3.2.2 / 2022-01-03
+==================
+* Added support for `set_once` properties.
+
 3.1.0 / 2019-09-27
 ==================
   * Added support for groups.

--- a/integrations/mixpanel/package.json
+++ b/integrations/mixpanel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-mixpanel",
   "description": "The Mixpanel analytics.js integration.",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/mixpanel/test/index.test.js
+++ b/integrations/mixpanel/test/index.test.js
@@ -196,6 +196,7 @@ describe('Mixpanel', function() {
         analytics.stub(window.mixpanel, 'name_tag');
         analytics.stub(window.mixpanel.people, 'set');
         analytics.stub(window.mixpanel.people, 'union');
+        analytics.stub(window.mixpanel.people, 'set_once');
       });
 
       it('should send an id', function() {
@@ -391,6 +392,21 @@ describe('Mixpanel', function() {
         });
         analytics.called(window.mixpanel.people.union, {
           pages_visited: ['homepage']
+        });
+      });
+
+      it('should set property once', function() {
+        mixpanel.options.setOnceProperties = ['signup_date'];
+        mixpanel.options.people = true;
+        analytics.identify({
+          signup_date: '123',
+          plan: 'free'
+        });
+        analytics.called(window.mixpanel.people.set_once, {
+          signup_date: '123'
+        });
+        analytics.called(window.mixpanel.people.set, {
+          plan: 'free'
         });
       });
     });


### PR DESCRIPTION
**What does this PR do?**
Adds support for mixpanel.people.set_once (https://developer.mixpanel.com/docs/javascript-full-api-reference#mixpanelpeopleset_once)

**Are there breaking changes in this PR?**
No

**Testing**
Mocha tests added

**Any background context you want to provide?**
Adds support for set properties once on a Mixpanel person.

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
N/A

**Does this require a new integration setting? If so, please explain how the new setting works**
Yes,  setOnceProperties (array)

**Links to helpful docs and other external resources**
https://developer.mixpanel.com/docs/javascript-full-api-reference#mixpanelpeopleset_once
