### PR TITLE
STRATCONN-1695: add support for collectHighEntropyUserAgentHints

### DIFF
--- a/integrations/adobe-analytics/HISTORY.md
+++ b/integrations/adobe-analytics/HISTORY.md
@@ -1,3 +1,8 @@
+1.17.0 / 2022-10-24
+===================
+* Bump AppMeasurement to 2.23.0
+* Add support for `collectHighEntropyUserAgentHints` setting, which allows richer User Agent data passed in as Client Hints.
+
 1.16.6 / 2022-07-26
 ===================
 * Drop support for `assetId` for `StandardVideoMetadata`

--- a/integrations/adobe-analytics/lib/index.js
+++ b/integrations/adobe-analytics/lib/index.js
@@ -83,6 +83,7 @@ AdobeAnalytics.global('s')
   .option('preferVisitorId', false)
   .option('heartbeatTrackingServerUrl', '')
   .option('ssl', false)
+  .option('collectHighEntropyUserAgentHints', false)
 
   .sOption('visitorID')
   .sOption('channel')
@@ -112,11 +113,11 @@ AdobeAnalytics.global('s')
   .sOption('usePlugins', true)
   .tag(
     'default',
-    '<script src="//cdn.segment.com/integrations/adobe-analytics/appmeasurement-2.20.0.js">'
+    '<script src="//cdn.segment.com/integrations/adobe-analytics/appmeasurement-2.23.0.js">'
   )
   .tag(
     'heartbeat',
-    '<script src="//cdn.segment.com/integrations/adobe-analytics/appmeasurement-2.20.0-heartbeat.js">'
+    '<script src="//cdn.segment.com/integrations/adobe-analytics/appmeasurement-2.23.0-heartbeat.js">'
   );
 
 /**
@@ -189,6 +190,10 @@ AdobeAnalytics.prototype.initialize = function() {
         };
       }
 
+      if (options.collectHighEntropyUserAgentHints) {
+        s.collectHighEntropyUserAgentHints = true;
+      }
+
       self.ready();
     });
   } else {
@@ -211,6 +216,10 @@ AdobeAnalytics.prototype.initialize = function() {
           trackingServerSecure:
             window.s.trackingServerSecure || options.trackingServerSecureUrl
         });
+      }
+
+      if (options.collectHighEntropyUserAgentHints) {
+        s.collectHighEntropyUserAgentHints = true;
       }
       self.ready();
     });

--- a/integrations/adobe-analytics/package.json
+++ b/integrations/adobe-analytics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-adobe-analytics",
   "description": "The Adobe Analytics analytics.js integration.",
-  "version": "1.16.6",
+  "version": "1.17.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/adobe-analytics/test/index.test.js
+++ b/integrations/adobe-analytics/test/index.test.js
@@ -56,7 +56,8 @@ describe('Adobe Analytics', function() {
     enableTrackPageName: true,
     disableVisitorId: false,
     preferVisitorId: false,
-    enableHeartbeat: true
+    enableHeartbeat: true,
+    collectHighEntropyUserAgentHints: true
   };
 
   beforeEach(function() {
@@ -94,6 +95,7 @@ describe('Adobe Analytics', function() {
         .option('marketingCloudOrgId', null)
         .option('heartbeatTrackingServerUrl', '')
         .option('ssl', false)
+        .option('collectHighEntropyUserAgentHints', false)
     );
   });
 
@@ -163,6 +165,21 @@ describe('Adobe Analytics', function() {
         analytics.equal(
           window.s.visitor.marketingCloudOrgID,
           options.marketingCloudOrgId
+        );
+      });
+
+      it('should set window.s.collectHighEntropyUserAgentHints', function() {
+        analytics.equal(
+          window.s.collectHighEntropyUserAgentHints,
+          options.collectHighEntropyUserAgentHints
+        );
+      });
+
+      it('should set window.s.collectHighEntropyUserAgentHints when heartbeatServerUrl is set', function() {
+        adobeAnalytics.options.heartbeatTrackingServerUrl = 'test url';
+        analytics.equal(
+          window.s.collectHighEntropyUserAgentHints,
+          options.collectHighEntropyUserAgentHints
         );
       });
     });


### PR DESCRIPTION
**What does this PR do?**

This PR increases the version of Adobe Analytics' AppMeasurement SDK from 2.20.0 to 2.23.0 in order to add support for collecting Client Hints from the User Agent. This is requested by customer in https://segment.atlassian.net/browse/STRATCONN-1695

**Are there breaking changes in this PR?**

As far as we know, increasing the AppMeasurement SDK version is backwards compatible.

**Testing**
- Testing completed successfully using local and staging via setting the new setting to true, and validating that ClientHints were populated on the `window.s` object.
![image](https://user-images.githubusercontent.com/103517471/197575121-7fa226cd-8eaf-48bb-8f39-772144106d01.png)
Also confirmed there were no regressions in calling the Adobe Analytics API by making `.track` and `.page` calls and confirming Adobe Analytics reports are registering new data.



**Any background context you want to provide?**
Slack thread: https://twilio.slack.com/archives/CATJY9BDW/p1666279110391459

**Is there parity with the server-side/android/iOS integration components (if applicable)?**


**Does this require a new integration setting? If so, please explain how the new setting works**
This requires a new setting that, if enabled, will populate the clientHints variable with additional User Agent data.

![image](https://user-images.githubusercontent.com/103517471/197575885-12013d55-2f3b-4b3f-bc87-29c5887bfe1c.png)


**Links to helpful docs and other external resources**
