### PR TITLE
[Walkme] Add bucket option

### DIFF
--- a/integrations/walkme/lib/index.js
+++ b/integrations/walkme/lib/index.js
@@ -19,6 +19,7 @@ var WalkMe = module.exports = integration('WalkMe')
   .option('trackWalkMeEvents', false)
   .option('loadWalkMeInIframe', false)
   .option('integrityHash', '')
+  .option('bucketName', 'users')
   .tag('<script async="true" src="{{ url }}" crossorigin="" integrity="{{ hash }}">')
 
 /**
@@ -37,7 +38,7 @@ WalkMe.prototype.initialize = function() {
     window.walkme_load_in_iframe = true;
   }
 
-  var env = "\/" + (this.options.environment && this.options.environment.toLowerCase());
+  var env = (this.options.environment && this.options.environment.toLowerCase());
 
   if (!env || env == "\/" || env == "\/production") {
     env = "";
@@ -67,7 +68,9 @@ WalkMe.prototype.initialize = function() {
     sriSuffix = 'private_';
   }
 
-  var url = 'https://cdn.walkme.com/users/' + walkMeSystemId + env + '/walkme_' + sriSuffix + walkMeSystemId + '_https.js';
+  var bucket = (this.options.userBucket) ? this.options.userBucket : 'users';
+
+  var url = `https://cdn.walkme.com/${bucket}/${walkMeSystemId}/${env}/walkme_${sriSuffix}${walkMeSystemId}_https.js`;
 
   this.load({
     url,

--- a/integrations/walkme/lib/index.js
+++ b/integrations/walkme/lib/index.js
@@ -68,8 +68,7 @@ WalkMe.prototype.initialize = function() {
     sriSuffix = 'private_';
   }
 
-  var bucket = (this.options.userBucket) ? this.options.userBucket : 'users';
-
+  var bucket = (this.options.bucketName) ? this.options.bucketName : 'users';
   var url = `https://cdn.walkme.com/${bucket}/${walkMeSystemId}/${env}/walkme_${sriSuffix}${walkMeSystemId}_https.js`;
 
   this.load({

--- a/integrations/walkme/lib/index.js
+++ b/integrations/walkme/lib/index.js
@@ -19,7 +19,7 @@ var WalkMe = module.exports = integration('WalkMe')
   .option('trackWalkMeEvents', false)
   .option('loadWalkMeInIframe', false)
   .option('integrityHash', '')
-  .option('bucketName', 'users')
+  .option('customDirecotry', 'users')
   .tag('<script async="true" src="{{ url }}" crossorigin="" integrity="{{ hash }}">')
 
 /**
@@ -68,7 +68,7 @@ WalkMe.prototype.initialize = function() {
     sriSuffix = 'private_';
   }
 
-  var bucket = (this.options.bucketName) ? this.options.bucketName : 'users';
+  var bucket = (this.options.customDirecotry) ? this.options.customDirecotry : 'users';
   var url = `https://cdn.walkme.com/${bucket}/${walkMeSystemId}/${env}/walkme_${sriSuffix}${walkMeSystemId}_https.js`;
 
   this.load({

--- a/integrations/walkme/lib/index.js
+++ b/integrations/walkme/lib/index.js
@@ -69,7 +69,7 @@ WalkMe.prototype.initialize = function() {
   }
 
   var bucket = (this.options.customDirectory) ? this.options.customDirectory : 'users';
-  var url = `https://cdn.walkme.com/${bucket}/${walkMeSystemId}/${env}/walkme_${sriSuffix}${walkMeSystemId}_https.js`;
+  var url = 'https://cdn.walkme.com/' + bucket + '/' + walkMeSystemId + '/' + env + '/walkme_' + sriSuffix + walkMeSystemId + '_https.js';
 
   this.load({
     url,

--- a/integrations/walkme/lib/index.js
+++ b/integrations/walkme/lib/index.js
@@ -19,7 +19,7 @@ var WalkMe = module.exports = integration('WalkMe')
   .option('trackWalkMeEvents', false)
   .option('loadWalkMeInIframe', false)
   .option('integrityHash', '')
-  .option('customDirecotry', 'users')
+  .option('customDirectory', 'users')
   .tag('<script async="true" src="{{ url }}" crossorigin="" integrity="{{ hash }}">')
 
 /**
@@ -68,7 +68,7 @@ WalkMe.prototype.initialize = function() {
     sriSuffix = 'private_';
   }
 
-  var bucket = (this.options.customDirecotry) ? this.options.customDirecotry : 'users';
+  var bucket = (this.options.customDirectory) ? this.options.customDirecotry : 'users';
   var url = `https://cdn.walkme.com/${bucket}/${walkMeSystemId}/${env}/walkme_${sriSuffix}${walkMeSystemId}_https.js`;
 
   this.load({

--- a/integrations/walkme/lib/index.js
+++ b/integrations/walkme/lib/index.js
@@ -68,7 +68,7 @@ WalkMe.prototype.initialize = function() {
     sriSuffix = 'private_';
   }
 
-  var bucket = (this.options.customDirectory) ? this.options.customDirecotry : 'users';
+  var bucket = (this.options.customDirectory) ? this.options.customDirectory : 'users';
   var url = `https://cdn.walkme.com/${bucket}/${walkMeSystemId}/${env}/walkme_${sriSuffix}${walkMeSystemId}_https.js`;
 
   this.load({

--- a/integrations/walkme/test/index.test.js
+++ b/integrations/walkme/test/index.test.js
@@ -16,7 +16,8 @@ describe('WalkMe', function() {
     environment: 'test',
     trackWalkMeEvents: false,
     loadWalkMeInIframe: true,
-    integrityHash: ''
+    integrityHash: '',
+    bucketName: '',
   };
 
   beforeEach(function() {
@@ -46,6 +47,7 @@ describe('WalkMe', function() {
       .option('trackWalkMeEvents', false)
       .option('loadWalkMeInIframe', false)
       .option('integrityHash', '')
+      .option('bucketName', 'users')
     );
   });
 
@@ -133,8 +135,43 @@ describe('WalkMe', function() {
           done();
         };
 
-        walkme.options.walkMeSystemId = '42b2849a0ca54749bd485bcbd5bcc64e';
-        walkme.options.integrityHash = 'sha256-FjbibNOUzdIz+mtyFRU7NHj1G5tPgzOuJNCkRyDmXr8=';
+        walkme.options.walkMeSystemId = walkMeSystemId;
+        walkme.options.integrityHash = integrityHash;
+
+        analytics.load(walkme, function() {
+          analytics.loaded(tag);
+        });
+      } catch (e) {
+        done(e);
+      }
+    }).timeout(10000);
+
+    it('should setup bucket', function(done) {
+      try {
+        var walkMeSystemId = '42b2849a0ca54749bd485bcbd5bcc64e';
+        var integrityHash = 'sha256-FjbibNOUzdIz+mtyFRU7NHj1G5tPgzOuJNCkRyDmXr8=';
+        var bucket = 'custom';
+
+        var tag = fmt(
+          '<script src="https://cdn.walkme.com/%s/%s/%s/walkme_%s_https.js" crossorigin="" >',
+          bucket, 
+          walkMeSystemId,
+          'test',
+          walkMeSystemId
+        );
+
+        window.walkme_ready = function() {
+          analytics.assert(
+            !!window.WalkMeAPI,
+            'Expected WalkMeAPI to be present on the page'
+          );
+
+          done();
+        };
+
+        walkme.options.walkMeSystemId = walkMeSystemId;
+        walkme.options.integrityHash = integrityHash;
+        walkme.options.bucketName = bucket;
 
         analytics.load(walkme, function() {
           analytics.loaded(tag);

--- a/integrations/walkme/test/index.test.js
+++ b/integrations/walkme/test/index.test.js
@@ -150,7 +150,7 @@ describe('WalkMe', function() {
       try {
         var walkMeSystemId = '42b2849a0ca54749bd485bcbd5bcc64e';
         var integrityHash = 'sha256-FjbibNOUzdIz+mtyFRU7NHj1G5tPgzOuJNCkRyDmXr8=';
-        var bucket = 'custom';
+        var bucket = 'users';
 
         var tag = fmt(
           '<script src="https://cdn.walkme.com/%s/%s/%s/walkme_%s_https.js" crossorigin="" >',

--- a/integrations/walkme/test/index.test.js
+++ b/integrations/walkme/test/index.test.js
@@ -17,7 +17,7 @@ describe('WalkMe', function() {
     trackWalkMeEvents: false,
     loadWalkMeInIframe: true,
     integrityHash: '',
-    customDirecotry: '',
+    customDirectory: '',
   };
 
   beforeEach(function() {
@@ -47,7 +47,7 @@ describe('WalkMe', function() {
       .option('trackWalkMeEvents', false)
       .option('loadWalkMeInIframe', false)
       .option('integrityHash', '')
-      .option('customDirecotry', 'users')
+      .option('customDirectory', 'users')
     );
   });
 
@@ -171,7 +171,7 @@ describe('WalkMe', function() {
 
         walkme.options.walkMeSystemId = walkMeSystemId;
         walkme.options.integrityHash = integrityHash;
-        walkme.options.customDirecotry = bucket;
+        walkme.options.customDirectory = bucket;
 
         analytics.load(walkme, function() {
           analytics.loaded(tag);

--- a/integrations/walkme/test/index.test.js
+++ b/integrations/walkme/test/index.test.js
@@ -17,7 +17,7 @@ describe('WalkMe', function() {
     trackWalkMeEvents: false,
     loadWalkMeInIframe: true,
     integrityHash: '',
-    bucketName: '',
+    customDirecotry: '',
   };
 
   beforeEach(function() {
@@ -47,7 +47,7 @@ describe('WalkMe', function() {
       .option('trackWalkMeEvents', false)
       .option('loadWalkMeInIframe', false)
       .option('integrityHash', '')
-      .option('bucketName', 'users')
+      .option('customDirecotry', 'users')
     );
   });
 
@@ -171,7 +171,7 @@ describe('WalkMe', function() {
 
         walkme.options.walkMeSystemId = walkMeSystemId;
         walkme.options.integrityHash = integrityHash;
-        walkme.options.bucketName = bucket;
+        walkme.options.customDirecotry = bucket;
 
         analytics.load(walkme, function() {
           analytics.loaded(tag);


### PR DESCRIPTION
**What does this PR do?**

Clone of https://github.com/segmentio/analytics.js-integrations/pull/759

**Are there breaking changes in this PR?**

No. This adds a new setting to allow customers load script from a private bucket in S3.

**Testing**


**Any background context you want to provide?**
N/A
**Is there parity with the server-side/android/iOS integration components (if applicable)?**
N/A

**Does this require a new integration setting? If so, please explain how the new setting works**
This requires a new setting called customDirectory. There is already an existing setting in partner portal with a typo called `customDirecotry'. But no customer has set the value in production. So, we'll delete the setting and create a new setting called `customDirectory`. This is the directory from which custom implementation 

**Links to helpful docs and other external resources**
