### PR TITLE
Removed sync-buildkit-plugin

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -45,7 +45,7 @@ steps:
             - SAUCE_ACCESS_KEY
 
   - wait: ~
-    depends_on: ["snyk", "build"]
+    depends_on: ["build"]
 
   - label: ":cloud: Upload Assets to stage bucket"
     branches: master staging

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -44,15 +44,6 @@ steps:
             - SAUCE_USERNAME
             - SAUCE_ACCESS_KEY
 
-  - label: "🔒 Snyk Security Check"
-    key: "snyk"
-    agents:
-      queue: v1
-    plugins:
-      - ssh://git@github.com/segmentio/snyk-buildkite-plugin#v1.2.0:
-          runtime: npm
-          fail-on: upgradable
-
   - wait: ~
     depends_on: ["snyk", "build"]
 


### PR DESCRIPTION
**What does this PR do?**

Removed `sync-buildkit-plugin` as sync is going to remove out of date images from dockerhub. 
 Slack conversations: https://twilio.slack.com/archives/C06M05XEUTX/p1722981209259329

**Are there breaking changes in this PR?**
No

**Testing**

Testing completed successfully by ensuring buildkite run succeeds for this branch.


**Any background context you want to provide?**


**Is there parity with the server-side/android/iOS integration components (if applicable)?**


**Does this require a new integration setting? If so, please explain how the new setting works**


**Links to helpful docs and other external resources**
