### PR TITLE
Support for SystemJS in MadKudu integration

### DIFF
--- a/integrations/madkudu/lib/index.js
+++ b/integrations/madkudu/lib/index.js
@@ -10,7 +10,7 @@ var integration = require('@segment/analytics.js-integration');
  * UMD?
  */
 
-var umd = typeof window.define === 'function' && window.define.amd;
+var umd = typeof window.define === 'function' && window.define.amd && window.require;
 
 /**
  * Expose `Madkudu` integration.

--- a/integrations/madkudu/package.json
+++ b/integrations/madkudu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-madkudu",
   "description": "The Madkudu analytics.js integration.",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",


### PR DESCRIPTION
**What does this PR do?**

This PR adds support for SystemJS in MadKudu integration.

When ran on a SystemJS environment `window.define.amd` is defined but not `window.require`. Which prevented the MadKudu script from loading.

**Are there breaking changes in this PR?**

No.

**Testing**

Testing not required because we just add a new check for `window.require` for UMD. If not present, we will use `this.load`.


**Any background context you want to provide?**

The PR is crated based on this issue https://github.com/segmentio/analytics.js-integrations/issues/761

**Is there parity with the server-side/android/iOS integration components (if applicable)?**

No.

**Does this require a new integration setting? If so, please explain how the new setting works**

No.

**Links to helpful docs and other external resources**

