### PR TITLE
Add support to GTM and GA4 for First-Party mode

### DIFF
--- a/integrations/google-analytics-4/HISTORY.md
+++ b/integrations/google-analytics-4/HISTORY.md
@@ -1,3 +1,8 @@
+0.1.0 / 2025-03-19
+==================
+
+  * Add support for custom domain configuration for gtag.js script loading
+
 0.0.2 / 2021-03-24
 ==================
 

--- a/integrations/google-analytics-4/lib/index.js
+++ b/integrations/google-analytics-4/lib/index.js
@@ -92,6 +92,12 @@ GA4.prototype.initialize = function() {
     send_page_view: opts.sendAutomaticPageViewEvent,
 
     /**
+     * Server Container URL
+     * https://developers.google.com/tag-platform/tag-manager/server-side/dependency-serving
+     */
+    server_container_url: '//' + opts.domain,
+
+    /**
      * Cookie Update
      * https://developers.google.com/analytics/devguides/collection/ga4/cookies-user-id#cookie_update_parameter
      */

--- a/integrations/google-analytics-4/lib/index.js
+++ b/integrations/google-analytics-4/lib/index.js
@@ -13,6 +13,7 @@ var GA4 = (module.exports = integration('Google Analytics 4')
   .global('gtag')
   .global('ga4DataLayer')
   .option('measurementIds', [])
+  .option('domain', 'www.googletagmanager.com')
   .option('cookieDomainName', 'auto')
   .option('cookiePrefix', '_ga')
   .option('cookieExpiration', 63072000)
@@ -48,7 +49,7 @@ var GA4 = (module.exports = integration('Google Analytics 4')
    */
   .option('customEventsAndParameters', [])
   .tag(
-    '<script src="//www.googletagmanager.com/gtag/js?id={{ measurementId }}&l=ga4DataLayer">'
+    '<script src="//{{{ domain }}}/gtag/js?id={{ measurementId }}&l=ga4DataLayer">'
   ));
 
 /**

--- a/integrations/google-analytics-4/package.json
+++ b/integrations/google-analytics-4/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/analytics.js-integration-google-analytics-4",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "description": "",
   "main": "lib/index.js",
   "directories": {

--- a/integrations/google-analytics-4/test/index.js
+++ b/integrations/google-analytics-4/test/index.js
@@ -40,6 +40,7 @@ describe('Google Analytics 4', function () {
                 .global('gtag')
                 .global('ga4DataLayer')
                 .option('measurementIds', [])
+                .option('domain', 'www.googletagmanager.com')
                 .option('cookieDomainName', 'auto')
                 .option('cookiePrefix', '_ga')
                 .option('cookieExpiration', 63072000)
@@ -96,6 +97,13 @@ describe('Google Analytics 4', function () {
                 analytics.called(ga4.load)
                 analytics.loaded('<script src="http://www.googletagmanager.com/gtag/js?id=G-100&l=ga4DataLayer"></script>')
             });
+
+            it('should load gtag.js with the custom domain', function () {
+                ga4.options.domain = 'custom.example.com';
+                analytics.initialize();
+                analytics.called(ga4.load)
+                analytics.loaded('<script src="http://custom.example.com/gtag/js?id=G-100&l=ga4DataLayer"></script>')
+            });
         });
     });
 
@@ -122,6 +130,13 @@ describe('Google Analytics 4', function () {
 
             analytics.equal(window.ga4DataLayer[1][2]['send_page_view'], false)
             analytics.equal(window.ga4DataLayer[2][2]['send_page_view'], false)
+        });
+
+        it('should set the server_container_url for all measurement IDs', function () {
+            ga4.options.domain = 'https://custom.example.com';
+            analytics.initialize();
+            analytics.equal(window.ga4DataLayer[1][2]['server_container_url'], 'https://custom.example.com')
+            analytics.equal(window.ga4DataLayer[2][2]['server_container_url'], 'https://custom.example.com')
         });
 
         it('should set cookie related setting for all measurement IDs', function () {

--- a/integrations/google-analytics-4/test/index.test.js
+++ b/integrations/google-analytics-4/test/index.test.js
@@ -31,23 +31,4 @@ describe('Google Analytics 4', function() {
     ga4.reset();
     sandbox();
   });
-
-  describe('loading', function() {
-    it('should load default domain', function() {
-      analytics.spy(ga4, 'load');
-      analytics.initialize();
-      analytics.page();
-      analytics.called(ga4.load);
-      analytics.assert(ga4.options.domain === 'www.googletagmanager.com');
-    });
-
-    it('should load custom domain if specified', function() {
-      ga4.options.domain = 'custom.example.com';
-      analytics.spy(ga4, 'load');
-      analytics.initialize();
-      analytics.page();
-      analytics.called(ga4.load);
-      analytics.assert(ga4.options.domain === 'custom.example.com');
-    });
-  });
 });

--- a/integrations/google-analytics-4/test/index.test.js
+++ b/integrations/google-analytics-4/test/index.test.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var Analytics = require('@segment/analytics.js-core').constructor;
+var integration = require('@segment/analytics.js-integration');
+var sandbox = require('@segment/clear-env');
+var tester = require('@segment/analytics.js-integration-tester');
+var GA4 = require('../lib/');
+
+describe('Google Analytics 4', function() {
+  var analytics;
+  var ga4;
+  var options = {
+    containerId: 'GTM-XXXX',
+    environment: '',
+    domain: 'www.googletagmanager.com',
+    trackNamedPages: true,
+    trackCategorizedPages: true
+  };
+
+  beforeEach(function() {
+    analytics = new Analytics();
+    ga4 = new GA4(options);
+    analytics.use(GA4);
+    analytics.use(tester);
+    analytics.add(ga4);
+  });
+
+  afterEach(function() {
+    analytics.restore();
+    analytics.reset();
+    ga4.reset();
+    sandbox();
+  });
+
+  describe('loading', function() {
+    it('should load default domain', function() {
+      analytics.spy(ga4, 'load');
+      analytics.initialize();
+      analytics.page();
+      analytics.called(ga4.load);
+      analytics.assert(ga4.options.domain === 'www.googletagmanager.com');
+    });
+
+    it('should load custom domain if specified', function() {
+      ga4.options.domain = 'custom.example.com';
+      analytics.spy(ga4, 'load');
+      analytics.initialize();
+      analytics.page();
+      analytics.called(ga4.load);
+      analytics.assert(ga4.options.domain === 'custom.example.com');
+    });
+  });
+});

--- a/integrations/google-tag-manager/HISTORY.md
+++ b/integrations/google-tag-manager/HISTORY.md
@@ -1,3 +1,8 @@
+2.6.0 / 2025-03-19
+==================
+
+  * Add support for custom domain configuration for GTM script loading
+
 2.5.0 / 2017-04-27
 ==================
 

--- a/integrations/google-tag-manager/lib/index.js
+++ b/integrations/google-tag-manager/lib/index.js
@@ -16,15 +16,16 @@ var GTM = (module.exports = integration('Google Tag Manager')
   .global('google_tag_manager')
   .option('containerId', '')
   .option('environment', '')
+  .option('domain', 'www.googletagmanager.com')
   .option('trackNamedPages', true)
   .option('trackCategorizedPages', true)
   .tag(
     'no-env',
-    '<script src="//www.googletagmanager.com/gtm.js?id={{ containerId }}&l=dataLayer">'
+    '<script src="//{{{ domain }}}/gtm.js?id={{ containerId }}&l=dataLayer">'
   )
   .tag(
     'with-env',
-    '<script src="//www.googletagmanager.com/gtm.js?id={{ containerId }}&l=dataLayer&gtm_preview={{ environment }}">'
+    '<script src="//{{{ domain }}}/gtm.js?id={{ containerId }}&l=dataLayer&gtm_preview={{ environment }}">'
   ));
 
 /**

--- a/integrations/google-tag-manager/package.json
+++ b/integrations/google-tag-manager/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-google-tag-manager",
   "description": "The Google Tag Manager analytics.js integration.",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/google-tag-manager/test/index.test.js
+++ b/integrations/google-tag-manager/test/index.test.js
@@ -45,6 +45,23 @@ describe('Google Tag Manager', function() {
     it('should load', function(done) {
       analytics.load(gtm, done);
     });
+
+    it('should load default domain', function() {
+      analytics.spy(gtm, 'load');
+      analytics.initialize();
+      analytics.page();
+      analytics.called(gtm.load);
+      analytics.assert(gtm.options.domain === 'www.googletagmanager.com');
+    });
+
+    it('should load custom domain if specified', function() {
+      gtm.options.domain = 'custom.example.com';
+      analytics.spy(gtm, 'load');
+      analytics.initialize();
+      analytics.page();
+      analytics.called(gtm.load);
+      analytics.assert(gtm.options.domain === 'custom.example.com');
+    });
   });
 
   describe('after loading', function() {


### PR DESCRIPTION
**What does this PR do?**
This allows for using Google's First-party mode, to load Google scripts from your own server through server-side tagging.

**Are there breaking changes in this PR?**
No

**Testing**
<!---

All PRs must follow the process for change control as outlined in:
https://segment.atlassian.net/wiki/spaces/GRC/pages/453935287/Reinforcing+Change+Control

- Testing completed successfully using <how did you test, environment>; or
- Testing not required because <explain why you think testing isn't needed>

--->


**Any background context you want to provide?**
This capability helps ensure that Google Tag Manager domain and script loading is not impeded by browsers, and Segment users can setup the First-party mode to support this.

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
N/A

**Does this require a new integration setting? If so, please explain how the new setting works**
- Yes, in the Google Analytics 4 Web and Google Tag Manager destinations, the new setting is `domain`, which defaults to `www.googletagmanager.com`

**Links to helpful docs and other external resources**

https://developers.google.com/tag-platform/tag-manager/server-side/dependency-serving?tag=gtag