### PR TITLE
Updating kissmetrics domain endpoint

### DIFF
--- a/integrations/kissmetrics/lib/index.js
+++ b/integrations/kissmetrics/lib/index.js
@@ -25,13 +25,12 @@ var KISSmetrics = (module.exports = integration('KISSmetrics')
   .option('trackNamedPages', true)
   .tag(
     'library',
-    '<script src="//scripts.kissmetrics.com/{{ apiKey }}.2.js">'
+    '<script src="//scripts.kissmetrics.io/{{ apiKey }}.2.js">'
   ));
 
 /**
  * Check if browser is mobile, for kissmetrics.
  *
- * http://support.kissmetrics.com/how-tos/browser-detection.html#mobile-vs-non-mobile
  */
 
 exports.isMobile =
@@ -45,7 +44,7 @@ exports.isMobile =
 /**
  * Initialize.
  *
- * http://support.kissmetrics.com/apis/javascript
+ * http://support.kissmetrics.io/apis/javascript
  */
 
 KISSmetrics.prototype.initialize = function() {
@@ -136,7 +135,7 @@ KISSmetrics.prototype.track = function(track) {
   if (revenue) {
     // legacy: client side integration used to only send 'Billing Amount', but
     // our server side sent both 'revenue' and 'Billing Amount'. From the docs,
-    // http://support.kissmetrics.com/tools/revenue-report.html, ther is no
+    // http://support.kissmetrics.io/tools/revenue-report.html, ther is no
     // reason to send it as 'Billing Amount', but we don't want to break reports
     // so we send it as 'revenue' and 'Billing Amount' for consistency across
     // platforms.


### PR DESCRIPTION
We will be deprecating the use of kissmetrics.com to kissmetrics.io


**What does this PR do?**


**Are there breaking changes in this PR?**


**Testing**
<!---

All PRs must follow the process for change control as outlined in:
https://segment.atlassian.net/wiki/spaces/GRC/pages/453935287/Reinforcing+Change+Control

- Testing completed successfully using <how did you test, environment>; or
- Testing not required because <explain why you think testing isn't needed>

--->


**Any background context you want to provide?**


**Is there parity with the server-side/android/iOS integration components (if applicable)?**


**Does this require a new integration setting? If so, please explain how the new setting works**


**Links to helpful docs and other external resources**
