### PR TITLE
[STRATCONN-5687] Added support for bing ads consent mode

### DIFF
--- a/integrations/bing-ads/lib/index.js
+++ b/integrations/bing-ads/lib/index.js
@@ -31,6 +31,10 @@ Bing.prototype.initialize = function() {
   window.uetq = window.uetq || [];
   var self = this;
 
+  window.uetq.push('consent', 'default', {
+    ad_storage: self.options.adStorage || 'denied'
+  });
+
   self.load(function() {
     var setup = {
       ti: self.options.tagId,
@@ -81,6 +85,30 @@ Bing.prototype.track = function(track) {
 
   if (track.category()) event.ec = track.category();
   if (track.revenue()) event.gv = track.revenue();
+
+  var consent = {};
+
+  if (track.properties[this.options.adStoragePropertyMapping]) {
+    consent.ad_storage =
+      track.properties[this.options.adStoragePropertyMapping];
+  }
+
+  if (
+    track.context.consent.categoryPreferences[
+      this.options.adStorageConsentCategory
+    ]
+  ) {
+    consent.ad_storage =
+      track.context.consent.categoryPreferences[
+        this.options.adStorageConsentCategory
+      ] === true
+        ? 'granted'
+        : 'denied';
+  }
+
+  if (consent.length > 0) {
+    window.uetq.push('consent', 'update', consent);
+  }
 
   window.uetq.push(event);
 };

--- a/integrations/bing-ads/lib/index.js
+++ b/integrations/bing-ads/lib/index.js
@@ -31,9 +31,10 @@ Bing.prototype.initialize = function() {
   window.uetq = window.uetq || [];
   var self = this;
 
-  window.uetq.push('consent', 'default', {
+  var consent = {
     ad_storage: self.options.adStorage || 'denied'
-  });
+  };
+  window.uetq.push('consent', 'default', consent);
 
   self.load(function() {
     var setup = {

--- a/integrations/bing-ads/lib/index.js
+++ b/integrations/bing-ads/lib/index.js
@@ -103,9 +103,7 @@ Bing.prototype.track = function(track) {
   }
 
   if (Object.keys(consent).length > 0) {
-    window.uetq.push('consent', 'update', {
-      ad_storage: 'granted'
-    });
+    window.uetq.push('consent', 'update', consent);
   }
 
   window.uetq.push(event);

--- a/integrations/bing-ads/lib/index.js
+++ b/integrations/bing-ads/lib/index.js
@@ -88,26 +88,23 @@ Bing.prototype.track = function(track) {
 
   var consent = {};
 
-  if (track.properties[this.options.adStoragePropertyMapping]) {
+  if (track.raw.properties[this.options.adStoragePropertyMapping]) {
     consent.ad_storage =
-      track.properties[this.options.adStoragePropertyMapping];
+      track.raw.properties[this.options.adStoragePropertyMapping];
   }
 
   if (
-    track.context.consent.categoryPreferences[
+    this.options.consentSettings.categories.includes(
       this.options.adStorageConsentCategory
-    ]
+    )
   ) {
-    consent.ad_storage =
-      track.context.consent.categoryPreferences[
-        this.options.adStorageConsentCategory
-      ] === true
-        ? 'granted'
-        : 'denied';
+    consent.ad_storage = 'granted';
   }
 
-  if (consent.length > 0) {
-    window.uetq.push('consent', 'update', consent);
+  if (Object.keys(consent).length > 0) {
+    window.uetq.push('consent', 'update', {
+      ad_storage: 'granted'
+    });
   }
 
   window.uetq.push(event);

--- a/integrations/bing-ads/package.json
+++ b/integrations/bing-ads/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-bing-ads",
   "description": "The Bing Ads analytics.js integration.",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/bing-ads/test/index.test.js
+++ b/integrations/bing-ads/test/index.test.js
@@ -50,6 +50,58 @@ describe('Bing Ads', function() {
     });
   });
 
+  describe('#initialize', function() {
+    beforeEach(function() {
+      window.uetq = [];
+      window.UET = function(setup) {
+        this.ti = setup.ti;
+        this.q = setup.q;
+      };
+      analytics.stub(bing, 'load', function(callback) {
+        callback();
+      });
+      analytics.spy(window.uetq, 'push');
+    });
+
+    afterEach(function() {
+      // Clean up after each test
+      delete window.uetq;
+    });
+
+    it('should initialize uetq as an empty array if not already defined', function() {
+      delete window.uetq;
+      bing.options.enableConsent = false;
+
+      bing.initialize();
+
+      analytics.assert(Array.isArray(window.uetq.q));
+      analytics.assert.deepEqual(window.uetq.q, []);
+    });
+
+    it('should push default consent if enableConsent is true', function() {
+      bing.options.enableConsent = true;
+      bing.initialize();
+      analytics.spy(window.uetq, 'push');
+      analytics.called(window.uetq.q.push, 'consent', 'default', {
+        ad_storage: 'denied'
+      });
+    });
+
+    it('should not push default consent if enableConsent is false', function() {
+      bing.options.enableConsent = false;
+      bing.initialize();
+      analytics.spy(window.uetq, 'push');
+      analytics.didNotCall(window.uetq.push, 'consent', 'default');
+    });
+
+    it('should call load and set up UET after loading', function() {
+      bing.initialize();
+      analytics.called(bing.load);
+      analytics.assert(window.uetq instanceof window.UET);
+      analytics.assert.equal(window.uetq.ti, bing.options.tagId);
+    });
+  });
+
   describe('after loading', function() {
     beforeEach(function(done) {
       analytics.once('ready', done);

--- a/webpack.config.integrations.js
+++ b/webpack.config.integrations.js
@@ -41,7 +41,8 @@ module.exports = {
     chunkFilename: 'vendor/[name].[contenthash].js',
     path: path.resolve(__dirname, 'build/integrations'),
     library: '[name]Integration',
-    libraryTarget: 'window'
+    libraryTarget: 'window',
+    hashFunction: "sha256"
   },
   module: {
     rules: [

--- a/webpack.config.middleware.js
+++ b/webpack.config.middleware.js
@@ -40,7 +40,8 @@ module.exports = {
     filename: '[name]/latest/[name].js',
     path: path.resolve(__dirname, 'build/middleware'),
     library: '[name]Middleware',
-    libraryTarget: 'umd'
+    libraryTarget: 'umd',
+    hashFunction: "sha256"
   },
   module: {
     rules: [

--- a/webpack.config.tester.js
+++ b/webpack.config.tester.js
@@ -30,7 +30,8 @@ module.exports = {
     chunkFilename: 'vendor/[name].[contenthash].js.gz',
     path: path.resolve(__dirname, 'tester/dist/next-integrations/integrations'),
     library: '[name]Integration',
-    libraryTarget: 'window'
+    libraryTarget: 'window',
+    hashFunction: "sha256"
   },
   module: {
     rules: [


### PR DESCRIPTION
**What does this PR do?**

In this PR added support for bing ads consent mode changes.

JIRA TICKETS: https://twilio-engineering.atlassian.net/browse/STRATCONN-5687


**Are there breaking changes in this PR?**
NO


**Testing**
Testing completed successfully


When Default is granted

<img width="1502" alt="Screenshot 2025-04-30 at 12 29 08 AM" src="https://github.com/user-attachments/assets/8579b553-7de7-4940-ab6f-92a874fffbcb" />


When default is denied and Manual value mapped when CMP is not used


<img width="1503" alt="Screenshot 2025-04-30 at 12 55 34 AM" src="https://github.com/user-attachments/assets/44060d37-5dbd-4b98-ae92-a6d16c875704" />


when default is denied and is a CMP user.


<img width="1501" alt="Screenshot 2025-04-30 at 12 32 02 AM" src="https://github.com/user-attachments/assets/2be2b66f-9bb0-4a2c-9315-247327ecae4b" />




**Any background context you want to provide?**


**Is there parity with the server-side/android/iOS integration components (if applicable)?**


**Does this require a new integration setting? If so, please explain how the new setting works**


**Links to helpful docs and other external resources**
