### PR TITLE
support Totango EU services (replace PR#650 per Pooyaj comment)

### DIFF
--- a/integrations/totango/lib/index.js
+++ b/integrations/totango/lib/index.js
@@ -23,6 +23,7 @@ var Totango = (module.exports = integration('Totango')
   .option('serviceId', null)
   .option('trackNamedPages', true)
   .option('trackCategorizedPages', true)
+  .option('region', 'us')
   .tag('<script src="//tracker.totango.com/totango4.0.3.js">'));
 
 /**
@@ -47,6 +48,7 @@ Totango.prototype.initialize = function(page) {
   window.totango_options = {
     allow_empty_accounts: false,
     service_id: this.options.serviceId,
+    region: this.options.region,
     disable_heartbeat: this.options.disableHeartbeat,
     module: page.category()
   };


### PR DESCRIPTION
This change needed to be supported with a new selection option, region, with the values "us" or "eu1"


**What does this PR do?**
Added support for Totango EU services.

**Are there breaking changes in this PR?**
No.

**Testing**
<!---

All PRs must follow the process for change control as outlined in:
https://segment.atlassian.net/wiki/spaces/GRC/pages/453935287/Reinforcing+Change+Control

- Testing completed successfully using <how did you test, environment>; or
- Testing not required because <explain why you think testing isn't needed>

--->


**Any background context you want to provide?**


**Is there parity with the server-side/android/iOS integration components (if applicable)?**


**Does this require a new integration setting? If so, please explain how the new setting works**


**Links to helpful docs and other external resources**
