### PR TITLE
Allow configuring heap integration settings

### DIFF
--- a/integrations/heap/HISTORY.md
+++ b/integrations/heap/HISTORY.md
@@ -1,3 +1,8 @@
+==================
+2.2.0 / 2023-02-13
+
+  * Allow overriding heap loading snippet
+  * Allow configuring heap options
 
 2.1.1 / 2018-07-06
 ==================

--- a/integrations/heap/lib/index.js
+++ b/integrations/heap/lib/index.js
@@ -21,7 +21,9 @@ var toString = Object.prototype.toString; // in case this method has been overri
 var Heap = (module.exports = integration('Heap')
   .global('heap')
   .option('appId', '')
-  .tag('<script src="//cdn.heapanalytics.com/js/heap-{{ appId }}.js">'));
+  .option('hostname', 'cdn.heapanalytics.com')
+  .option('options', {})
+  .tag('<script src="//{{ hostname }}/js/heap-{{ appId }}.js">'));
 
 /**
  * Initialize.
@@ -61,7 +63,7 @@ Heap.prototype.initialize = function() {
     });
   };
 
-  window.heap.load(this.options.appId);
+  window.heap.load(this.options.appId, this.options.options);
   this.load(this.ready);
 };
 

--- a/integrations/heap/package.json
+++ b/integrations/heap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-heap",
   "description": "The Heap analytics.js integration.",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",


### PR DESCRIPTION
**What does this PR do?**
The current heap integration has two limitations which are proving challenging for our segment deployment:
* the snippet is loaded from a hardcoded URL, so we can't configure it to load the heap JS from our CDN
* there is no way to specify any heap configuration options, so we can't control the options like `secureCookie` or `disableTextCapture`.

This PR adds additional configuration options to the heap integration to support changing both.

**Are there breaking changes in this PR?**
No. 

**Testing**
I used the (very slick and excellent) local runner to test manually. I didn't see an easy way to add any tests, since it's hard to mock the underlying heap object. I'm also not sure the tests would be hugely valuable, since they would essentially be asserting that the code exists as written rather than really testing behavior. I am open to suggestions about a better way to handle this!

**Any background context you want to provide?**
No

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
N/A

**Does this require a new integration setting? If so, please explain how the new setting works**
This change introduces two new optional settings:
1. `hostname` (`string`): Allows changing the URL from which the heap snippet is loaded. It defaults to "cdn.heapanalytics.com", the current hard-coded value, to preserve backwards compatibility. 
2. `options` (`object`): Allows passing an arbitrary set of configuration options to heap. They are passed to the heap JS code as is. Defaults to `{}` to preserve backwards compatibility.

**Links to helpful docs and other external resources**

[Heap JS options](https://developers.heap.io/docs/web#advanced-configurations)
