### PR TITLE
fix(ShareASale): Updates integration to submit subtotal correctly.

### DIFF
--- a/integrations/shareasale/HISTORY.md
+++ b/integrations/shareasale/HISTORY.md
@@ -1,3 +1,13 @@
+2.2.3 / 2020-01-26
+===================
+
+  * Correct subtotal logic to match oder completed schema documentation.
+
+2.2.2 / 2021-06-03
+===================
+
+  * Pins @segment/analytics.js-integration
+
 2.2.1 / 2020-12-14
 ===================
 

--- a/integrations/shareasale/lib/index.js
+++ b/integrations/shareasale/lib/index.js
@@ -40,7 +40,7 @@ ShareASale.prototype.orderCompleted = function(track) {
   var orderTotal =
     this.options.useTotalAsAmount && track.total()
       ? track.total().toFixed(2)
-      : (subtotal - discount).toFixed(2);
+      : subtotal.toFixed(2);
   var products = track.products();
   var currency = track.currency() || this.options.currency;
   var coupon = track.coupon() || '';

--- a/integrations/shareasale/lib/index.js
+++ b/integrations/shareasale/lib/index.js
@@ -36,7 +36,6 @@ ShareASale.prototype.orderCompleted = function(track) {
   var orderId = track.orderId();
   var isRepeat = track.proxy('properties.repeat');
   var subtotal = (track.subtotal() || 0).toFixed(2);
-  var discount = (track.discount() || 0).toFixed(2);
   var orderTotal =
     this.options.useTotalAsAmount && track.total()
       ? track.total().toFixed(2)

--- a/integrations/shareasale/package.json
+++ b/integrations/shareasale/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-shareasale",
   "description": "The Shareasale analytics.js integration.",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/shareasale/test/index.test.js
+++ b/integrations/shareasale/test/index.test.js
@@ -152,7 +152,7 @@ describe('ShareASale', function() {
         );
       });
 
-      it('should calculate order total from subtotal including discount', function() {
+      it('should calculate order total from subtotal not including discount', function() {
         analytics.track('order completed', {
           orderId: 123,
           discount: 5,
@@ -161,7 +161,7 @@ describe('ShareASale', function() {
           subtotal: 55.5
         });
         analytics.loaded(
-          '<img src="https://shareasale.com/sale.cfm?amount=50.50&tracking=123&transtype=sale&merchantID=bonobos&skulist=&quantitylist=&pricelist=&currency=USD&couponcode=">'
+          '<img src="https://shareasale.com/sale.cfm?amount=55.50&tracking=123&transtype=sale&merchantID=bonobos&skulist=&quantitylist=&pricelist=&currency=USD&couponcode=">'
         );
       });
 

--- a/integrations/shareasale/test/index.test.js
+++ b/integrations/shareasale/test/index.test.js
@@ -152,7 +152,7 @@ describe('ShareASale', function() {
         );
       });
 
-      it('should calculate order total from subtotal not including discount', function() {
+      it('should calculate order total from subtotal', function() {
         analytics.track('order completed', {
           orderId: 123,
           discount: 5,


### PR DESCRIPTION
**What does this PR do?**

Per the [order completed schema documentation](https://segment.com/docs/connections/spec/ecommerce/v2/#order-completed), the `subtotal` property is the "Order total after discounts but before taxes and shipping", so the discount should already be removed before the subtotal is submitted with this trigger event.


**Are there breaking changes in this PR?**
No.

**Testing**

- Testing completed successfully. Existing tests have been updated to reflect the correct behavior.

**Any background context you want to provide?**
The current implementation causes the subtotal to have the discount removed from the subtotal twice. Once as part of the order completed event schema, and once in the Share a Sale integration. 

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
No.

**Does this require a new integration setting? If so, please explain how the new setting works**
No.

**Links to helpful docs and other external resources**
[Order completed schema documentation](https://segment.com/docs/connections/spec/ecommerce/v2/#order-completed)
[Share a Sale integration documentation](https://segment.com/docs/connections/destinations/catalog/shareasale/) - This documentation has been updated via this PR: https://github.com/segmentio/segment-docs/pull/2396