### PR TITLE
[STRATCONN] 2841 Created mapping for Segment message id to pinterest event id

### DIFF
--- a/integrations/pinterest-tag/lib/index.js
+++ b/integrations/pinterest-tag/lib/index.js
@@ -190,10 +190,6 @@ Pinterest.prototype.generatePropertiesObject = function(track) {
   // Finally, add in any custom properties defined by the user.
   var customProps = this.options.pinterestCustomProperties;
 
-  if(this.options.mapMessageIdToEventId && customProps.indexOf('event_id') === -1){
-    customProps.push('event_id');
-  }
-
   for (var j = 0; j < customProps.length; j++) {
     var customProperty = customProps[j];
     trackValue = track.proxy('properties.' + customProperty);

--- a/integrations/pinterest-tag/lib/index.js
+++ b/integrations/pinterest-tag/lib/index.js
@@ -16,6 +16,7 @@ var Pinterest = (module.exports = integration('Pinterest Tag')
   .option('tid', '')
   .option('pinterestCustomProperties', [])
   .option('useEnhancedMatchLoad', false)
+  .option('mapMessageIdToEvnentId', false)
   .mapping('pinterestEventMapping')
   .tag('<script src="https://s.pinimg.com/ct/core.js"></script>'));
 
@@ -132,6 +133,10 @@ Pinterest.prototype.createPropertyMapping = function() {
     quantity: 'product_quantity',
     brand: 'product_brand'
   };
+
+  if(this.options.mapMessageIdToEvnentId){
+    this.productPropertyMap.messageId = 'event_id';
+  }
 };
 
 /**
@@ -184,6 +189,11 @@ Pinterest.prototype.generatePropertiesObject = function(track) {
 
   // Finally, add in any custom properties defined by the user.
   var customProps = this.options.pinterestCustomProperties;
+
+  if(this.options.mapMessageIdToEvnentId && customProps.indexOf('event_id') === -1){
+    customProps.push('event_id');
+  }
+
   for (var j = 0; j < customProps.length; j++) {
     var customProperty = customProps[j];
     trackValue = track.proxy('properties.' + customProperty);

--- a/integrations/pinterest-tag/lib/index.js
+++ b/integrations/pinterest-tag/lib/index.js
@@ -16,7 +16,7 @@ var Pinterest = (module.exports = integration('Pinterest Tag')
   .option('tid', '')
   .option('pinterestCustomProperties', [])
   .option('useEnhancedMatchLoad', false)
-  .option('mapMessageIdToEvnentId', false)
+  .option('mapMessageIdToEventId', false)
   .mapping('pinterestEventMapping')
   .tag('<script src="https://s.pinimg.com/ct/core.js"></script>'));
 
@@ -134,8 +134,8 @@ Pinterest.prototype.createPropertyMapping = function() {
     brand: 'product_brand'
   };
 
-  if(this.options.mapMessageIdToEvnentId){
-    this.productPropertyMap.messageId = 'event_id';
+  if(this.options.mapMessageIdToEventId){
+    this.propertyMap.messageId = 'event_id';
   }
 };
 
@@ -190,7 +190,7 @@ Pinterest.prototype.generatePropertiesObject = function(track) {
   // Finally, add in any custom properties defined by the user.
   var customProps = this.options.pinterestCustomProperties;
 
-  if(this.options.mapMessageIdToEvnentId && customProps.indexOf('event_id') === -1){
+  if(this.options.mapMessageIdToEventId && customProps.indexOf('event_id') === -1){
     customProps.push('event_id');
   }
 

--- a/integrations/pinterest-tag/test/index.test.js
+++ b/integrations/pinterest-tag/test/index.test.js
@@ -94,5 +94,20 @@ describe('Pinterest', function() {
         });
       });
     });
+
+    describe('#track', function() {
+      beforeEach(function() {
+        analytics.spy(window, 'pintrk');
+      });
+
+      it('should set Segment messageId as Pinterest Evnet Id', function() {
+        analytics.track('Order Completed', {
+          currency: 'SGD',
+          value: 12.12,
+          messageId: 'testing5671',
+          order_id: 'HJIHNI'
+        });
+      });
+    });
   });
 });

--- a/integrations/pinterest-tag/test/index.test.js
+++ b/integrations/pinterest-tag/test/index.test.js
@@ -18,7 +18,7 @@ describe('Pinterest', function() {
     },
     pinterestCustomProperties: ['custom_prop'],
     useEnhancedMatchLoad: false,
-    mapMessageIdToEventId: false
+    mapMessageIdToEventId: true
   };
 
   beforeEach(function() {
@@ -103,9 +103,13 @@ describe('Pinterest', function() {
       it('should set Segment messageId as Pinterest Evnet Id', function() {
         analytics.track('Order Completed', {
           currency: 'SGD',
-          value: 12.12,
-          messageId: 'testing5671',
-          order_id: 'HJIHNI'
+          value: 10.0,
+          messageId: 'testing5671'
+        });
+        analytics.called(window.pintrk, 'track', 'Checkout', {
+          value: 10.0,
+          currency: 'SGD',
+          event_id: 'testing5671'
         });
       });
     });

--- a/integrations/pinterest-tag/test/index.test.js
+++ b/integrations/pinterest-tag/test/index.test.js
@@ -17,7 +17,8 @@ describe('Pinterest', function() {
       'User Signed Up': 'Signup'
     },
     pinterestCustomProperties: ['custom_prop'],
-    useEnhancedMatchLoad: false
+    useEnhancedMatchLoad: false,
+    mapMessageIdToEventId: false
   };
 
   beforeEach(function() {
@@ -44,6 +45,7 @@ describe('Pinterest', function() {
         .option('pinterestCustomProperties', [])
         .option('tid', '')
         .option('useEnhancedMatchLoad', false)
+        .option('mapMessageIdToEventId', false)
     );
   });
 


### PR DESCRIPTION
**What does this PR do?**

Created new settings field to enable message Id to map with pinterest event id, also when enabled checking event_id is available or not in custom properties of segment settings. 

Jira tickets: https://segment.atlassian.net/browse/STRATCONN-2841?atlOrigin=eyJpIjoiZGM3ODNkZGJiOWM0NDJiY2FmOGJiM2FmODI0NjY3YmQiLCJwIjoiaiJ9

![Screenshot 2023-08-31 at 11 54 34 AM](https://github.com/segmentio/analytics.js-integrations/assets/139338151/afafcf6a-5e1f-410c-8e20-a27ef1cd9683)



![Screenshot 2023-08-31 at 11 54 51 AM](https://github.com/segmentio/analytics.js-integrations/assets/139338151/d19e5873-ae06-428d-b1c5-0e4c8ba0071b)

![Screenshot 2023-08-31 at 12 00 57 PM](https://github.com/segmentio/analytics.js-integrations/assets/139338151/d25a66e9-e53e-4303-8cc5-a83c9282453f)


**Are there breaking changes in this PR?**

NO


**Testing**

Testing completed successfully


**Any background context you want to provide?**


**Is there parity with the server-side/android/iOS integration components (if applicable)?**


**Does this require a new integration setting? If so, please explain how the new setting works**


**Links to helpful docs and other external resources**
