### PR TITLE
[MAIN] [STRATCONN-2841] Added event_id in page action of Pinterest Tag

### DIFF
--- a/integrations/pinterest-tag/lib/index.js
+++ b/integrations/pinterest-tag/lib/index.js
@@ -63,15 +63,27 @@ Pinterest.prototype.identify = function(identify) {
 
 Pinterest.prototype.page = function(page) {
   // If we have a category, the use ViewCategory. Otherwise, use a normal PageVisit.
+  var pinterestPageProps = {
+    name: page.name() || ''
+  };
+
+  var eventKeys = ['event_id', 'eid', 'eventID'];
+
+  for (var i = 0; i < eventKeys.length; i++) {
+    if (page.properties()[eventKeys[i]]) {
+      pinterestPageProps.event_id = page.properties()[eventKeys[i]];
+    }
+  }
+
+  if (this.options.mapMessageIdToEventId) {
+    pinterestPageProps.event_id = page.proxy('messageId');
+  }
+
   if (page.category()) {
-    window.pintrk('track', 'ViewCategory', {
-      category: page.category(),
-      name: page.name() || ''
-    });
+    pinterestPageProps.category = page.category();
+    window.pintrk('track', 'ViewCategory', pinterestPageProps);
   } else {
-    window.pintrk('track', 'PageVisit', {
-      name: page.name() || ''
-    });
+    window.pintrk('track', 'PageVisit', pinterestPageProps);
   }
 };
 

--- a/integrations/pinterest-tag/lib/index.js
+++ b/integrations/pinterest-tag/lib/index.js
@@ -62,7 +62,6 @@ Pinterest.prototype.identify = function(identify) {
 };
 
 Pinterest.prototype.page = function(page) {
-  // If we have a category, the use ViewCategory. Otherwise, use a normal PageVisit.
   var pinterestPageProps = {
     name: page.name() || ''
   };
@@ -79,6 +78,7 @@ Pinterest.prototype.page = function(page) {
     pinterestPageProps.event_id = page.proxy('messageId');
   }
 
+  // If we have a category, the use ViewCategory. Otherwise, use a normal PageVisit.
   if (page.category()) {
     pinterestPageProps.category = page.category();
     window.pintrk('track', 'ViewCategory', pinterestPageProps);

--- a/integrations/pinterest-tag/lib/index.js
+++ b/integrations/pinterest-tag/lib/index.js
@@ -70,7 +70,7 @@ Pinterest.prototype.page = function(page) {
   var eventKeys = ['event_id', 'eid', 'eventID'];
 
   for (var i = 0; i < eventKeys.length; i++) {
-    if (page.properties()[eventKeys[i]]) {
+    if (page.properties() && page.properties()[eventKeys[i]]) {
       pinterestPageProps.event_id = page.properties()[eventKeys[i]];
     }
   }

--- a/integrations/pinterest-tag/package.json
+++ b/integrations/pinterest-tag/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-pinterest-tag",
   "description": "The Pinterest Tag analytics.js integration.",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/pinterest-tag/test/index.test.js
+++ b/integrations/pinterest-tag/test/index.test.js
@@ -100,7 +100,7 @@ describe('Pinterest', function() {
         analytics.spy(window, 'pintrk');
       });
 
-      it('should set Segment messageId as Pinterest Evnet Id', function() {
+      it('should set Segment messageId as Pinterest Event Id', function() {
         analytics.track('Order Completed', {});
         analytics.called(window.pintrk, 'track', 'Checkout');
         if (!window.pintrk.args[0][2].event_id.startsWith('ajs-')) {
@@ -114,7 +114,7 @@ describe('Pinterest', function() {
         analytics.spy(window, 'pintrk');
       });
 
-      it('should set Segment messageId as Pinterest Evnet Id', function() {
+      it('should set Segment messageId as Pinterest Event Id', function() {
         analytics.page('PageVisit', {});
         analytics.called(window.pintrk, 'track', 'PageVisit');
         if (!window.pintrk.args[0][2].event_id.startsWith('ajs-')) {

--- a/integrations/pinterest-tag/test/index.test.js
+++ b/integrations/pinterest-tag/test/index.test.js
@@ -108,5 +108,19 @@ describe('Pinterest', function() {
         }
       });
     });
+
+    describe('#page', function() {
+      beforeEach(function() {
+        analytics.spy(window, 'pintrk');
+      });
+
+      it('should set Segment messageId as Pinterest Evnet Id', function() {
+        analytics.page('PageVisit', {});
+        analytics.called(window.pintrk, 'track', 'PageVisit');
+        if (!window.pintrk.args[0][2].event_id.startsWith('ajs-')) {
+          throw new Error('Expected eventId on window.pintrk Not found.');
+        }
+      });
+    });
   });
 });


### PR DESCRIPTION
**What does this PR do?**
JIRA TICKET: https://segment.atlassian.net/browse/STRATCONN-2841

Create mapping for Pinterest event_id as segment messageId. 


1. When `mapMessageIdToEventId` is disabled/false

<img width="1500" alt="Screenshot 2024-05-30 at 11 57 30 AM" src="https://github.com/segmentio/analytics.js-integrations/assets/139338151/54a7c8e1-9440-45e1-8fac-0d9d37709c2b">


<img width="1032" alt="Screenshot 2024-05-30 at 11 56 12 AM" src="https://github.com/segmentio/analytics.js-integrations/assets/139338151/3d748be2-1a47-4fb1-8f74-c505421ab830">





2. When `mapMessageIdToEventId` is enabled/true


<img width="1508" alt="Screenshot 2024-05-30 at 11 29 53 AM" src="https://github.com/segmentio/analytics.js-integrations/assets/139338151/d1e67f23-c183-4d1a-8e8d-4ced69c6a02b">


<img width="1041" alt="Screenshot 2024-05-30 at 11 52 59 AM" src="https://github.com/segmentio/analytics.js-integrations/assets/139338151/e8194176-5908-4f2a-8b56-bd2633e7b0e6">




**Are there breaking changes in this PR?**


**Testing**

- Testing completed successfully using stage 


**Any background context you want to provide?**


**Is there parity with the server-side/android/iOS integration components (if applicable)?**


**Does this require a new integration setting? If so, please explain how the new setting works**


**Links to helpful docs and other external resources**
