### PR TITLE
[MAIN] [STRATCONN-4128] Updated adobe-analytics CDN version 2.23.1

### DIFF
--- a/integrations/adobe-analytics/lib/index.js
+++ b/integrations/adobe-analytics/lib/index.js
@@ -113,11 +113,11 @@ AdobeAnalytics.global('s')
   .sOption('usePlugins', true)
   .tag(
     'default',
-    '<script src="//cdn.segment.com/integrations/adobe-analytics/appmeasurement-2.23.0.js">'
+    '<script src="//cdn.segment.com/integrations/adobe-analytics/appmeasurement-2.23.1.js">'
   )
   .tag(
     'heartbeat',
-    '<script src="//cdn.segment.com/integrations/adobe-analytics/appmeasurement-2.23.0-heartbeat.js">'
+    '<script src="//cdn.segment.com/integrations/adobe-analytics/appmeasurement-2.23.1-heartbeat.js">'
   );
 
 /**


### PR DESCRIPTION
**What does this PR do?**

Bump up the adobe-analytics CDN version, 
Removed ActivityMap section from AppMeasurement.js File. 

JIRA TICKETS: https://segment.atlassian.net/browse/STRATCONN-4128


<img width="1507" alt="Screenshot 2024-09-24 at 11 41 10 PM" src="https://github.com/user-attachments/assets/49c32736-e979-4c4e-b549-25d228b16417">



**Are there breaking changes in this PR?**


**Testing**
<!---

All PRs must follow the process for change control as outlined in:
https://segment.atlassian.net/wiki/spaces/GRC/pages/453935287/Reinforcing+Change+Control

- Testing completed successfully using <how did you test, environment>; or
- Testing not required because <explain why you think testing isn't needed>

--->


**Any background context you want to provide?**


**Is there parity with the server-side/android/iOS integration components (if applicable)?**


**Does this require a new integration setting? If so, please explain how the new setting works**


**Links to helpful docs and other external resources**
