### PR TITLE
Fixed issue of Shareasale not working without use total as amount enabled

### DIFF
--- a/integrations/shareasale/lib/index.js
+++ b/integrations/shareasale/lib/index.js
@@ -36,10 +36,11 @@ ShareASale.prototype.orderCompleted = function(track) {
   var orderId = track.orderId();
   var isRepeat = track.proxy('properties.repeat');
   var subtotal = (track.subtotal() || 0).toFixed(2);
+  var total= (track.total() || 0).toFixed(2)
   var orderTotal =
     this.options.useTotalAsAmount && track.total()
-      ? track.total().toFixed(2)
-      : subtotal.toFixed(2);
+      ? total
+      : subtotal;
   var products = track.products();
   var currency = track.currency() || this.options.currency;
   var coupon = track.coupon() || '';

--- a/integrations/shareasale/test/index.test.js
+++ b/integrations/shareasale/test/index.test.js
@@ -69,11 +69,11 @@ describe('ShareASale', function() {
           subtotal: 42,
           shipping: 10,
           tax: 3.5,
-          total: 55.5,
+          total: 55,
           revenue: 15
         });
         analytics.loaded(
-          '<img src="https://shareasale.com/sale.cfm?amount=55.50&tracking=123&transtype=sale&merchantID=bonobos&skulist=&quantitylist=&pricelist=&currency=USD&couponcode=">'
+          '<img src="https://shareasale.com/sale.cfm?amount=55.00&tracking=123&transtype=sale&merchantID=bonobos&skulist=&quantitylist=&pricelist=&currency=USD&couponcode=">'
         );
       });
 
@@ -93,10 +93,10 @@ describe('ShareASale', function() {
           orderId: 123,
           shipping: 10,
           tax: 3.5,
-          total: 55.5
+          total: 55
         });
         analytics.loaded(
-          '<img src="https://shareasale.com/sale.cfm?amount=42.00&tracking=123&transtype=sale&merchantID=bonobos&skulist=&quantitylist=&pricelist=&currency=USD&couponcode=">'
+          '<img src="https://shareasale.com/sale.cfm?amount=41.50&tracking=123&transtype=sale&merchantID=bonobos&skulist=&quantitylist=&pricelist=&currency=USD&couponcode=">'
         );
       });
 
@@ -148,7 +148,7 @@ describe('ShareASale', function() {
           total: 55.5
         });
         analytics.loaded(
-          '<img src="https://shareasale.com/sale.cfm?amount=42.00&tracking=123&transtype=sale&merchantID=bonobos&skulist=&quantitylist=&pricelist=&currency=USD&couponcode=">'
+          '<img src="https://shareasale.com/sale.cfm?amount=47.00&tracking=123&transtype=sale&merchantID=bonobos&skulist=&quantitylist=&pricelist=&currency=USD&couponcode=">'
         );
       });
 


### PR DESCRIPTION

**What does this PR do?**
This Pull request is to fix the issue of shareasale not working without use total as amount enabled.

**Are there breaking changes in this PR?**


**Testing**
<!---

All PRs must follow the process for change control as outlined in:
https://segment.atlassian.net/wiki/spaces/GRC/pages/453935287/Reinforcing+Change+Control

- Testing completed successfully using <how did you test, environment>; or
 Testing not required as it is simple fix and tested through unit test cases.

--->


**Any background context you want to provide?**


**Is there parity with the server-side/android/iOS integration components (if applicable)?**


**Does this require a new integration setting? If so, please explain how the new setting works**


**Links to helpful docs and other external resources**
