### PR TITLE
Bump Google Tag Manager to v2.5.2

### DIFF
--- a/integrations/google-tag-manager/package.json
+++ b/integrations/google-tag-manager/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-google-tag-manager",
   "description": "The Google Tag Manager analytics.js integration.",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",


### PR DESCRIPTION
Version bump to deploy the fullURLpath changes from commit 78fd671. The previous commit modified code but didn't bump the version, causing the new code to overwrite cached 2.5.1 assets that have a 1-year immutable cache policy.


**What does this PR do?**


**Are there breaking changes in this PR?**


**Testing**
<!---

All PRs must follow the process for change control as outlined in:
https://segment.atlassian.net/wiki/spaces/GRC/pages/453935287/Reinforcing+Change+Control

- Testing completed successfully using <how did you test, environment>; or
- Testing not required because <explain why you think testing isn't needed>

--->

**Existing Unit Tests**

Since the existing unit tests for several integrations are not in good shape, developers are expected to fix
them for the integration they are working/touch on.
Please ensure the following before submitting a PR:
- [ ] Fixed all the existing unit tests for the integration touched.

**Any background context you want to provide?**


**Is there parity with the server-side/android/iOS integration components (if applicable)?**


**Does this require a new integration setting? If so, please explain how the new setting works**


**Links to helpful docs and other external resources**
