### PR TITLE
add support for snake_case for contentAssetId in Adobe Heartbeat

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch Chrome",
+            "type": "chrome",
+            "request": "launch",
+            "url": "http://localhost:8080/"
+        },
+    ]
+}

--- a/integrations/adobe-analytics/HISTORY.md
+++ b/integrations/adobe-analytics/HISTORY.md
@@ -1,3 +1,8 @@
+1.16.6 / 2022-07-26
+===================
+* Drop support for `assetId` for `StandardVideoMetadata`
+* Add support for `content_asset_id` for `StandardVideoMetadata`
+
 1.16.5 / 2022-02-15
 ===================
 * Bump @segment/trample to ^0.2.1.

--- a/integrations/adobe-analytics/lib/index.js
+++ b/integrations/adobe-analytics/lib/index.js
@@ -1501,7 +1501,7 @@ function createStandardVideoMetadata(track, mediaObj) {
   adbSegMap[metaKeys.SHOW] = ["program"],
   adbSegMap[metaKeys.SEASON] = ["season"],
   adbSegMap[metaKeys.EPISODE] = ["episode"],
-  adbSegMap[metaKeys.ASSET_ID] = [ "content_asset_id", "contentAssetId"],
+  adbSegMap[metaKeys.ASSET_ID] = ["contentAssetId", "content_asset_id"],
   adbSegMap[metaKeys.GENRE] = ["genre"],
   adbSegMap[metaKeys.FIRST_AIR_DATE] = ["airdate"],
   adbSegMap[metaKeys.ORIGINATOR] = ["publisher"],

--- a/integrations/adobe-analytics/lib/index.js
+++ b/integrations/adobe-analytics/lib/index.js
@@ -1497,23 +1497,30 @@ function createStandardVideoMetadata(track, mediaObj) {
   var props = track.properties();
   var metaKeys = videoAnalytics.MediaHeartbeat.VideoMetadataKeys;
   var stdVidMeta = {};
-  var segAdbMap = {
-    program: metaKeys.SHOW,
-    season: metaKeys.SEASON,
-    episode: metaKeys.EPISODE,
-    assetId: metaKeys.ASSET_ID,
-    contentAssetId: metaKeys.ASSET_ID,
-    genre: metaKeys.GENRE,
-    airdate: metaKeys.FIRST_AIR_DATE,
-    publisher: metaKeys.ORIGINATOR,
-    channel: metaKeys.NETWORK,
-    rating: metaKeys.RATING
-  };
+  var adbSegMap = {}
+  adbSegMap[metaKeys.SHOW] = ["program"],
+  adbSegMap[metaKeys.SEASON] = ["season"],
+  adbSegMap[metaKeys.EPISODE] = ["episode"],
+  adbSegMap[metaKeys.ASSET_ID] = [ "content_asset_id", "contentAssetId"],
+  adbSegMap[metaKeys.GENRE] = ["genre"],
+  adbSegMap[metaKeys.FIRST_AIR_DATE] = ["airdate"],
+  adbSegMap[metaKeys.ORIGINATOR] = ["publisher"],
+  adbSegMap[metaKeys.NETWORK] = ["channel"],
+  adbSegMap[metaKeys.RATING] = ["rating"]
 
-  // eslint-disable-next-line
-  for (var prop in segAdbMap) {
-    // If the property exists on the Segment object, set the Adobe metadata key to that value.
-    stdVidMeta[segAdbMap[prop]] = props[prop] || 'no ' + segAdbMap[prop];
+  // Iterate over each Adobe property and check our props to see if the corresponding Segment property exists.
+  for (var adbProp in adbSegMap) {
+    for (var i = 0; i < adbSegMap[adbProp].length; i++) {
+      var segProp = adbSegMap[adbProp][i];
+      if (props[segProp]) {
+        stdVidMeta[adbProp] = props[segProp];
+        break;
+      }
+    }
+
+    if (!stdVidMeta[adbProp]) {
+      stdVidMeta[adbProp] = 'no ' + adbProp
+    }
   }
 
   mediaObj.setValue(

--- a/integrations/adobe-analytics/package.json
+++ b/integrations/adobe-analytics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-adobe-analytics",
   "description": "The Adobe Analytics analytics.js integration.",
-  "version": "1.16.5",
+  "version": "1.16.6",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/adobe-analytics/test/index.test.js
+++ b/integrations/adobe-analytics/test/index.test.js
@@ -1654,6 +1654,27 @@ describe('Adobe Analytics', function() {
         );
       });
 
+      it('should prefer snake_case over camelCase for contentAssetId', function() {
+        var contentAssetIdValue = 'Good Value';
+        analytics.track('Video Playback Started', {
+          session_id: sessionId,
+          channel: 'Black Mesa',
+          video_player: 'Transit Announcement System',
+          playhead: 5,
+          content_asset_id: contentAssetIdValue,
+          contentAssetId: 'wrong value',
+          title: 'Half-Life',
+          total_length: 1260,
+          livestream: false
+        });
+
+        analytics.equal(
+          contentAssetIdValue,
+          adobeAnalytics.mediaHeartbeats[sessionId].heartbeat._aaPlugin
+            ._videoMetadata['a.media.asset']
+        );
+      });
+
       it('should call trackPause when a video is paused', function() {
         analytics.track('Video Playback Started', {
           session_id: sessionId,

--- a/integrations/adobe-analytics/test/index.test.js
+++ b/integrations/adobe-analytics/test/index.test.js
@@ -1654,15 +1654,15 @@ describe('Adobe Analytics', function() {
         );
       });
 
-      it('should prefer snake_case over camelCase for contentAssetId', function() {
+      it('should prefer camelCase over snake_case for contentAssetId', function() {
         var contentAssetIdValue = 'Good Value';
         analytics.track('Video Playback Started', {
           session_id: sessionId,
           channel: 'Black Mesa',
           video_player: 'Transit Announcement System',
           playhead: 5,
-          content_asset_id: contentAssetIdValue,
-          contentAssetId: 'wrong value',
+          content_asset_id: 'wrong value',
+          contentAssetId: contentAssetIdValue,
           title: 'Half-Life',
           total_length: 1260,
           livestream: false


### PR DESCRIPTION
**What does this PR do?**
* Drop support for `assetId` for `StandardVideoMetadata` in Adobe Heartbeat
* Add support for `content_asset_id` for `StandardVideoMetadata` in Adobe Heartbeat

**Are there breaking changes in this PR?**

The removal of `assetId` from `StandardVideoMetadata` cannot be considered a breaking change given that the value was always overriden by `content_asset_id`, even if undefined. See for more details:  https://segment.atlassian.net/browse/STRATCONN-1491

**Testing**

Testing completed successfully using the `tester` page by stepping through debugger on the `createStandardVideoMetadata` function and making sure that

 ```analytics.track("video playback started", {assetId: "content-asset-id"})```

did not populate the media asset id while

 ```analytics.track("video playback started", {content-asset-id: "content-asset-id"})```

did successfully so

Testing completed successfully using unit tests.

**Any background context you want to provide?**
https://segment.atlassian.net/browse/STRATCONN-1491

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
N/A

**Does this require a new integration setting? If so, please explain how the new setting works**
N/A

**Links to helpful docs and other external resources**
https://segment.com/docs/connections/destinations/catalog/adobe-analytics/heartbeat/#video-playback-started