### PR TITLE
STRATCONN-5792: Remove vulnerable dependency from several destinations.

### DIFF
--- a/integrations/chartbeat/lib/index.js
+++ b/integrations/chartbeat/lib/index.js
@@ -1,10 +1,19 @@
 'use strict';
 
+const defaults = (obj, defaults) => {
+  const result = { ...defaults };
+  for (const key in obj) {
+    if (obj[key] !== undefined) {
+      result[key] = obj[key];
+    }
+  }
+  return result;
+};
+
 /**
  * Module dependencies.
  */
 
-var defaults = require('@ndhoule/defaults');
 var integration = require('@segment/analytics.js-integration');
 var onBody = require('on-body');
 

--- a/integrations/chartbeat/package.json
+++ b/integrations/chartbeat/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-chartbeat",
   "description": "The Chartbeat analytics.js integration.",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",
@@ -24,7 +24,6 @@
     "url": "git+https://github.com/segmentio/analytics.js-integrations.git"
   },
   "dependencies": {
-    "@ndhoule/defaults": "^2.0.1",
     "@segment/analytics.js-integration": "^3.2.0",
     "on-body": "0.0.1"
   },

--- a/integrations/google-analytics-4/package.json
+++ b/integrations/google-analytics-4/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/analytics.js-integration-google-analytics-4",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "",
   "main": "lib/index.js",
   "directories": {
@@ -21,7 +21,6 @@
     "url": "git+https://github.com/segmentio/analytics.js-integrations.git"
   },
   "dependencies": {
-    "@ndhoule/defaults": "^2.0.1",
     "@segment/analytics.js-integration": "^3.1.0",
     "component-each": "^0.2.6",
     "extend": "^3.0.2",

--- a/integrations/google-analytics/lib/index.js
+++ b/integrations/google-analytics/lib/index.js
@@ -1,11 +1,20 @@
 'use strict';
 
+const defaults = (obj, defaults) => {
+  const result = { ...defaults };
+  for (const key in obj) {
+    if (obj[key] !== undefined) {
+      result[key] = obj[key];
+    }
+  }
+  return result;
+};
+
 /**
  * Module dependencies.
  */
 
 var Track = require('segmentio-facade').Track;
-var defaults = require('@ndhoule/defaults');
 var dot = require('obj-case');
 var each = require('component-each');
 var integration = require('@segment/analytics.js-integration');

--- a/integrations/google-analytics/package.json
+++ b/integrations/google-analytics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-google-analytics",
   "description": "The Google Analytics analytics.js integration.",
-  "version": "2.18.5",
+  "version": "2.18.6",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",
@@ -24,7 +24,6 @@
     "url": "git+https://github.com/segmentio/analytics.js-integrations.git"
   },
   "dependencies": {
-    "@ndhoule/defaults": "^2.0.1",
     "@segment/analytics.js-integration": "^3.1.0",
     "component-each": "^0.2.6",
     "extend": "^3.0.2",

--- a/integrations/gtag/lib/index.js
+++ b/integrations/gtag/lib/index.js
@@ -1,5 +1,15 @@
 'use strict';
 
+const defaults = (obj, defaults) => {
+  const result = { ...defaults };
+  for (const key in obj) {
+    if (obj[key] !== undefined) {
+      result[key] = obj[key];
+    }
+  }
+  return result;
+};
+
 /**
  * Module dependencies.
  */
@@ -7,7 +17,6 @@
 var integration = require('@segment/analytics.js-integration');
 var Track = require('segmentio-facade').Track;
 var reject = require('reject');
-var defaults = require('@ndhoule/defaults');
 var extend = require('extend');
 
 /**

--- a/integrations/gtag/package.json
+++ b/integrations/gtag/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-gtag",
   "description": "The Gtag analytics.js integration.",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/intercom/lib/index.js
+++ b/integrations/intercom/lib/index.js
@@ -1,11 +1,20 @@
 'use strict';
 
+const defaults = (obj, defaults) => {
+  const result = { ...defaults };
+  for (const key in obj) {
+    if (obj[key] !== undefined) {
+      result[key] = obj[key];
+    }
+  }
+  return result;
+};
+
 /**
  * Module dependencies.
  */
 
 var convertDates = require('@segment/convert-dates');
-var defaults = require('@ndhoule/defaults');
 var del = require('obj-case').del;
 var integration = require('@segment/analytics.js-integration');
 var is = require('is');

--- a/integrations/intercom/package.json
+++ b/integrations/intercom/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-intercom",
   "description": "The Intercom analytics.js integration.",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",
@@ -25,12 +25,11 @@
   },
   "dependencies": {
     "@ndhoule/clone": "^1.0.0",
-    "@ndhoule/defaults": "^2.0.1",
     "@ndhoule/each": "^2.0.1",
     "@ndhoule/extend": "^2.0.0",
     "@ndhoule/foldl": "^2.0.1",
     "@ndhoule/pick": "^2.0.0",
-    "@segment/analytics.js-integration": "^2.1.0",
+    "@segment/analytics.js-integration": "^3.2.0",
     "@segment/convert-dates": "^1.0.0",
     "flat": "2.0.1",
     "is": "^3.1.0",

--- a/integrations/intercom/package.json
+++ b/integrations/intercom/package.json
@@ -29,7 +29,7 @@
     "@ndhoule/extend": "^2.0.0",
     "@ndhoule/foldl": "^2.0.1",
     "@ndhoule/pick": "^2.0.0",
-    "@segment/analytics.js-integration": "^3.2.0",
+    "@segment/analytics.js-integration": "^2.1.0",
     "@segment/convert-dates": "^1.0.0",
     "flat": "2.0.1",
     "is": "^3.1.0",

--- a/integrations/owneriq/package.json
+++ b/integrations/owneriq/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@owneriq/analytics.js-integration-owneriq-pixel",
   "description": "The OwnerIQ analytics.js integration.",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",
@@ -24,7 +24,6 @@
   },
   "homepage": "https://github.com/owneriq/analytics.js-integration-owneriq#readme",
   "dependencies": {
-    "@ndhoule/defaults": "^2.0.1",
     "@segment/analytics.js-integration": "^3.1.0",
     "component-each": "^0.2.6",
     "extend": "^3.0.2",

--- a/integrations/parsely/lib/index.js
+++ b/integrations/parsely/lib/index.js
@@ -1,5 +1,15 @@
 'use strict';
 
+const defaults = (obj, defaults) => {
+  const result = { ...defaults };
+  for (const key in obj) {
+    if (obj[key] !== undefined) {
+      result[key] = obj[key];
+    }
+  }
+  return result;
+};
+
 /**
  * Module dependencies.
  */
@@ -9,7 +19,6 @@ var when = require('do-when');
 var reject = require('reject');
 var json = JSON;
 var is = require('is');
-var defaults = require('@ndhoule/defaults');
 
 /**
  * Expose `Parsely` integration.

--- a/integrations/parsely/package.json
+++ b/integrations/parsely/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-parsely",
   "description": "The Parsely analytics.js integration.",
-  "version": "2.3.5",
+  "version": "2.3.6",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",
@@ -24,13 +24,7 @@
     "url": "git+https://github.com/segmentio/analytics.js-integrations.git"
   },
   "dependencies": {
-    "@ndhoule/defaults": "^2.0.1",
-    "@ndhoule/each": "^2.0.1",
-    "@segment/analytics.js-integration": "^3.x",
-    "array-filter": "^1.0.0",
-    "do-when": "^1.0.0",
-    "is": "3.2.1",
-    "reject": "0.0.1"
+    "@segment/analytics.js-integration": "^3.2.0"
   },
   "devDependencies": {
     "@segment/analytics.js-core": "^3.0.0",

--- a/integrations/parsely/package.json
+++ b/integrations/parsely/package.json
@@ -24,7 +24,12 @@
     "url": "git+https://github.com/segmentio/analytics.js-integrations.git"
   },
   "dependencies": {
-    "@segment/analytics.js-integration": "^3.2.0"
+    "@ndhoule/each": "^2.0.1",
+    "@segment/analytics.js-integration": "^3.x",
+    "array-filter": "^1.0.0",
+    "do-when": "^1.0.0",
+    "is": "3.2.1",
+    "reject": "0.0.1"
   },
   "devDependencies": {
     "@segment/analytics.js-core": "^3.0.0",

--- a/integrations/simplereach/lib/index.js
+++ b/integrations/simplereach/lib/index.js
@@ -1,10 +1,19 @@
 'use strict';
 
+const defaults = (obj, defaults) => {
+  const result = { ...defaults };
+  for (const key in obj) {
+    if (obj[key] !== undefined) {
+      result[key] = obj[key];
+    }
+  }
+  return result;
+};
+
 /**
  * Module dependencies.
  */
 
-var defaults = require('@ndhoule/defaults');
 var integration = require('@segment/analytics.js-integration');
 
 /**

--- a/integrations/simplereach/package.json
+++ b/integrations/simplereach/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-simplereach",
   "description": "The Simplereach analytics.js integration.",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",
@@ -24,7 +24,6 @@
     "url": "git+https://github.com/segmentio/analytics.js-integrations.git"
   },
   "dependencies": {
-    "@ndhoule/defaults": "^2.0.1",
     "@segment/analytics.js-integration": "^2.1.0"
   },
   "devDependencies": {

--- a/integrations/track-js/lib/index.js
+++ b/integrations/track-js/lib/index.js
@@ -1,12 +1,21 @@
 'use strict';
 
+const defaults = (obj, defaults) => {
+  const result = { ...defaults };
+  for (const key in obj) {
+    if (obj[key] !== undefined) {
+      result[key] = obj[key];
+    }
+  }
+  return result;
+};
+
 /**
  * Module dependencies.
  */
 
 var integration = require('@segment/analytics.js-integration');
 var is = require('is');
-var defaults = require('@ndhoule/defaults');
 
 /**
  * Expose `TrackJS`.

--- a/integrations/track-js/package.json
+++ b/integrations/track-js/package.json
@@ -24,9 +24,7 @@
     "url": "git+https://github.com/segmentio/analytics.js-integrations.git"
   },
   "dependencies": {
-    "@ndhoule/defaults": "^2.0.1",
-    "@segment/analytics.js-integration": "^2.1.0",
-    "is": "^3.1.0"
+    "@segment/analytics.js-integration": "^3.2.0"
   },
   "devDependencies": {
     "@segment/analytics.js-core": "^3.8.2",

--- a/integrations/track-js/package.json
+++ b/integrations/track-js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-trackjs",
   "description": "The Trackjs analytics.js integration.",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/track-js/package.json
+++ b/integrations/track-js/package.json
@@ -24,7 +24,8 @@
     "url": "git+https://github.com/segmentio/analytics.js-integrations.git"
   },
   "dependencies": {
-    "@segment/analytics.js-integration": "^3.2.0"
+    "@segment/analytics.js-integration": "^2.1.0",
+    "is": "^3.1.0"
   },
   "devDependencies": {
     "@segment/analytics.js-core": "^3.8.2",

--- a/integrations/twitter-ads/lib/index.js
+++ b/integrations/twitter-ads/lib/index.js
@@ -1,11 +1,20 @@
 'use strict';
 
+const defaults = (obj, defaults) => {
+  const result = { ...defaults };
+  for (const key in obj) {
+    if (obj[key] !== undefined) {
+      result[key] = obj[key];
+    }
+  }
+  return result;
+};
+
 /**
  * Module dependencies.
  */
 
 var integration = require('@segment/analytics.js-integration');
-var defaults = require('@ndhoule/defaults');
 var foldl = require('@ndhoule/foldl');
 var each = require('component-each');
 var get = require('obj-case');

--- a/integrations/twitter-ads/package.json
+++ b/integrations/twitter-ads/package.json
@@ -24,7 +24,12 @@
     "url": "git+https://github.com/segmentio/analytics.js-integrations.git"
   },
   "dependencies": {
-    "@segment/analytics.js-integration": "^3.2.0"
+    "@ndhoule/extend": "^2.0.0",
+    "@ndhoule/foldl": "^2.0.1",
+    "@segment/analytics.js-integration": "^3.1.0",
+    "component-each": "^0.2.6",
+    "obj-case": "^0.2.0",
+    "segmentio-facade": "^3.2.7"
   },
   "devDependencies": {
     "@segment/analytics.js-core": "^3.0.0",

--- a/integrations/twitter-ads/package.json
+++ b/integrations/twitter-ads/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-twitter-ads",
   "description": "The Twitter Ads analytics.js integration.",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",
@@ -24,13 +24,7 @@
     "url": "git+https://github.com/segmentio/analytics.js-integrations.git"
   },
   "dependencies": {
-    "@ndhoule/defaults": "^2.0.1",
-    "@ndhoule/extend": "^2.0.0",
-    "@ndhoule/foldl": "^2.0.1",
-    "@segment/analytics.js-integration": "^3.1.0",
-    "component-each": "^0.2.6",
-    "obj-case": "^0.2.0",
-    "segmentio-facade": "^3.2.7"
+    "@segment/analytics.js-integration": "^3.2.0"
   },
   "devDependencies": {
     "@segment/analytics.js-core": "^3.0.0",

--- a/tester/src/utils.js
+++ b/tester/src/utils.js
@@ -1,7 +1,7 @@
 import { AnalyticsBrowser } from '@segment/analytics-next';
 
 export async function getSettings(wk) {
-  let data = await fetch(`https://cdn.segment.com/v1/projects/${wk}/settings`);
+  let data = await fetch(`https://cdn.segment.build/v1/projects/${wk}/settings`);
   data = await data.json();
   return cleanSettings(data);
 }

--- a/tester/src/utils.js
+++ b/tester/src/utils.js
@@ -1,7 +1,7 @@
 import { AnalyticsBrowser } from '@segment/analytics-next';
 
 export async function getSettings(wk) {
-  let data = await fetch(`https://cdn.segment.build/v1/projects/${wk}/settings`);
+  let data = await fetch(`https://cdn.segment.com/v1/projects/${wk}/settings`);
   data = await data.json();
   return cleanSettings(data);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1916,7 +1916,7 @@
     slug-component "^1.1.0"
     to-no-case "^0.1.3"
 
-"@segment/analytics.js-integration@^3.0.0", "@segment/analytics.js-integration@^3.1.0", "@segment/analytics.js-integration@^3.2.0", "@segment/analytics.js-integration@^3.2.1", "@segment/analytics.js-integration@^3.3.0", "@segment/analytics.js-integration@^3.3.2", "@segment/analytics.js-integration@^3.3.3", "@segment/analytics.js-integration@^3.x":
+"@segment/analytics.js-integration@^3.0.0", "@segment/analytics.js-integration@^3.1.0", "@segment/analytics.js-integration@^3.2.0", "@segment/analytics.js-integration@^3.2.1", "@segment/analytics.js-integration@^3.3.0", "@segment/analytics.js-integration@^3.3.2", "@segment/analytics.js-integration@^3.3.3":
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/@segment/analytics.js-integration/-/analytics.js-integration-3.3.3.tgz#c8fb06747f0864f931c3d0a16f014d9b0e726ec2"
   integrity sha512-RpUQBSE2wH/ovVrT1b0dTesalLZer7iX21p2TDaM+8mhi4M91HdqK4nOtE/Ny5+GAYU4v7LvTfvb9zgTC34rPA==
@@ -2872,11 +2872,6 @@ array-differ@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-differ/-/array-differ-1.0.0.tgz#eff52e3758249d33be402b8bb8e564bb2b5d4031"
   integrity sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=
-
-array-filter@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/array-filter/-/array-filter-1.0.0.tgz#baf79e62e6ef4c2a4c0b831232daffec251f9d83"
-  integrity sha1-uveeYubvTCpMC4MSMtr/7CUfnYM=
 
 array-filter@~0.0.0:
   version "0.0.1"
@@ -9070,11 +9065,6 @@ is-wsl@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
   integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
-
-is@3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/is/-/is-3.2.1.tgz#d0ac2ad55eb7b0bec926a5266f6c662aaa83dca5"
-  integrity sha1-0Kwq1V63sL7JJqUmb2xmKqqD3KU=
 
 is@^3.0.1, is@^3.1.0, is@^3.2.1, is@^3.3.0:
   version "3.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1916,7 +1916,7 @@
     slug-component "^1.1.0"
     to-no-case "^0.1.3"
 
-"@segment/analytics.js-integration@^3.0.0", "@segment/analytics.js-integration@^3.1.0", "@segment/analytics.js-integration@^3.2.0", "@segment/analytics.js-integration@^3.2.1", "@segment/analytics.js-integration@^3.3.0", "@segment/analytics.js-integration@^3.3.2", "@segment/analytics.js-integration@^3.3.3":
+"@segment/analytics.js-integration@^3.0.0", "@segment/analytics.js-integration@^3.1.0", "@segment/analytics.js-integration@^3.2.0", "@segment/analytics.js-integration@^3.2.1", "@segment/analytics.js-integration@^3.3.0", "@segment/analytics.js-integration@^3.3.2", "@segment/analytics.js-integration@^3.3.3", "@segment/analytics.js-integration@^3.x":
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/@segment/analytics.js-integration/-/analytics.js-integration-3.3.3.tgz#c8fb06747f0864f931c3d0a16f014d9b0e726ec2"
   integrity sha512-RpUQBSE2wH/ovVrT1b0dTesalLZer7iX21p2TDaM+8mhi4M91HdqK4nOtE/Ny5+GAYU4v7LvTfvb9zgTC34rPA==
@@ -2872,6 +2872,11 @@ array-differ@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-differ/-/array-differ-1.0.0.tgz#eff52e3758249d33be402b8bb8e564bb2b5d4031"
   integrity sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=
+
+array-filter@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/array-filter/-/array-filter-1.0.0.tgz#baf79e62e6ef4c2a4c0b831232daffec251f9d83"
+  integrity sha512-Ene1hbrinPZ1qPoZp7NSx4jQnh4nr7MtY78pHNb+yr8yHbxmTS7ChGW0a55JKA7TkRDeoQxK4GcJaCvBYplSKA==
 
 array-filter@~0.0.0:
   version "0.0.1"
@@ -9065,6 +9070,11 @@ is-wsl@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
   integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
+
+is@3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/is/-/is-3.2.1.tgz#d0ac2ad55eb7b0bec926a5266f6c662aaa83dca5"
+  integrity sha512-NgGnzF+/wucMxle6i32obg/UjUqQruwlJUtjBpDEMXNq8vPLuaf28U4q+yes1I6J89FoErr7kDtBGICoNaY7rQ==
 
 is@^3.0.1, is@^3.1.0, is@^3.2.1, is@^3.3.0:
   version "3.3.0"


### PR DESCRIPTION
**What does this PR do?**
Remove a vulnerable dependency from all integrations.

version updates :

chartbeat: 2.2.4
google-analytics: 2.18.6
google-analytics-4: 0.0.4
gtag: 1.0.3
intercom: 3.1.1
owneriq: 1.0.20
parsely: 2.3.6
simplereach: 2.1.3
trackjs: 2.0.2
twitter-ads: 2.5.4


**Are there breaking changes in this PR?**
No

**Testing**
Testing not required because there is no change in functionality 

**Any background context you want to provide?**


**Is there parity with the server-side/android/iOS integration components (if applicable)?**


**Does this require a new integration setting? If so, please explain how the new setting works**


**Links to helpful docs and other external resources**
