### PR TITLE
Gtm bugfix2

### DIFF
--- a/integrations/google-tag-manager/lib/index.js
+++ b/integrations/google-tag-manager/lib/index.js
@@ -16,7 +16,7 @@ var GTM = (module.exports = integration('Google Tag Manager')
   .global('google_tag_manager')
   .option('containerId', '')
   .option('environment', '')
-  .option('fullURLpath', 'www.googletagmanager.com/gtm.js')
+  .option('fullURLpath', '')
   .option('trackNamedPages', true)
   .option('trackCategorizedPages', true)
   .tag(
@@ -26,7 +26,15 @@ var GTM = (module.exports = integration('Google Tag Manager')
   .tag(
     'with-env',
     '<script src="//{{ fullURLpath }}?id={{ containerId }}&l=dataLayer&gtm_preview={{ environment }}">'
-  ));
+  ))
+  .tag(
+    'no-env-default-url',
+    '<script src="//www.googletagmanager.com/gtm.js?id={{ containerId }}&l=dataLayer">'
+  )
+  .tag(
+    'with-env-default-url',
+    '<script src="//www.googletagmanager.com/gtm.js?id={{ containerId }}&l=dataLayer&gtm_preview={{ environment }}">'
+  );
 
 /**
  * Initialize.
@@ -39,10 +47,16 @@ var GTM = (module.exports = integration('Google Tag Manager')
 GTM.prototype.initialize = function() {
   push({ 'gtm.start': Number(new Date()), event: 'gtm.js' });
 
-  if (this.options.environment.length) {
-    this.load('with-env', this.options, this.ready);
+  if (this.options.fullURLpath && this.options.fullURLpath.length > 0) {
+    if (this.options.environment.length) {
+      this.load('with-env', this.options, this.ready);
+    } else {
+      this.load('no-env', this.options, this.ready);
+    }
+  } else if (this.options.environment.length) {
+    this.load('with-env-default-url', this.options, this.ready);
   } else {
-    this.load('no-env', this.options, this.ready);
+    this.load('no-env-default-url', this.options, this.ready);
   }
 };
 

--- a/integrations/google-tag-manager/package.json
+++ b/integrations/google-tag-manager/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-google-tag-manager",
   "description": "The Google Tag Manager analytics.js integration.",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",


### PR DESCRIPTION
**What does this PR do?**

Makes the GTM domain configurable for the GTM Classic web destination.  

**Are there breaking changes in this PR?**

NO. 

**Testing**

- Testing completed successfully using staging environment

Destination instance 
https://app.segment.build/joe-ayoub-segment-stage/destinations/google-tag-manager/sources/gtm_test_3/instances/6989db2527c15b15e1c5d48a/configuration 

Version pinned here. 
https://github.com/segmentio/analytics.js-versions/commit/78a95bde128ad548071456cbbda675ec1d47145f

With custom URL configured. 
<img width="1564" height="622" alt="image" src="https://github.com/user-attachments/assets/1bb64556-ed92-4cba-b8de-6161d401d07c" />

Default behaviour, without custom URL configured. 
<img width="1390" height="681" alt="image" src="https://github.com/user-attachments/assets/07914e94-979d-4fc9-a7bd-d3c2968095a2" />

Note this fixes an issue which caused a SEV 3. inc-sev3-17182-gtm-events-not-flowing-after-domain-change-2026-02-06

**Existing Unit Tests**

Since the existing unit tests for several integrations are not in good shape, developers are expected to fix
them for the integration they are working/touch on.
Please ensure the following before submitting a PR:
- [ ] Fixed all the existing unit tests for the integration touched.

**Any background context you want to provide?**


**Is there parity with the server-side/android/iOS integration components (if applicable)?**


**Does this require a new integration setting? If so, please explain how the new setting works**


**Links to helpful docs and other external resources**
