### PR TITLE
Incorporate changes for fastUrl. Update version to 2.0.3

### DIFF
--- a/integrations/chameleon/HISTORY.md
+++ b/integrations/chameleon/HISTORY.md
@@ -1,3 +1,14 @@
+2.0.3 / 2022-06-22
+==================
+
+* Update version to 2.0.3
+
+2.0.2 / 2022-05-16
+==================
+
+* Add configuration for connecting to a custom endpoint (fastUrl).
+* Pass integrations-specific arguments through to identify.
+
 2.0.1 / 2017-06-14
 ==================
 

--- a/integrations/chameleon/package.json
+++ b/integrations/chameleon/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-chameleon",
   "description": "The Chameleon analytics.js integration.",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",


### PR DESCRIPTION
**What does this PR do?**
Updates Chameleon to 2.0.3 to incorporate changes from 2.0.2

**Are there breaking changes in this PR?**
Nope

Testing not required as this is a version bump. 