### PR TITLE
Added support for version, whitelistUrls, ignoreUrls, ignoreErrors, and other disable options

### DIFF
--- a/integrations/atatus/HISTORY.md
+++ b/integrations/atatus/HISTORY.md
@@ -1,3 +1,8 @@
+2.3.0 / 2022-11-11
+==================
+
+  * Add support for version, whitelistUrls, ignoreUrls, ignoreErrors, and disable options
+
 2.2.0 / 2019-12-04
 ==================
 

--- a/integrations/atatus/lib/index.js
+++ b/integrations/atatus/lib/index.js
@@ -14,10 +14,23 @@ var isObject = require('isobject');
 var Atatus = (module.exports = integration('Atatus')
   .global('atatus')
   .option('apiKey', '')
+  .option('version', '')
+
+  .option('disableRUM', false)
+  .option('disableSession', false)
+  .option('disableSPA', false)
   .option('disableAjaxMonitoring', false)
-  .option('disableSpa', false)
-  .option('allowedDomains', [])
+  .option('disableErrorTracking', false)
+  .option('disableTransaction', false)
+
+  .option('whitelistUrls', [])
+  .option('ignoreUrls', [])
+  .option('ignoreErrors', [])
+
+  .option('hashRoutes', false)
+  .option('reportUnhandledRejections', false)
   .option('enableOffline', false)
+
   .tag('<script src="//dmc1acwvwny3.cloudfront.net/{{ lib }}.js">'));
 
 /**
@@ -29,26 +42,32 @@ var Atatus = (module.exports = integration('Atatus')
  */
 
 Atatus.prototype.initialize = function() {
-  var lib = this.options.disableSpa ? 'atatus' : 'atatus-spa';
+  var lib = this.options.disableSPA ? 'atatus' : 'atatus-spa';
   var self = this;
 
   this.load({ lib: lib }, function() {
     var configOptions = {
+      version: self.options.version,
+
+      disableRUM: self.options.disableRUM,
+      disableSession: self.options.disableSession,
+      disableSPA: self.options.disableSPA,
       disableAjaxMonitoring: self.options.disableAjaxMonitoring,
-      disableSPA: self.options.disableSpa
+      disableErrorTracking: self.options.disableErrorTracking,
+      disableTransaction: self.options.disableTransaction,
+
+      whitelistUrls: self.options.whitelistUrls,
+      ignoreUrls: self.options.ignoreUrls,
+      ignoreErrors: self.options.ignoreErrors,
+
+      hashRoutes: self.options.hashRoutes,
+      reportUnhandledRejections: self.options.reportUnhandledRejections
     };
 
     // Configure Atatus and install default handler to capture uncaught
     // exceptions
     window.atatus.config(self.options.apiKey, configOptions).install();
 
-    // Set allowed domains and enable offline
-    if (
-      Array.isArray(self.options.allowedDomains) &&
-      self.options.allowedDomains.length > 0
-    ) {
-      window.atatus.setAllowedDomains(self.options.allowedDomains);
-    }
     window.atatus.enableOffline(self.options.enableOffline);
 
     self.ready();

--- a/integrations/atatus/package.json
+++ b/integrations/atatus/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-atatus",
   "description": "The Atatus analytics.js integration.",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/atatus/test/index.test.js
+++ b/integrations/atatus/test/index.test.js
@@ -35,9 +35,21 @@ describe('Atatus', function() {
       integration('Atatus')
         .global('atatus')
         .option('apiKey', '')
+        .option('version', '')
+
+        .option('disableRUM', false)
+        .option('disableSession', false)
+        .option('disableSPA', false)
         .option('disableAjaxMonitoring', false)
-        .option('disableSpa', false)
-        .option('allowedDomains', [])
+        .option('disableErrorTracking', false)
+        .option('disableTransaction', false)
+
+        .option('whitelistUrls', [])
+        .option('ignoreUrls', [])
+        .option('ignoreErrors', [])
+
+        .option('hashRoutes', false)
+        .option('reportUnhandledRejections', false)
         .option('enableOffline', false)
     );
   });
@@ -68,8 +80,8 @@ describe('Atatus', function() {
       });
     });
 
-    it('should load non-spa version if you have set `disableSpa` to true', function(done) {
-      atatus.options.disableSpa = true;
+    it('should load non-spa version if you have set `disableSPA` to true', function(done) {
+      atatus.options.disableSPA = true;
       analytics.load(atatus, function() {
         analytics.assert(!window.atatus.spa);
         done();


### PR DESCRIPTION
**What does this PR do?**

Added options to `hashRoutes`, `version`, `disableRUM`, `disableSession`, `disableSPA`, `disableAjaxMonitoring`, `disableErrorTracking`, `disableTransaction`, `whitelistUrls`, `ignoreUrls`, `ignoreErrors` and `reportUnhandledRejections`.

**Are there breaking changes in this PR?**

We have removed **allowedDomains** and renamed the option to **whitelistUrls**.


**Testing**
<!---

All PRs must follow the process for change control as outlined in:
https://segment.atlassian.net/wiki/spaces/GRC/pages/453935287/Reinforcing+Change+Control

- Testing completed successfully using <how did you test, environment>; or
- Testing not required because <explain why you think testing isn't needed>

--->

Testing completed successfully. local env and the options flag works as expected.


**Any background context you want to provide?**

We have added a few options which have been asked by our customers.

**Is there parity with the server-side/android/iOS integration components (if applicable)?**

No


**Does this require a new integration setting? If so, please explain how the new setting works**

Yes,

`hashRoutes` - Atatus removes the hash from the URL and if you're using hash based routes you can set this option to true. It is of type boolean and defaults to false.

`version` - Helps you in filtering the errors from the dashboard using the version. It is of type string " ".

`disableRUM` - You can disable RUM metrics by setting this option to true. It is of type boolean and defaults to false.

`disableSession` - You can set this option to true if you want to disable reporting of session traces. It is of type boolean and defaults to false.

`disableSPA` - Set this option to true to disable SPA monitoring. It is of type boolean and defaults to false.
 
`disableAjaxMonitoring` - Disable AJAX monitoring by setting this option to true. It is of type boolean and defaults to false.

`disableErrorTracking` - Set disableErrorTracking to true to disable error tracking. It is of type boolean and defaults to false.

`disableTransaction` - You can disable the collection of transactions by setting the option to true. It is of type boolean and defaults to false.

`whitelistUrls` - Captures the page views, AJAX and JS Errors from the given domains or URLs and ignores insights from all other URLs. It is of type array [].

`ignoreUrls` - Ignore capturing insights from a given set of domains or URLs. It is of type array [].

`ignoreErrors` - It is an array of unwanted error messages to be filtered out before being sent to Atatus as either array of regular expressions or strings. Type array [].

`reportUnhandledRejections` - This will allow disabling or enabling the unhandled promise rejection errors. By default, it is set to true. It is of type boolean and defaults to true.


**Links to helpful docs and other external resources**

With the help of the documentation below, you can easily set up the options.

https://docs.atatus.com/docs/browser-monitoring/customize-agent.html