### PR TITLE
[MAIN] [STRATCONN] Bumpup Adobe analytics version from 1.17.0 to 1.18.0

### DIFF
--- a/integrations/adobe-analytics/lib/index.js
+++ b/integrations/adobe-analytics/lib/index.js
@@ -113,11 +113,11 @@ AdobeAnalytics.global('s')
   .sOption('usePlugins', true)
   .tag(
     'default',
-    '<script src="//cdn.segment.com/integrations/adobe-analytics/appmeasurement-2.23.0.js">'
+    '<script src="//cdn.segment.com/integrations/adobe-analytics/appmeasurement-2.23.1.js">'
   )
   .tag(
     'heartbeat',
-    '<script src="//cdn.segment.com/integrations/adobe-analytics/appmeasurement-2.23.0-heartbeat.js">'
+    '<script src="//cdn.segment.com/integrations/adobe-analytics/appmeasurement-2.23.1-heartbeat.js">'
   );
 
 /**

--- a/integrations/adobe-analytics/package.json
+++ b/integrations/adobe-analytics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-adobe-analytics",
   "description": "The Adobe Analytics analytics.js integration.",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",


### PR DESCRIPTION
**What does this PR do?**

This PR is Part of #805 . Updated latest version of adobe analytics cdn and bumped up the version from 1.17.0 to 1.18.0. 

**Are there breaking changes in this PR?**


**Testing**
<!---

All PRs must follow the process for change control as outlined in:
https://segment.atlassian.net/wiki/spaces/GRC/pages/453935287/Reinforcing+Change+Control

- Testing completed successfully using <how did you test, environment>; or
- Testing not required because <explain why you think testing isn't needed>

--->


**Any background context you want to provide?**


**Is there parity with the server-side/android/iOS integration components (if applicable)?**


**Does this require a new integration setting? If so, please explain how the new setting works**


**Links to helpful docs and other external resources**
