### PR TITLE
Added adStorage consent in bing ads

### DIFF
--- a/integrations/bing-ads/lib/index.js
+++ b/integrations/bing-ads/lib/index.js
@@ -31,6 +31,10 @@ Bing.prototype.initialize = function() {
   window.uetq = window.uetq || [];
   var self = this;
 
+  var consent = {
+    ad_storage: self.options.adStorage || 'denied'
+  };
+  window.uetq.push('consent', 'default', consent);
   self.load(function() {
     var setup = {
       ti: self.options.tagId,

--- a/integrations/bing-ads/package.json
+++ b/integrations/bing-ads/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-bing-ads",
   "description": "The Bing Ads analytics.js integration.",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",


### PR DESCRIPTION
**What does this PR do?**

Added support of consent mode in the Bing Ads destination. 

**Are there breaking changes in this PR?**
No.

**Testing**
<!---

All PRs must follow the process for change control as outlined in:
https://segment.atlassian.net/wiki/spaces/GRC/pages/453935287/Reinforcing+Change+Control

- Testing completed successfully using <how did you test, environment>; or
- Testing not required because <explain why you think testing isn't needed>

--->

<img width="1511" alt="Screenshot 2025-04-17 at 9 53 28 AM" src="https://github.com/user-attachments/assets/639b2547-d460-4ba1-8afa-3fbde27dd2bb" />

<img width="1072" alt="Screenshot 2025-04-17 at 9 52 56 AM" src="https://github.com/user-attachments/assets/38c6c3dc-293d-415d-973b-88eda93ec6d8" />



**Any background context you want to provide?**


**Is there parity with the server-side/android/iOS integration components (if applicable)?**


**Does this require a new integration setting? If so, please explain how the new setting works**


**Links to helpful docs and other external resources**
