### PR TITLE
STRATCONN-1287 - Add support for DoubleClick Floodlight config in in Google Ads (GTag)

### DIFF
--- a/integrations/google-adwords-new/HISTORY.md
+++ b/integrations/google-adwords-new/HISTORY.md
@@ -1,7 +1,11 @@
+1.3.0 / 2023-02-08
+==================
+  * Introduces a new setting `floodlightAccountId` to enable passing the DoubleClick Floodlight config ID to GTag's `config` to allow better synergy between these two products.
+
 1.2.0 / 2020-02-18
 ==================
 
-  * Introduces a new setting `disableAdPersonalization` to disable collection of remarketing data for users who do not wish to view personalized ads. When this settiing is `true`, Segment will set `allow_ad_personalization_signals` to false. 
+  * Introduces a new setting `disableAdPersonalization` to disable collection of remarketing data for users who do not wish to view personalized ads. When this setting is `true`, Segment will set `allow_ad_personalization_signals` to false. 
 
 1.1.1 / 2019-12-09
 ==================

--- a/integrations/google-adwords-new/lib/index.js
+++ b/integrations/google-adwords-new/lib/index.js
@@ -22,6 +22,7 @@ var GoogleAdWordsNew = (module.exports = integration('Google AdWords New')
   .option('pageLoadConversions', [])
   .option('defaultPageConversion', '')
   .option('disableAdPersonalization', false)
+  .option('floodlightAccountId', '')
   // The ID in this line (i.e. the gtag.js ID) does not determine which account(s) will receive data from the tag; rather, it is used to uniquely identify your global site tag. Which account(s) receive data from the tag is determined by calling the config command (and by using the send_to parameter on an event). For instance, if you use Google Analytics, you may already have the gtag.js global site tag installed on your site. In that case, the gtag.js ID may be that of the Google Analytics property where you first obtained the snippet.
   .tag(
     '<script src="https://www.googletagmanager.com/gtag/js?id={{ accountId }}">'

--- a/integrations/google-adwords-new/lib/index.js
+++ b/integrations/google-adwords-new/lib/index.js
@@ -55,7 +55,11 @@ GoogleAdWordsNew.prototype.initialize = function() {
     if (self.options.disableAdPersonalization)
       window.gtag('set', 'allow_ad_personalization_signals', false);
 
+    if (self.options.floodlightAccountId) {
+      window.gtag('config', self.options.floodlightAccountId, config);
+    }
     window.gtag('config', self.options.accountId, config);
+
     self.ready();
   });
 };

--- a/integrations/google-adwords-new/package.json
+++ b/integrations/google-adwords-new/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-google-adwords-new",
   "description": "The google-adwords-new analytics.js integration.",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/google-adwords-new/test/index.test.js
+++ b/integrations/google-adwords-new/test/index.test.js
@@ -150,6 +150,18 @@ describe('Google AdWords New', function() {
       analytics.initialize();
       analytics.spy(window, 'gtag');
     });
+
+    it('should support Doubleclick Floodlight account if provided', function(done) {
+      var floodlightAccountId = 'DC-1234567';
+      googleadwordsnew.options.floodlightAccountId = floodlightAccountId;
+      analytics.once('ready', function() {
+        analytics.deepEqual(window.gtag.args[1], ['config', floodlightAccountId, {}]);
+        analytics.deepEqual(window.gtag.args[2], ['config', options.accountId, {}]);
+        done();
+      });
+      analytics.initialize();
+      analytics.spy(window, 'gtag');
+    });
   });
 
   describe('after loading', function() {


### PR DESCRIPTION
**What does this PR do?**

The following PR intends to provide a workaround for browsers that are not able to set DC cookies through normal means, so we are leveraging [GTag](https://support.google.com/campaignmanager/answer/7554821?hl=en#zippy=%2Cstep-add-the-global-snippet-to-every-page-of-your-site%2Cstep-add-the-event-snippet-to-pages-with-events-youre-tracking) to set those cookies. See ticket [STRATCONN-1287](https://segment.atlassian.net/browse/STRATCONN-1287) for more information.

**Are there breaking changes in this PR?**
No, all changes are backwards compatible.

**Testing**
Testing completed successfully in local tester via checking for regressions, as we are unable to test E2E to see the effect of the changes. Will rely on customer to assist in validation. See ticket for details.

**Does this require a new integration setting? If so, please explain how the new setting works**

Yes, this requires a new optional setting called `floodlightAccountId` which represents the DoubleClick Floodlight Config ID. It will be passed to gtag's `config` parameter as part of the integration initialization.

**Links to helpful docs and other external resources**

https://segment.atlassian.net/browse/STRATCONN-1287

https://support.google.com/campaignmanager/answer/7554821?hl=en#zippy=%2Cstep-add-the-global-snippet-to-every-page-of-your-site%2Cstep-add-the-event-snippet-to-pages-with-events-youre-tracking


[STRATCONN-1287]: https://segment.atlassian.net/browse/STRATCONN-1287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ