### PR TITLE
Chameleon: Add config for fastUrl and pass integration-specific options to identify.

### DIFF
--- a/integrations/chameleon/lib/index.js
+++ b/integrations/chameleon/lib/index.js
@@ -5,6 +5,7 @@
  */
 
 var integration = require('@segment/analytics.js-integration');
+var extend = require('@ndhoule/extend');
 
 /**
  * Expose `Chameleon` integration.
@@ -15,8 +16,9 @@ var Chameleon = (module.exports = integration('Chameleon')
   .readyOnLoad()
   .global('chmln')
   .option('apiKey', null)
+  .option('fastUrl', 'https://fast.trychameleon.com/')
   .tag(
-    '<script src="https://fast.trychameleon.com/messo/{{apiKey}}/messo.min.js"></script>'
+    '<script src="{{fastUrl}}messo/{{apiKey}}/messo.min.js"></script>'
   ));
 
 /**
@@ -27,7 +29,7 @@ var Chameleon = (module.exports = integration('Chameleon')
 
 Chameleon.prototype.initialize = function() {
   /* eslint-disable */
-  var that=this;!function(){var c=(window.chmln||(window.chmln={}));if(c.root){return;}c.location=window.location.href.toString();c.accountToken=that.options.apiKey;var names='setup identify alias track set show on off custom help _data'.split(' ');for(var i=0;i<names.length;i++){(function(){var t=c[names[i]+'_a']=[];c[names[i]]=function(){t.push(arguments);};})()}}();
+  var that=this;!function(){var c=(window.chmln||(window.chmln={}));if(c.root){return;}c.location=window.location.href.toString();c.accountToken=that.options.apiKey;c.fastUrl=that.options.fastUrl;var names='setup identify alias track set show on off custom help _data'.split(' ');for(var i=0;i<names.length;i++){(function(){var t=c[names[i]+'_a']=[];c[names[i]]=function(){t.push(arguments);};})()}}();
   /* eslint-enable */
 
   this.ready();
@@ -54,9 +56,11 @@ Chameleon.prototype.loaded = function() {
 
 Chameleon.prototype.identify = function(identify) {
   var traits = identify.traits();
+  var opts = identify.options(this.name);
+
   delete traits.id;
 
-  window.chmln.identify(identify.userId(), traits);
+  window.chmln.identify(identify.userId(), extend(traits, opts));
 };
 
 /**

--- a/integrations/chameleon/test/index.test.js
+++ b/integrations/chameleon/test/index.test.js
@@ -33,11 +33,6 @@ describe('Chameleon', function() {
     sandbox();
   });
 
-  // FIXME: Chameleon freaks out after tests run
-  after(function() {
-    window.chmln = function() {};
-  });
-
   it('should have the right settings', function() {
     analytics.compare(
       Chameleon,
@@ -46,6 +41,8 @@ describe('Chameleon', function() {
         .readyOnLoad()
         .global('chmln')
         .option('apiKey', null)
+        .option('fastUrl', 'https://fast.trychameleon.com/')
+        .tag('<script src="{{fastUrl}}messo/{{apiKey}}/messo.min.js"></script>')
     );
   });
 
@@ -164,6 +161,16 @@ describe('Chameleon', function() {
       it('should send the given id and traits', function() {
         analytics.identify('id', { trait: true });
         analytics.called(window.chmln.identify, 'id', { trait: true });
+      });
+
+      it('should send the given id, traits, and options', function() {
+        analytics.identify('id', { trait: true }, { Chameleon: { uid_hash: 'id-h' } });
+        analytics.called(window.chmln.identify, 'id', { trait: true, uid_hash: 'id-h' });
+      });
+
+      it('should send the given id, traits, and nested-options', function() {
+        analytics.identify('id', { trait: 2 }, { integrations: { Chameleon: { uid_hash: 'id-h' } } });
+        analytics.called(window.chmln.identify, 'id', { trait: 2, uid_hash: 'id-h' });
       });
     });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "analytics.js-integrations",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "index.js",
   "repository": "https://github.com/segmentio/analytics.js-integrations.git",
   "author": "Segment",


### PR DESCRIPTION
**What does this PR do?**

In this PR we're adding two main things:

1. Add a new configuration variable `fastUrl` that allows our customers to configure and use a first-party domain to run Chameleon.
2. Now merge "Integration-specific-args" sent via identify in with properties sent the normal way. This allows Chameleon [Identity Verification](https://help.chameleon.io/en/articles/4281577-using-identity-verification-secure-mode) to be enabled with a simplified approach (similar to how Intercom handles identity verification / secure mode).

```
# with integration-specific args
analytics.identify(12, { one: 1 }, { Chameleon: { uid_hash: '12-hash' } });

# now translates to Chameleon as this
chmln.identify(12, { one: 1, uid_hash: '12-hash' })
```


**Are there breaking changes in this PR?**
There are no breaking changes 👍 


**Testing**
1. We've updated the unit tests to cover the specific cases we have changed in this PR. 
2. `fastUrl` defaults to the same value as the static string that was previously hardcoded within.
3. We've tested that similar calls with integration-specific-args to Intercom is working properly; we used the same method to extract the integration-specific-args.


**Does this require a new integration setting? If so, please explain how the new setting works**
A new configuration setting called `fastUrl` is added in the PR. The new setting allows our customers to run Chameleon from their own (first party) domain name. For example, they could run Chameleon from `https://chameleon.acme.co/` assuming their application was running on `app.acme.co`. This new variable should be configured to have the protocol and a trailing slash.

In the preceding example fastUrl would be configured as `https://chameleon.acme.co/` w/ the trailing slash.