### PR TITLE
Fix variable name typo

### DIFF
--- a/integrations/parsely/lib/index.js
+++ b/integrations/parsely/lib/index.js
@@ -22,7 +22,7 @@ var Parsely = (module.exports = integration('Parsely')
   .option('trackEvents', false)
   .option('inPixelMetadata', false)
   .tag(
-    '<script id="parsely-cfg" src="//cdn.parsely.com/keys/{{ apikey }}/p.js">'
+    '<script id="parsely-cfg" src="//cdn.parsely.com/keys/{{ apiKey }}/p.js">'
   ));
 
 /**

--- a/integrations/parsely/package.json
+++ b/integrations/parsely/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-parsely",
   "description": "The Parsely analytics.js integration.",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",


### PR DESCRIPTION
**What does this PR do?**
Original PR had a typo in `apiKey` variable name. 

**Are there breaking changes in this PR?**
No breaking change

**Testing**
- Testing completed successfully on local dev testing tool 


**Any background context you want to provide?**
Original PR: https://github.com/segmentio/analytics.js-integrations/pull/417