### PR TITLE
[STRATCONN-1076] Add deprecation notice to Adobe Target

### DIFF
--- a/integrations/adobe-target/README.md
+++ b/integrations/adobe-target/README.md
@@ -1,6 +1,8 @@
-# analytics.js-integration-adobe-target [![Build Status][ci-badge]][ci-link]
+# analytics.js-integration-adobe-target
 
-Adobe Target integration for [Analytics.js][].
+# Deprecation Notice 🚨
+
+This integration has been deprecated in favor of [Actions Adobe Target Web](https://github.com/segmentio/action-destinations/tree/main/packages/browser-destinations/src/destinations/adobe-target). No further development or support will be provided.
 
 ## License
 
@@ -8,5 +10,3 @@ Released under the [MIT license](LICENSE).
 
 
 [Analytics.js]: https://segment.com/docs/libraries/analytics.js/
-[ci-link]: https://ci.segment.com/gh/segment-integrations/analytics.js-integration-adobe-target
-[ci-badge]: https://ci.segment.com/gh/segment-integrations/analytics.js-integration-adobe-target.svg?style=svg

--- a/integrations/adobe-target/lib/index.js
+++ b/integrations/adobe-target/lib/index.js
@@ -1,6 +1,11 @@
 'use strict';
 
 /**
+ * Deprecation Notice 🚨
+ * This integration has been deprecated in favor of [Actions Adobe Target Web](https://github.com/segmentio/action-destinations/tree/main/packages/browser-destinations/src/destinations/adobe-target). No further development or support will be provided.
+ */
+
+/**
  * Module dependencies.
  */
 

--- a/integrations/adobe-target/test/index.test.js
+++ b/integrations/adobe-target/test/index.test.js
@@ -1,5 +1,10 @@
 'use strict';
 
+/**
+ * Deprecation Notice 🚨
+ * This integration has been deprecated in favor of [Actions Adobe Target Web](https://github.com/segmentio/action-destinations/tree/main/packages/browser-destinations/src/destinations/adobe-target). No further development or support will be provided.
+ */
+
 var Analytics = require('@segment/analytics.js-core').constructor;
 var tester = require('@segment/analytics.js-integration-tester');
 var sandbox = require('@segment/clear-env');


### PR DESCRIPTION
**What does this PR do?**

Add a deprecation warning to the Adobe Target integration.


**Are there breaking changes in this PR?**

No, no customers are using this integration.

**Testing**

- Testing not required because this only adds comments into the codebase.


**Any background context you want to provide?**

StratConn is building a new target destination in actions, that's why we are marking this as deprecated.

