### PR TITLE
Don't overwrite $crisp array when initializing.

### DIFF
--- a/integrations/crisp/lib/index.js
+++ b/integrations/crisp/lib/index.js
@@ -34,7 +34,7 @@ Crisp.prototype.initialize = function() {
  */
 Crisp.prototype.load = function(done) {
   window.CRISP_WEBSITE_ID = this.options.websiteId;
-  window.$crisp = [];
+  window.$crisp = window.$crisp || [];
 
   var script = document.createElement('script');
   script.src = 'https://client.crisp.chat/l.js';


### PR DESCRIPTION
**What does this PR do?**
Currently there is no way to call crisp methods since when the integration loads it overwrites the $crisp array.

This PR update the integration to leave the $crisp array alone if its exists similar to how its done for [google analytics](https://github.com/segmentio/analytics.js-integrations/blob/79d4aedbf04fddf95f997ab6a7682b0c0226b371/integrations/google-analytics-4/lib/index.js#L62) (and others)

**Are there breaking changes in this PR?**

NO

**Testing**
<!---

All PRs must follow the process for change control as outlined in:
https://segment.atlassian.net/wiki/spaces/GRC/pages/453935287/Reinforcing+Change+Control

- Testing completed successfully using <how did you test, environment>; or
- Testing not required because <explain why you think testing isn't needed>

--->

I cant access the [link](https://segment.atlassian.net/wiki/spaces/GRC/pages/453935287/Reinforcing+Change+Control) provided, however I don't think testing is needed for this change.


**Any background context you want to provide?**


**Is there parity with the server-side/android/iOS integration components (if applicable)?**
Not applicable

**Does this require a new integration setting? If so, please explain how the new setting works**
No new setting required

**Links to helpful docs and other external resources**
