### PR TITLE
Added queueName option for custom dataLayer

### DIFF
--- a/integrations/google-tag-manager/HISTORY.md
+++ b/integrations/google-tag-manager/HISTORY.md
@@ -1,3 +1,7 @@
+2.6.0 / 2023-05-17
+==================
+  * Add support for queueName (custom dataLayer) option
+
 2.5.0 / 2017-04-27
 ==================
 

--- a/integrations/google-tag-manager/package.json
+++ b/integrations/google-tag-manager/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-google-tag-manager",
   "description": "The Google Tag Manager analytics.js integration.",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",


### PR DESCRIPTION
**What does this PR do?**
Google Tag Manager supports custom queue (dataLayer) name but the existing integration does not allow for this. This change adds a `queueName` option to the GTM integration to support this.

**Are there breaking changes in this PR?**
No. This change adds an optional option which defaults to `dataLayer` so that it will continue to function as prior to the change.

**Testing**
Testing completed successfully. Unit tests were updated to test the new queueName option.

**Any background context you want to provide?**
This change is needed to aid migration from on-site GTM to Segment destination for large or complex websites which cannot implement the migration all at once. Without this change, a GTM destination cannot be added to a Segment source without breaking an existing GTM implementation.

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
No

**Does this require a new integration setting? If so, please explain how the new setting works**
Yes.
- DataLayer
- You can specify a custom name for your dataLayer variable if you need to (e.g., coexist with an existing GTM implementation). The name must contain only letters, numbers, underscore, or dollar sign to meet JavaScript identifier rules.

**Links to helpful docs and other external resources**
