### PR TITLE
STRATCONN-5950: Upgrade twitter-ads sdk

### DIFF
--- a/integrations/twitter-ads/lib/index.js
+++ b/integrations/twitter-ads/lib/index.js
@@ -39,12 +39,13 @@ TwitterAds.prototype.initialize = function() {
   // load universal website tag
   if (this.options.universalTagPixelId) {
     /* eslint-disable */
-    (function(e,t,n,s,u,a){e.twq||(s=e.twq=function(){s.exe?s.exe.apply(s,arguments):s.queue.push(arguments);
-},s.version='1.1',s.queue=[])})(window,document,'script');
+    !function(e,t,n,s,u,a){e.twq||(s=e.twq=function(){s.exe?s.exe.apply(s,arguments):s.queue.push(arguments);
+    },s.version='1.1',s.queue=[],u=t.createElement(n),u.async=!0,u.src='https://static.ads-twitter.com/uwt.js',
+      a=t.getElementsByTagName(n)[0],a.parentNode.insertBefore(u,a))}(window,document,'script');
     /* eslint-disable */
 
     this.load('universalTag', function() {
-      window.twq('init', self.options.universalTagPixelId);
+      window.twq('config', self.options.universalTagPixelId);
       self.ready();
     });
   } else {

--- a/integrations/twitter-ads/test/index.test.js
+++ b/integrations/twitter-ads/test/index.test.js
@@ -85,7 +85,7 @@ describe('Twitter Ads', function() {
       });
 
       it('should initialize twq with the universal tag pixel id if provided', function() {
-        analytics.called(window.twq, 'init', 'teemo');
+        analytics.called(window.twq, 'config', 'teemo');
       });
     });
   });


### PR DESCRIPTION
**What does this PR do?**
Upgrades twitter ads sdk 

**Are there breaking changes in this PR?**

Probably yes, this is not backward compatible 

**Testing**
<!---

All PRs must follow the process for change control as outlined in:
https://segment.atlassian.net/wiki/spaces/GRC/pages/453935287/Reinforcing+Change+Control

- Testing completed successfully using <how did you test, environment>; or
- Testing not required because <explain why you think testing isn't needed>

--->
Testing completed successfully in local dev environment that the destination script is loading with `window.twq`

**Any background context you want to provide?**
https://twilio-engineering.atlassian.net/browse/STRATCONN-5950

**Is there parity with the server-side/android/iOS integration components (if applicable)?**

NA

**Does this require a new integration setting? If so, please explain how the new setting works**
No

**Links to helpful docs and other external resources**
https://business.x.com/en/help/campaign-measurement-and-analytics/conversion-tracking-for-websites
