### PR TITLE
fix (moengage): handled obj-case find method fuzzy traits method calling

### DIFF
--- a/integrations/moengage/HISTORY.md
+++ b/integrations/moengage/HISTORY.md
@@ -1,3 +1,8 @@
+1.0.9 / 2026-03-26
+==================
+
+  * Fixed issue in user attribute tracking related to obj-case find method
+
 1.0.6 / 2019-01-07
 ==================
 

--- a/integrations/moengage/lib/index.js
+++ b/integrations/moengage/lib/index.js
@@ -130,10 +130,10 @@ MoEngage.prototype.identify = function(identify) {
         return self._client.add_user_attribute('username', identify.username()); // if they are sending `traits.name` as a semantic trait, there's no other way to get username other than as a custom user attribute
     }
     // check if there are sendable semantic traits
-    if (find(traitsMethodMap, key)) {
-      var method = 'add_' + traitsMethodMap[key];
-      var trait = identify[key]();
-      self._client[method](trait);
+    var mappedValue = find(traitsMethodMap, key);
+    if (mappedValue) {
+      var method = 'add_' + mappedValue;
+      self._client[method](value);
     }
   }, traits);
 

--- a/integrations/moengage/package.json
+++ b/integrations/moengage/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-moengage",
   "description": "The MoEngage analytics.js integration.",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/moengage/test/index.test.js
+++ b/integrations/moengage/test/index.test.js
@@ -160,6 +160,73 @@ describe('MoEngage', function() {
         analytics.didNotCall(moengage._client.destroy_session);
         analytics.called(moengage._client.add_unique_user_id, 'drogon');
       });
+
+      describe('trait mapping with different case conventions', function() {
+        it('should map firstName variations (camelCase, snake_case, kebab-case)', function() {
+          analytics.identify('user1', { firstName: 'Jon' });
+          analytics.called(moengage._client.add_first_name, 'Jon');
+          
+          analytics.identify('user2', { first_name: 'Arya' });
+          analytics.called(moengage._client.add_first_name, 'Arya');
+          
+          analytics.identify('user3', { 'first-name': 'Sansa' });
+          analytics.called(moengage._client.add_first_name, 'Sansa');
+        });
+
+        it('should map lastName variations (camelCase, snake_case, kebab-case)', function() {
+          analytics.identify('user1', { lastName: 'Snow' });
+          analytics.called(moengage._client.add_last_name, 'Snow');
+          
+          analytics.identify('user2', { last_name: 'Stark' });
+          analytics.called(moengage._client.add_last_name, 'Stark');
+          
+          analytics.identify('user3', { 'last-name': 'Targaryen' });
+          analytics.called(moengage._client.add_last_name, 'Targaryen');
+        });
+
+        it('should map phone variations to add_mobile', function() {
+          analytics.identify('user1', { phone: '1234567890' });
+          analytics.called(moengage._client.add_mobile, '1234567890');
+          
+          analytics.identify('user2', { Phone: '0987654321' });
+          analytics.called(moengage._client.add_mobile, '0987654321');
+        });
+
+        it('should map email variations', function() {
+          analytics.identify('user1', { email: 'test@example.com' });
+          analytics.called(moengage._client.add_email, 'test@example.com');
+          
+          analytics.identify('user2', { Email: 'test2@example.com' });
+          analytics.called(moengage._client.add_email, 'test2@example.com');
+        });
+
+        it('should map gender variations', function() {
+          analytics.identify('user1', { gender: 'male' });
+          analytics.called(moengage._client.add_gender, 'male');
+          
+          analytics.identify('user2', { Gender: 'female' });
+          analytics.called(moengage._client.add_gender, 'female');
+        });
+
+        it('should map birthday variations', function() {
+          analytics.identify('user1', { birthday: '01/01/1990' });
+          analytics.called(moengage._client.add_birthday, '01/01/1990');
+          
+          analytics.identify('user2', { Birthday: '12/31/1985' });
+          analytics.called(moengage._client.add_birthday, '12/31/1985');
+        });
+
+        it('should map username variations (camelCase, snake_case, kebab-case)', function() {
+          analytics.identify('user1', { userName: 'johndoe' });
+          analytics.called(moengage._client.add_user_name, 'johndoe');
+          
+          analytics.identify('user2', { user_name: 'janedoe' });
+          analytics.called(moengage._client.add_user_name, 'janedoe');
+          
+          analytics.identify('user3', { 'user-name': 'bobsmith' });
+          analytics.called(moengage._client.add_user_name, 'bobsmith');
+        });
+      });
     });
 
     describe('#track', function() {


### PR DESCRIPTION
**What does this PR do?**
- it fixes an issue occurring for moengage user attribute tracking. obj-case library's find method does fuzzy matching of property. for example, userName will get matched with username. but because there is no identify.userName() in segment, it was causing error. 

**Are there breaking changes in this PR?**
- No

**Testing**
<!---

All PRs must follow the process for change control as outlined in:
https://segment.atlassian.net/wiki/spaces/GRC/pages/453935287/Reinforcing+Change+Control

--->

- Testing completed successfully
- Have added new tests regarding obj-case find method's fuzzy matching.

**Existing Unit Tests**

Since the existing unit tests for several integrations are not in good shape, developers are expected to fix
them for the integration they are working/touch on.
Please ensure the following before submitting a PR:
- [x] Fixed all the existing unit tests for the integration touched.

**Any background context you want to provide?**
- We were expecting userName to be tracked as custom user attribute as it would be a custom trait from segment. But because obj-case's find method fuzzy matches keys, identify.userName() (for example) was getting executed which causes error. Now, we with these changes, we can track userName and user_name as standard user attribute along with the expected username.


**Is there parity with the server-side/android/iOS integration components (if applicable)?**
- N/A


**Does this require a new integration setting? If so, please explain how the new setting works**
- No


**Links to helpful docs and other external resources**
- https://partners.moengage.com/hc/en-us/articles/4409146768404-Overview
