### PR TITLE
update all @segment/trample to same minimum version

### DIFF
--- a/integrations/kenshoo-infinity/package.json
+++ b/integrations/kenshoo-infinity/package.json
@@ -29,7 +29,7 @@
     "@ndhoule/extend": "^2.0.0",
     "@ndhoule/keys": "^2.0.0",
     "@segment/analytics.js-integration": "^3.2.0",
-    "@segment/trample": "^0.2.0",
+    "@segment/trample": "^0.2.1",
     "obj-case": "^0.2.0",
     "reject": "0.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2381,11 +2381,6 @@
     element-matches-polyfill "^1.0.0"
     whatwg-fetch "^3.0.0"
 
-"@segment/trample@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@segment/trample/-/trample-0.2.0.tgz#5b141159f67b06efaa295d2ebe240b51096134c5"
-  integrity sha1-WxQRWfZ7Bu+qKV0uviQLUQlhNMU=
-
 "@segment/trample@^0.2.1":
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/@segment/trample/-/trample-0.2.1.tgz#1f9ab47d0f69af633ffe5f3d80317d1a2ecd822a"


### PR DESCRIPTION
This PR updates the `@segment/trample` dependency to have the same minimum version across all integrations (currently just 2 - adobe analytics and kenshoo infinity).

This is needed because the common vendor file that contains the dependencies of all integrations was only pulling in the older version of `@segment/trample`. I'm not sure why it chose `0.2.0` instead of `0.2.1` since the latter met the version requirements for kenshoo, but this change resolves the issue.

This is especially important for the adobe analytics integration which needs the `0.2.1` update.

**Testing**
Testing completed successfully by rebuilding the integrations and validating the new trample code exists in the vendor file.


