### PR TITLE
feat: add experiment name to VWO tracking data

### DIFF
--- a/integrations/visual-website-optimizer/lib/index.js
+++ b/integrations/visual-website-optimizer/lib/index.js
@@ -124,9 +124,11 @@ VWO.prototype.roots = function() {
   rootExperiments(function(err, data) {
     each(data, function(experimentId, variationName) {
       var uuid = window.VWO.data.vin.uuid;
+      var experimentName = window._vwo_exp[experimentId].name;
       var props = {
         experimentId: experimentId,
         variationName: variationName,
+        experimentName: experimentName,
         vwoUserId: uuid
       };
 


### PR DESCRIPTION
**What does this PR do?**  
This PR updates to also send the **experiment name** along with the existing experiment ID, variation name, and user ID.  

**Are there breaking changes in this PR?**  
No, this is a non-breaking change. Existing functionality remains the same; we are only adding an additional property (`experimentName`).  

**Testing**  
Testing completed successfully
- Verified locally by running the integration and confirming that the `experimentName` is included in the payload sent to Segment.  
- Confirmed no regressions in the existing properties (`experimentId`, `variationName`, `vwoUserId`).  

**Any background context you want to provide?**  
Previously, only experiment ID, variation name, and VWO user ID were sent to Segment. Some customers requested the **experiment name** for easier reporting and debugging, so this enhancement adds that field.  

**Is there parity with the server-side/android/iOS integration components (if applicable)?**  
No change needed — this update is for the JavaScript integration only. (Parity can be considered for other SDKs later if required.)  

**Does this require a new integration setting? If so, please explain how the new setting works**  
No, no new settings are required. The additional property (`experimentName`) is included automatically in the payload.  

