### PR TITLE
feat: support appcues integration custom domain option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ package-lock.json
 yarn-error.log
 dist/
 build/
+.idea/

--- a/integrations/appcues/lib/index.js
+++ b/integrations/appcues/lib/index.js
@@ -13,7 +13,8 @@ var load = require('@segment/load-script');
 
 var Appcues = integration('Appcues')
   .global('Appcues')
-  .option('appcuesId', '');
+  .option('appcuesId', '')
+  .option('domain', '');
 
 /**
  * Initialize.
@@ -47,7 +48,8 @@ Appcues.prototype.loaded = function() {
 
 Appcues.prototype.load = function(callback) {
   var id = this.options.appcuesId || 'appcues';
-  load('//fast.appcues.com/' + id + '.js', callback);
+  var domain = this.options.domain || '//fast.appcues.com/';
+  load(domain + id + '.js', callback);
 };
 
 /**

--- a/integrations/appcues/test/index.test.js
+++ b/integrations/appcues/test/index.test.js
@@ -10,7 +10,8 @@ describe('Appcues', function() {
   var appcues;
   var analytics;
   var options = {
-    appcuesId: '1663'
+    appcuesId: '1663',
+    domain: '//fast.appcues.net/'
   };
 
   // Disable AMD for these browser tests.
@@ -42,6 +43,7 @@ describe('Appcues', function() {
       integration('Appcues')
         .global('Appcues')
         .option('appcuesId', '')
+        .option('domain', '')
     );
   });
 


### PR DESCRIPTION
**What does this PR do?**
This PR adds a custom domain (also known as CNAME) option for appcues integration.
Currently, the only way to use a custom domain for appcues is to integrate directly with their SDK,
So by providing this custom option, a user will still be able to use appcues as a segment integration.

Link: https://docs.appcues.com/dev-installing-appcues/host-appcues-sdk-under-your-own-domain

**Are there breaking changes in this PR?**
NO

**Testing**
No special tests are needed
<!---

All PRs must follow the process for change control as outlined in:
https://segment.atlassian.net/wiki/spaces/GRC/pages/453935287/Reinforcing+Change+Control

- Testing completed successfully using <how did you test, environment>; or
- Testing not required because <explain why you think testing isn't needed>

--->


**Any background context you want to provide?**


**Is there parity with the server-side/android/iOS integration components (if applicable)?**


**Does this require a new integration setting? If so, please explain how the new setting works**


**Links to helpful docs and other external resources**
