### PR TITLE
Add support for fullstory relay options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 bin/
 node_modules/
 coverage/

--- a/integrations/fullstory/lib/index.js
+++ b/integrations/fullstory/lib/index.js
@@ -21,9 +21,11 @@ var FullStory = (module.exports = integration('FullStory')
   .option('trackNamedPages', false)
   .option('trackCategorizedPages', false)
   .option('trackPagesWithEvents', true)
+  .option('script', 'edge.fullstory.com/s/fs.js')
+  .option('host', 'fullstory.com')
   .option('isOuterScript', false)
   .tag(
-    '<script async src="https://edge.fullstory.com/s/fs.js" crossorigin="anonymous"></script>'
+    '<script async src="https://{{script}}" crossorigin="anonymous"></script>'
   ));
 
 /**
@@ -39,8 +41,8 @@ var apiSource = 'segment';
 FullStory.prototype.initialize = function() {
   window._fs_is_outer_script = this.options.isOuterScript;
   window._fs_debug = this.options.debug;
-  window._fs_host = 'fullstory.com';
-  window._fs_script = 'edge.fullstory.com/s/fs.js';
+  window._fs_host = this.options.host;
+  window._fs_script = this.options.script;
   window._fs_org = this.options.org;
   window._fs_namespace = 'FS';
 


### PR DESCRIPTION
**What does this PR do?**
This originates from a discussion with Segment support about this integration.


Adds support for setting the required options to enable [FullStory Relay](https://help.fullstory.com/hc/en-us/articles/360046112593-How-to-send-captured-traffic-to-your-First-Party-Domain-using-Fullstory-Relay#h_01GZ2AENF4D4MK71E77PYF86TX)

**Are there breaking changes in this PR?**
None

**Testing**
<!---

All PRs must follow the process for change control as outlined in:
https://segment.atlassian.net/wiki/spaces/GRC/pages/453935287/Reinforcing+Change+Control

- Testing completed successfully using <how did you test, environment>; or
- Testing not required because <explain why you think testing isn't needed>

--->


**Any background context you want to provide?**
Segment supports a traffic proxy, and this would add support to allow for proxying the assets from FullStory through Segment instead of requiring manual FullStory SDK integration.

**Is there parity with the server-side/android/iOS integration components (if applicable)?**


**Does this require a new integration setting? If so, please explain how the new setting works**

The 2 settings added use the original defaults so no additional configuration is necessary.


**Links to helpful docs and other external resources**
See link in section 1.