### PR TITLE
KLAVIYO - Mapped total key in klaviyo payload

### DIFF
--- a/integrations/klaviyo/lib/index.js
+++ b/integrations/klaviyo/lib/index.js
@@ -132,8 +132,7 @@ Klaviyo.prototype.orderCompleted = function(track) {
     $value: track.revenue(),
     Categories: products.categories,
     ItemNames: products.names,
-    Items: products.items,
-    total: track.total()
+    Items: products.items
   };
 
   var whitelist = [
@@ -145,7 +144,6 @@ Klaviyo.prototype.orderCompleted = function(track) {
     'itemNames',
     'items',
     'revenue',
-    'total',
     'products'
   ];
   // strip standard props and leave custom props only

--- a/integrations/klaviyo/lib/index.js
+++ b/integrations/klaviyo/lib/index.js
@@ -132,7 +132,8 @@ Klaviyo.prototype.orderCompleted = function(track) {
     $value: track.revenue(),
     Categories: products.categories,
     ItemNames: products.names,
-    Items: products.items
+    Items: products.items,
+    total: track.total()
   };
 
   var whitelist = [

--- a/integrations/klaviyo/package.json
+++ b/integrations/klaviyo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-klaviyo",
   "description": "The Klaviyo analytics.js integration.",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/klaviyo/test/index.test.js
+++ b/integrations/klaviyo/test/index.test.js
@@ -228,6 +228,7 @@ describe('Klaviyo', function() {
             $value: 25,
             Categories: ['Games', 'Interwebs'],
             ItemNames: ['Monopoly: 3rd Edition', 'Suh dude'],
+            total: 30,
             Items: [
               {
                 id: '507f1f77bcf86cd799439011',
@@ -291,6 +292,7 @@ describe('Klaviyo', function() {
             $value: 25,
             Categories: ['Games'],
             ItemNames: ['Monopoly: 3rd Edition'],
+            total: 30,
             Items: [
               {
                 id: '507f1f77bcf86cd799439011',
@@ -452,6 +454,7 @@ describe('Klaviyo', function() {
             $value: 25,
             Categories: ['Games', 'Interwebs'],
             ItemNames: ['Monopoly: 3rd Edition', 'Suh dude'],
+            total: 30,
             Items: [
               {
                 id: '507f1f77bcf86cd799439011',

--- a/integrations/klaviyo/test/index.test.js
+++ b/integrations/klaviyo/test/index.test.js
@@ -416,7 +416,6 @@ describe('Klaviyo', function() {
           letMePass: 'hi',
           customProp: true,
           total: 30,
-          revenue: 25,
           shipping: 3,
           tax: 2,
           discount: 2.5,
@@ -451,7 +450,7 @@ describe('Klaviyo', function() {
           'Completed Order',
           {
             $event_id: '50314b8e9bcf000000000000',
-            $value: 25,
+            $value: 30,
             Categories: ['Games', 'Interwebs'],
             ItemNames: ['Monopoly: 3rd Edition', 'Suh dude'],
             total: 30,


### PR DESCRIPTION
**What does this PR do?**

This PR is to map total field in klaviyo payload as it was being skipped earlier .

**Are there breaking changes in this PR?**
No

**Testing**

- Testing completed successfully locally

<img width="778" alt="Screenshot 2023-04-04 at 3 39 21 PM" src="https://user-images.githubusercontent.com/117165746/229760055-558c89ad-38e3-44fe-b66b-f92d2edc8f98.png">

<img width="788" alt="Screenshot 2023-04-04 at 3 39 42 PM" src="https://user-images.githubusercontent.com/117165746/229760086-0f657a22-2e0f-49b9-bbce-830aed6a2897.png">

**Any background context you want to provide?**
No


**Is there parity with the server-side/android/iOS integration components (if applicable)?**
N/A

**Does this require a new integration setting? If so, please explain how the new setting works**
No

**Links to helpful docs and other external resources**
https://segment.atlassian.net/browse/STRATCONN-1977
