### PR TITLE
HGI 81 - Add event ID to page calls sent to FB Pixel for deduplication

### DIFF
--- a/integrations/facebook-pixel/lib/index.js
+++ b/integrations/facebook-pixel/lib/index.js
@@ -135,8 +135,8 @@ FacebookPixel.prototype.loaded = function() {
  * @param {Facade} identify
  */
 
-FacebookPixel.prototype.page = function() {
-  window.fbq('track', 'PageView');
+FacebookPixel.prototype.page = function(track) {
+  window.fbq('track', 'PageView', {}, { eventID: track.proxy('messageId') });
 };
 
 /**

--- a/integrations/facebook-pixel/package.json
+++ b/integrations/facebook-pixel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-facebook-pixel",
   "description": "The Facebook Pixel analytics.js integration.",
-  "version": "2.11.4",
+  "version": "2.11.5",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/facebook-pixel/test/index.test.js
+++ b/integrations/facebook-pixel/test/index.test.js
@@ -14,6 +14,16 @@ function assertEventId(spy) {
     throw new Error('Expected eventId on window.fbq.call. Not found.');
   }
 }
+/**
+ * Event ID is generated automatically by Analytics.js, this function
+ * only checks that it was succesfully added as an 4th argument in PageView to a `window.fbq` call.
+ */
+
+function assertEventIdInPageView(spy) {
+  if (!spy.args[0][3].eventID.startsWith('ajs-')) {
+    throw new Error('Expected eventId on window.fbq.call. Not found.');
+  }
+}
 
 describe('Facebook Pixel', function() {
   var analytics;
@@ -256,9 +266,10 @@ describe('Facebook Pixel', function() {
         analytics.stub(window, 'fbq');
       });
 
-      it('should track a pageview', function() {
+      it('should track a pageview along with eventID', function() {
         analytics.page();
-        analytics.called(window.fbq, 'track', 'PageView');
+        analytics.called(window.fbq, 'track', 'PageView', {});
+        assertEventIdInPageView(window.fbq);
       });
     });
 


### PR DESCRIPTION
**What does this PR do?**
In Facebook Pixel and Facebook Conversions API (Actions) integrations, the eventId parameter is used to dedupe events, however Segment doesn't send eventId for Facebook Pixel Page events. This PR maps AJS messageId to Facebook's eventId.

**Are there breaking changes in this PR?**
No, this is a bug fix

**Testing**

<!---

All PRs must follow the process for change control as outlined in:
https://segment.atlassian.net/wiki/spaces/GRC/pages/453935287/Reinforcing+Change+Control

--->
Testing completed successfully in local environment with event tester
<img width="1084" alt="Facebook Pixel Dashboard" src="https://user-images.githubusercontent.com/109198085/192445641-e061a4e1-486a-48b2-aedf-105dd94ebbeb.png">


**Any background context you want to provide?**


**Is there parity with the server-side/android/iOS integration components (if applicable)?**
This PR is a bug fix which brings parity to Facebook Pixel Page Calls with Page Calls from Facebook Conversion API.

**Does this require a new integration setting? If so, please explain how the new setting works**
No

**Links to helpful docs and other external resources**
https://docs.google.com/document/d/19-PjSYJTH5tmKptMPXLBXPz3oF9c7sUpCSZ4TdyPYts