### PR TITLE
STRATCONN-6010 - [GTM - Classic] - full domain with file path

### DIFF
--- a/integrations/google-tag-manager/lib/index.js
+++ b/integrations/google-tag-manager/lib/index.js
@@ -16,16 +16,16 @@ var GTM = (module.exports = integration('Google Tag Manager')
   .global('google_tag_manager')
   .option('containerId', '')
   .option('environment', '')
-  .option('domain', 'www.googletagmanager.com')
+  .option('fullURLpath', 'www.googletagmanager.com/gtm.js')
   .option('trackNamedPages', true)
   .option('trackCategorizedPages', true)
   .tag(
     'no-env',
-    '<script src="//{{ domain }}/gtm.js?id={{ containerId }}&l=dataLayer">'
+    '<script src="//{{ fullURLpath }}?id={{ containerId }}&l=dataLayer">'
   )
   .tag(
     'with-env',
-    '<script src="//{{ domain }}/gtm.js?id={{ containerId }}&l=dataLayer&gtm_preview={{ environment }}">'
+    '<script src="//{{ fullURLpath }}?id={{ containerId }}&l=dataLayer&gtm_preview={{ environment }}">'
   ));
 
 /**

--- a/integrations/google-tag-manager/test/index.test.js
+++ b/integrations/google-tag-manager/test/index.test.js
@@ -36,7 +36,7 @@ describe('Google Tag Manager', function() {
         .global('dataLayer')
         .option('containerId', '')
         .option('environment', '')
-        .option('domain', 'www.googletagmanager.com')
+        .option('fullURLpath', 'www.googletagmanager.com/gtm.js')
         .option('trackNamedPages', true)
         .option('trackCategorizedPages', true)
     );
@@ -218,7 +218,7 @@ describe('Google Tag Manager', function() {
       gtm.options = {
         containerId: 'GTM-M8M29T',
         environment: 'test',
-        domain: 'www.googletagmanager.com'
+        fullURLpath: 'www.googletagmanager.com/gtm.js'
       };
 
       var tag =
@@ -239,7 +239,7 @@ describe('Google Tag Manager', function() {
       gtm.options = {
         containerId: 'GTM-M8M29T',
         environment: '',
-        domain: 'www.googletagmanager.com'
+        fullURLpath: 'www.googletagmanager.com/gtm.js'
       };
 
       var tag =
@@ -256,11 +256,11 @@ describe('Google Tag Manager', function() {
       gtm.options = {
         containerId: 'GTM-M8M29T',
         environment: '',
-        domain: 'custom.example.com'
+        fullURLpath: 'custom.example.com/somepath/blah.js'
       };
 
       var tag =
-        '<script src="http://custom.example.com/gtm.js?id=' +
+        '<script src="http://custom.example.com/somepath/blah.js?id=' +
         gtm.options.containerId +
         '&l=dataLayer">';
       analytics.spy(gtm, 'load');
@@ -273,11 +273,11 @@ describe('Google Tag Manager', function() {
       gtm.options = {
         containerId: 'GTM-M8M29T',
         environment: 'test',
-        domain: 'custom.example.com'
+        fullURLpath: 'custom.example.com/somepath/blah.js'
       };
 
       var tag =
-        '<script src="http://custom.example.com/gtm.js?id=' +
+        '<script src="http://custom.example.com/somepath/blah.js?id=' +
         gtm.options.containerId +
         '&l=dataLayer&gtm_preview=' +
         gtm.options.environment +


### PR DESCRIPTION
This PR lets customers configure the full file path for the GTM library. 

The setting named `domain` is being changed to be named `fullURLpath`, however the code with the `domain` setting has never been deployed so no customers has yet configured it (so it is safe to remove). 

**Testing**
Testing completed successfully

New field added in staging. Tested with Classic tester tool. 

Screenshot 1: when the new setting is applied and has a value. Notice the path provided in the new field is used. 
<img width="1412" height="813" alt="Screenshot 2026-01-27 at 06 27 58" src="https://github.com/user-attachments/assets/63976090-0d58-4c32-a25d-0673c4e04505" />

Screenshot 2: when the new setting does not have a value. Notice the default URL is used. 
<img width="1378" height="761" alt="Screenshot 2026-01-27 at 06 30 23" src="https://github.com/user-attachments/assets/b5f3c778-83f9-4f03-af88-b3033c73e44d" />


**Existing Unit Tests**

Since the existing unit tests for several integrations are not in good shape, developers are expected to fix
them for the integration they are working/touch on.
Please ensure the following before submitting a PR:
- [ ] Fixed all the existing unit tests for the integration touched.

**Any background context you want to provide?**


**Is there parity with the server-side/android/iOS integration components (if applicable)?**


**Does this require a new integration setting? If so, please explain how the new setting works**


**Links to helpful docs and other external resources**
