### PR TITLE
Adds segment track support in hellobar client script.

### DIFF
--- a/integrations/hello-bar/HISTORY.md
+++ b/integrations/hello-bar/HISTORY.md
@@ -1,3 +1,8 @@
+3.0.2 / 2023-01-10
+==================
+
+  * Hook segment track events to hellobar event trigger
+
 3.0.0 / 2017-06-06
 ==================
 

--- a/integrations/hello-bar/lib/index.js
+++ b/integrations/hello-bar/lib/index.js
@@ -30,3 +30,18 @@ Hellobar.prototype.initialize = function() {
 Hellobar.prototype.loaded = function() {
   return typeof window.hellobar === 'function';
 };
+
+/**
+ * Track.
+ *
+ * https://hellobarassist.freshdesk.com/support/solutions/articles/44002393650-triggering-popups-and-bars-on-a-user-event
+ *
+ * @api public
+ * @param {Track} track
+ */
+
+ Hellobar.prototype.track = function(track) {
+  var event = track.event();
+  var properties = track.properties();
+  window.hellobar.trigger.event(event, properties);
+};

--- a/integrations/hello-bar/lib/index.js
+++ b/integrations/hello-bar/lib/index.js
@@ -18,7 +18,7 @@ var Hellobar = (module.exports = integration('Hello Bar')
 /**
  * Initialize.
  *
- * https://s3.amazonaws.com/scripts.hellobar.com/bb900665a3090a79ee1db98c3af21ea174bbc09f.js
+ * https://my.hellobar.com/a18c23dec1b87e9401465165eca61459d405684d.js
  *
  * @api public
  */
@@ -28,7 +28,7 @@ Hellobar.prototype.initialize = function() {
 };
 
 Hellobar.prototype.loaded = function() {
-  return typeof window.hellobar === 'function';
+  return !!window.hellobarSiteSettings;
 };
 
 /**

--- a/integrations/hello-bar/package.json
+++ b/integrations/hello-bar/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-hellobar",
   "description": "The Hellobar analytics.js integration.",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/hello-bar/test/index.test.js
+++ b/integrations/hello-bar/test/index.test.js
@@ -60,6 +60,34 @@ describe('Hellobar', function() {
       analytics.load(hellobar, done);
     });
   });
+
+  describe('after loading', function() {
+    beforeEach(function(done) {
+      analytics.initialize();
+      analytics.page();
+      analytics.once('ready', done);
+    });
+
+    describe('#track', function() {
+      beforeEach(function() {
+        analytics.stub(window.hellobar.trigger, 'event');
+      });
+
+      it('should send trigger an event', function() {
+        analytics.track('event');
+        analytics.called(window.hellobar.trigger.event, 'event', {});
+      });
+
+      it('should send a trigger event and properties', function() {
+        analytics.track('event', {
+          property: true
+        });
+        analytics.called(window.hellobar.trigger.event, 'event', {
+          property: true
+        });
+      });
+    });
+  });
 });
 
 /**


### PR DESCRIPTION
**What does this PR do?**
This PR updates the hellobar script integration and provides the customer ability to use segment track events in hellobar event triggers.

**Are there breaking changes in this PR?**
No.

**Testing**
- Testing completed successfully using dev environment. A popup is tied to an event named `segment_event_1` which can be triggered successfully using `analytics.track("segment_event_1");` which validates the use case here.


**Any background context you want to provide?**
We have hellobar popups being triggered on custom events. The customers who already use segment would now be able to use segment track events without integrating hellobar events directly by hooking into the segment events.

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
NA

**Does this require a new integration setting? If so, please explain how the new setting works**
No.

**Links to helpful docs and other external resources**
https://hellobarassist.freshdesk.com/support/solutions/articles/44002393650-triggering-popups-and-bars-on-a-user-event
