### PR TITLE
support Totango EU services

### DIFF
--- a/integrations/totango/lib/index.js
+++ b/integrations/totango/lib/index.js
@@ -44,10 +44,14 @@ Totango.prototype.initialize = function(page) {
     track:function(t,o,n,a){window.totango_tmp_stack.push({activity:t,module:o,org:n,user:a}); return -1;}};
   /* eslint-enable */
 
+  /* Int Totango JS */
+  var defaultRegion = 'us'
+  var selected_region = this.options.region ?  this.options.region : defaultRegion; 
   window.totango_options = {
     allow_empty_accounts: false,
     service_id: this.options.serviceId,
     disable_heartbeat: this.options.disableHeartbeat,
+    region: selected_region,
     module: page.category()
   };
 


### PR DESCRIPTION
**Note: This change needed to be supported with a new selection option, region, with the values "us" or "eu1"**


**What does this PR do?**
adding region field to Totango init. 


**Are there breaking changes in this PR?**
no

**Testing**
<!---

All PRs must follow the process for change control as outlined in:
https://segment.atlassian.net/wiki/spaces/GRC/pages/453935287/Reinforcing+Change+Control

- Testing completed successfully using <how did you test, environment>; or
- Testing not required because <explain why you think testing isn't needed>

--->


**Any background context you want to provide?**


**Is there parity with the server-side/android/iOS integration components (if applicable)?**


**Does this require a new integration setting? If so, please explain how the new setting works**


**Links to helpful docs and other external resources**
